### PR TITLE
Add structured logging, fix error leaking in auth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ JWT_SECRET=
 
 # Optional: database URL (default: sqlite:../data/beerio-kart.db?mode=rwc)
 # DATABASE_URL=sqlite:../data/beerio-kart.db?mode=rwc
+
+# Optional: log level filter (default: info)
+# RUST_LOG=info

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,34 @@ Beerio Kart is a mobile-first web app for tracking times and stats for the Mario
 | Package mgr | Bun                           | Drop-in npm replacement; faster installs and script running   |
 | Containers  | Dockerfile + compose.yaml    | Works with Docker or Podman                                  |
 
+## Observability
+
+### Crates
+
+- **`tracing`** — structured, leveled logging facade (used throughout application code)
+- **`tracing-subscriber`** — formats and emits log output (with `fmt` and `env-filter` features)
+- **`tower-http`** — provides `TraceLayer` middleware for automatic HTTP request/response logging (method, path, status, duration)
+
+### Log level conventions
+
+- `error` — unexpected failures (DB errors, hashing failures, token creation failures)
+- `warn` — suspicious but recoverable (e.g., rate-limit warnings in the future)
+- `info` — request lifecycle, startup, seeding complete
+- `debug` — detailed diagnostics during development
+
+### Error response pattern
+
+Internal error details are never exposed to clients. When an unexpected error occurs:
+1. Log the real error server-side with `tracing::error!` (including the error value for diagnostics)
+2. Return a generic `"Internal server error"` message in the JSON response body
+3. Keep the appropriate HTTP status code (e.g., 500)
+
+### Configuration
+
+Log output is controlled via the `RUST_LOG` environment variable. Defaults to `info` if not set. Examples:
+- `RUST_LOG=debug` — all debug-level output
+- `RUST_LOG=beerio_kart=debug` — debug only for application code, info for dependencies
+
 ## Naming Conventions
 
 - Table names: plural, snake_case (`drink_types`, `characters`)

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -280,6 +280,9 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1455,6 +1458,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -2945,6 +2957,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +3014,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2995,12 +3035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3120,6 +3163,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,6 +15,9 @@ sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "m
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower-http = { version = "0.6", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4", "v5"] }
 dotenvy = "0.15"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,6 +7,8 @@ use axum::{
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
 use serde::Serialize;
+use tower_http::trace::TraceLayer;
+use tracing_subscriber::EnvFilter;
 
 use beerio_kart::AppState;
 use beerio_kart::config::AppConfig;
@@ -21,6 +23,14 @@ struct HelloResponse {
 async fn main() {
     // Load .env file if present (non-fatal if missing)
     dotenvy::dotenv().ok();
+
+    // Initialize structured logging. Defaults to `info` level; override with
+    // the RUST_LOG env var (e.g., RUST_LOG=debug or RUST_LOG=beerio_kart=debug).
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
 
     let database_url = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "sqlite:../data/beerio-kart.db?mode=rwc".to_string());
@@ -48,9 +58,9 @@ async fn main() {
 
     // Seed static game data (characters, tracks, cups, etc.) from JSON files.
     // Only inserts into empty tables — safe to call on every startup.
-    println!("Seeding static data...");
+    tracing::info!("Seeding static data...");
     seed::run(&db).await.expect("Failed to seed database");
-    println!("Seeding complete.");
+    tracing::info!("Seeding complete");
 
     let state = AppState { db, config };
 
@@ -59,10 +69,11 @@ async fn main() {
         .route("/api/v1/auth/register", post(routes::auth::register))
         .route("/api/v1/auth/login", post(routes::auth::login))
         .route("/api/v1/auth/logout", post(routes::auth::logout))
+        .layer(TraceLayer::new_for_http())
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("Listening on http://localhost:3000");
+    tracing::info!("Listening on http://localhost:3000");
     axum::serve(listener, app).await.unwrap();
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -28,7 +28,8 @@ async fn main() {
     // the RUST_LOG env var (e.g., RUST_LOG=debug or RUST_LOG=beerio_kart=debug).
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info,sqlx=warn,sea_orm_migration=warn")),
         )
         .init();
 

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -1,6 +1,7 @@
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::AppState;
 use crate::entities::users;
@@ -84,10 +85,11 @@ pub async fn register(
                 .into_response();
         }
         Err(e) => {
+            error!(error = %e, "Failed to check username availability");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Database error: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();
@@ -99,10 +101,11 @@ pub async fn register(
     let password_hash = match crate::services::auth::hash_password(&body.password) {
         Ok(h) => h,
         Err(e) => {
+            error!(error = %e, "Failed to hash password");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Failed to hash password: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();
@@ -129,10 +132,11 @@ pub async fn register(
     };
 
     if let Err(e) = new_user.insert(&state.db).await {
+        error!(error = %e, "Failed to insert user");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorBody {
-                error: format!("Failed to create user: {e}"),
+                error: "Internal server error".to_string(),
             }),
         )
             .into_response();
@@ -142,10 +146,11 @@ pub async fn register(
     let token = match crate::services::auth::create_token(&user_id, username, &state.config) {
         Ok(t) => t,
         Err(e) => {
+            error!(error = %e, "Failed to create JWT during registration");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Failed to create token: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();
@@ -199,10 +204,11 @@ pub async fn login(
             return invalid.into_response();
         }
         Err(e) => {
+            error!(error = %e, "Failed to look up user during login");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Database error: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();
@@ -214,10 +220,11 @@ pub async fn login(
         Ok(true) => {}
         Ok(false) => return invalid.into_response(),
         Err(e) => {
+            error!(error = %e, "Password verification failed unexpectedly");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Password verification error: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();
@@ -228,10 +235,11 @@ pub async fn login(
     let token = match crate::services::auth::create_token(&user.id, &user.username, &state.config) {
         Ok(t) => t,
         Err(e) => {
+            error!(error = %e, "Failed to create JWT during login");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
-                    error: format!("Failed to create token: {e}"),
+                    error: "Internal server error".to_string(),
                 }),
             )
                 .into_response();

--- a/backend/src/seed.rs
+++ b/backend/src/seed.rs
@@ -86,7 +86,7 @@ where
 {
     let existing = E::find().one(db).await?;
     if existing.is_some() {
-        println!("  {table_name}: already seeded, skipping");
+        tracing::debug!("{table_name}: already seeded, skipping");
         return Ok(());
     }
 
@@ -105,7 +105,7 @@ where
     }
     txn.commit().await?;
 
-    println!("  {table_name}: seeded {num_items} rows");
+    tracing::info!("{table_name}: seeded {num_items} rows");
     Ok(())
 }
 
@@ -139,7 +139,7 @@ impl_simple_seed!(characters, bodies, wheels, gliders, cups);
 async fn seed_tracks(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
     let existing = tracks::Entity::find().one(db).await?;
     if existing.is_some() {
-        println!("  tracks: already seeded, skipping");
+        tracing::debug!("tracks: already seeded, skipping");
         return Ok(());
     }
 
@@ -180,6 +180,6 @@ async fn seed_tracks(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::
     }
     txn.commit().await?;
 
-    println!("  tracks: seeded {num_items} rows");
+    tracing::info!("tracks: seeded {num_items} rows");
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Added `tracing`, `tracing-subscriber`, and `tower-http` crates for structured logging
- Initialized tracing subscriber in `main.rs` with `RUST_LOG` env filter (defaults to `info,sqlx=warn,sea_orm_migration=warn`)
- Added `TraceLayer` middleware for automatic HTTP request/response logging (method, path, status, duration)
- Fixed all 7 sites in `auth.rs` that leaked internal error details (DB errors, hashing errors, token errors) to clients — now logs the real error server-side with `tracing::error!` and returns generic `"Internal server error"` to the client
- Replaced `println!` calls in `main.rs` and `seed.rs` with `tracing::info!`/`tracing::debug!`
- Added `RUST_LOG` to `.env.example`
- Added Observability section to `DESIGN.md` documenting crate choices, log level conventions, and error response pattern

## Test plan

All 22 existing tests pass (8 unit + 14 integration). No test changes needed — none of the tests asserted on the old leaked error strings.

- [x] `cargo test` — verify all tests pass
- [x] `cargo run` — verify structured log output appears on startup (not a wall of sqlx noise):
  ```
  2026-03-31T...  INFO beerio_kart: Seeding static data...
  2026-03-31T...  INFO beerio_kart: Seeding complete
  2026-03-31T...  INFO beerio_kart: Listening on http://localhost:3000
  ```
- [x] Add `RUST_LOG=info,tower_http=debug` to `.env`, restart, then curl a request — verify request trace appears in server logs:
  ```
  curl -X POST localhost:3000/api/v1/auth/register -H 'Content-Type: application/json' -d '{"username":"testlog","password":"password123"}'
  ```
- [ ] Verify error-leaking fix by code review: every `Err(e)` branch in `auth.rs` logs with `tracing::error!` and returns `"Internal server error"` (not the real error)
- [x] `RUST_LOG=debug cargo run` — verify debug-level output appears (including sqlx queries and seed skip messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)