### PR TITLE
Add Docker setup with single-container Axum serving

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+node_modules/
+data/beerio-kart.db
+uploads/
+.git/
+.claude/
+*.md
+.env

--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ JWT_SECRET=
 
 # Optional: log level filter (default: info)
 # RUST_LOG=info
+
+# Optional: directory for built frontend files (default: ../frontend/dist)
+# STATIC_DIR=../frontend/dist
+
+# Optional: directory for user-uploaded photos (default: ../uploads)
+# UPLOAD_DIR=../uploads

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,7 @@ Beerio Kart is a mobile-first web app for tracking times and stats for the Mario
 | Database    | SQLite                        | File-based; no separate server; sufficient for this scale     |
 | Package mgr | Bun                           | Drop-in npm replacement; faster installs and script running   |
 | Containers  | Dockerfile + compose.yaml    | Works with Docker or Podman                                  |
+| Serving     | Axum (single container)       | Axum serves both the API and the frontend static files via `tower-http::ServeDir`. No separate nginx or frontend container. |
 
 ## Observability
 
@@ -622,6 +623,10 @@ Note: Deploying early (before core features) keeps the deployment simple and cat
 - **UUID storage in SQLite:** UUIDs stored as TEXT (not BLOB) for human readability when debugging with CLI tools. PostgreSQL migration will map to native UUID type. SeaORM maps both to `String` in Rust, so application code won't change.
 - **Timestamp storage in SQLite:** Timestamps stored as TEXT in ISO 8601 format. SQLite has no native timestamp type. PostgreSQL migration will map to `TIMESTAMPTZ`.
 - **run_flags audit trail:** `run_id` is not unique — a run can have multiple flags (different reasons tracked separately, resolved independently). Resolved flags are kept as history. Only duplicate flags (same run + same reason while unresolved) are prevented in application code.
+## Resolved Decisions (continued)
+
+- **Frontend serving strategy:** Axum serves everything in a single container. The Vite build produces static files that Axum serves via `tower-http::ServeDir`, with SPA fallback to `index.html`. No nginx or separate frontend container. Rationale: simpler deployment for a small-scale app, no CORS (same origin), one container to manage. If static asset performance ever matters (it won't at this scale), a CDN or nginx can be added in front later.
+
 ## Future Ideas (Not Committed)
 
 These are loose ideas that may or may not be pursued. No guarantees.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -623,8 +623,6 @@ Note: Deploying early (before core features) keeps the deployment simple and cat
 - **UUID storage in SQLite:** UUIDs stored as TEXT (not BLOB) for human readability when debugging with CLI tools. PostgreSQL migration will map to native UUID type. SeaORM maps both to `String` in Rust, so application code won't change.
 - **Timestamp storage in SQLite:** Timestamps stored as TEXT in ISO 8601 format. SQLite has no native timestamp type. PostgreSQL migration will map to `TIMESTAMPTZ`.
 - **run_flags audit trail:** `run_id` is not unique — a run can have multiple flags (different reasons tracked separately, resolved independently). Resolved flags are kept as history. Only duplicate flags (same run + same reason while unresolved) are prevented in application code.
-## Resolved Decisions (continued)
-
 - **Frontend serving strategy:** Axum serves everything in a single container. The Vite build produces static files that Axum serves via `tower-http::ServeDir`, with SPA fallback to `index.html`. No nginx or separate frontend container. Rationale: simpler deployment for a small-scale app, no CORS (same origin), one container to manage. If static asset performance ever matters (it won't at this scale), a CDN or nginx can be added in front later.
 
 ## Future Ideas (Not Committed)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Stage 1: Build frontend
+FROM docker.io/oven/bun:1 AS frontend-build
+WORKDIR /app
+
+# Copy workspace root (package.json + bun.lock) and frontend package.json
+# for dependency caching. Bun workspaces keep the lockfile at the root.
+COPY package.json bun.lock ./
+COPY frontend/package.json ./frontend/
+RUN cd frontend && bun install --frozen-lockfile
+
+COPY frontend/ ./frontend/
+RUN cd frontend && bun run build
+
+# Stage 2: Prepare Rust dependency cache with cargo-chef
+FROM docker.io/library/rust:1-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY backend/ ./backend/
+WORKDIR /app/backend
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Build backend (dependencies cached separately from source)
+FROM chef AS backend-build
+COPY --from=planner /app/backend/recipe.json /app/backend/recipe.json
+WORKDIR /app/backend
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY backend/ ./
+# Seed data is embedded at compile time via include_str!() with paths
+# relative to src/ (e.g., ../../data/cups.json), so data/ must exist
+# at the expected location relative to the backend workspace.
+COPY data/ /app/data/
+RUN cargo build --release
+
+# Stage 4: Runtime
+FROM docker.io/library/debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the compiled binary
+COPY --from=backend-build /app/backend/target/release/beerio-kart ./beerio-kart
+
+# Copy the built frontend
+COPY --from=frontend-build /app/frontend/dist/ ./static/
+
+# Create directories for runtime data
+RUN mkdir -p /app/db /app/uploads
+
+EXPOSE 3000
+
+ENV DATABASE_URL="sqlite:///app/db/beerio-kart.db?mode=rwc"
+ENV STATIC_DIR="/app/static"
+ENV UPLOAD_DIR="/app/uploads"
+ENV RUST_LOG="info"
+
+CMD ["./beerio-kart"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,14 @@ COPY --from=backend-build /app/backend/target/release/beerio-kart ./beerio-kart
 # Copy the built frontend
 COPY --from=frontend-build /app/frontend/dist/ ./static/
 
-# Create directories for runtime data
-RUN mkdir -p /app/db /app/uploads
+# Create directories for runtime data and a non-root user to run the app.
+# Running as root inside a container is a security risk — if the app were
+# compromised, the attacker would have root privileges in the container.
+RUN useradd --create-home --no-log-init appuser \
+    && mkdir -p /app/db /app/uploads \
+    && chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,64 @@
 
 We're really doing this thing.
 
-## Running
+## Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) (stable)
+- [Bun](https://bun.sh/) (v1+)
+- For Docker: [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/)
+
+## Setup
 
 ```sh
+cp .env.example .env
+# Edit .env and set JWT_SECRET to a random string
 bun install      # installs all dependencies (root + frontend workspace)
+```
+
+## Running (local dev)
+
+```sh
 bun run dev      # starts backend (port 3000) and frontend (port 5173) together
 ```
 
-Open `http://localhost:5173` in your browser.
+Open `http://localhost:5173` in your browser. The Vite dev server proxies API calls to the backend.
 
 To run them separately:
 
 ```sh
 cd backend && cargo run    # API server on port 3000
 cd frontend && bun dev     # Dev server on port 5173
+```
+
+## Running (Docker)
+
+Build and start the app in a single container. Axum serves both the API and the frontend.
+
+```sh
+# Set JWT_SECRET in your .env file first (see .env.example)
+
+# With Docker:
+docker compose up --build
+
+# With Podman:
+podman compose up --build
+# Or without compose:
+podman build -t beerio-kart .
+podman run --rm -p 3000:3000 -e JWT_SECRET=your-secret-here beerio-kart
+```
+
+Open `http://localhost:3000`. The API is at `/api/v1/*`, everything else serves the React frontend.
+
+Data is persisted in Docker volumes (`db-data` for the SQLite database, `uploads` for user photos). To reset:
+
+```sh
+docker compose down -v   # removes volumes (deletes all data)
+```
+
+## Running tests
+
+```sh
+cd backend && cargo test
 ```
 
 ## Linting & Formatting

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1075,6 +1075,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1455,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -2911,6 +2927,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,9 +2993,19 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3087,6 +3126,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,7 +15,7 @@ sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "m
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.6", features = ["trace", "fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,6 +7,7 @@ use axum::{
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
 use serde::Serialize;
+use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -65,13 +66,24 @@ async fn main() {
 
     let state = AppState { db, config };
 
+    // STATIC_DIR defaults to ../frontend/dist for local dev (running from backend/).
+    // In Docker, set to /app/static where the built frontend is copied.
+    let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_| "../frontend/dist".to_string());
+
     let app = Router::new()
         .route("/api/v1/hello", get(hello))
         .route("/api/v1/auth/register", post(routes::auth::register))
         .route("/api/v1/auth/login", post(routes::auth::login))
         .route("/api/v1/auth/logout", post(routes::auth::logout))
         .layer(TraceLayer::new_for_http())
-        .with_state(state);
+        .with_state(state)
+        // Serve frontend static files. If no API route or static file matches,
+        // fall back to index.html so React Router can handle client-side routing.
+        // Using .fallback() instead of .not_found_service() returns 200 (not 404).
+        .fallback_service(
+            ServeDir::new(&static_dir)
+                .fallback(ServeFile::new(format!("{}/index.html", static_dir))),
+        );
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     tracing::info!("Listening on http://localhost:3000");

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set}
+      - JWT_EXPIRY_HOURS=${JWT_EXPIRY_HOURS:-24}
+      - ADMIN_USER_ID=${ADMIN_USER_ID:-}
+      - DATABASE_URL=sqlite:///app/db/beerio-kart.db?mode=rwc
+      - RUST_LOG=${RUST_LOG:-info}
+    volumes:
+      - db-data:/app/db
+      - uploads:/app/uploads
+    restart: unless-stopped
+
+volumes:
+  db-data:
+  uploads:


### PR DESCRIPTION
## Summary

- **Single-container architecture**: Axum serves both the API (`/api/v1/*`) and frontend static files via `tower-http::ServeDir`, with SPA fallback to `index.html` for React Router
- **Multi-stage Dockerfile**: cargo-chef for Rust dependency caching, bun workspace-aware frontend build, slim Debian runtime with only `libsqlite3-0` and `ca-certificates`
- **compose.yaml**: Named volumes for DB and uploads, required `JWT_SECRET`, configurable log level
- **README**: Added prerequisites, setup, Docker run instructions, and test commands

### Files changed

| File | What |
|------|------|
| `Dockerfile` | 4-stage multi-stage build (frontend → planner → backend → runtime) |
| `compose.yaml` | Single service with named volumes |
| `.dockerignore` | Excludes target/, node_modules/, .git/, etc. |
| `backend/Cargo.toml` | Added `fs` feature to tower-http |
| `backend/src/main.rs` | Added `ServeDir` + `ServeFile` SPA fallback, `STATIC_DIR` env var |
| `.env.example` | Added `STATIC_DIR` and `UPLOAD_DIR` documentation |
| `DESIGN.md` | Documented frontend serving strategy decision |
| `README.md` | Added setup, Docker, and test instructions |

### Design decisions

- **Seed data is compile-time embedded** via `include_str!()`, so no `SEED_DATA_DIR` env var needed — but `data/` must be available during the Docker build stage
- **SQLite is not bundled** (no `bundled` feature on `libsqlite3-sys`), so `libsqlite3-0` is required in the runtime image
- **bun.lock lives at repo root** (bun workspace), not in `frontend/` — Dockerfile accounts for this
- Used `.fallback()` instead of `.not_found_service()` for SPA routing so unknown paths return 200 (not 404) with `index.html`

## Test plan

- [x] `podman build -t beerio-kart .` (or `docker build`) — completes without errors
- [x] `podman run --rm -p 3000:3000 -e JWT_SECRET=test-secret beerio-kart` — app starts, logs show migrations + seeding
- [x] `curl http://localhost:3000/api/v1/hello` — returns `{"message":"Hello from Beerio Kart!"}`
- [x] `curl http://localhost:3000/` — returns 200 with React app HTML
- [x] `curl -o /dev/null -w "%{http_code}" http://localhost:3000/profile/123` — returns 200 (SPA fallback)
- [x] Register: `curl -X POST http://localhost:3000/api/v1/auth/register -H 'Content-Type: application/json' -d '{"username":"testuser","password":"testpass123"}'` — returns 201 with JWT
- [x] Login: `curl -X POST http://localhost:3000/api/v1/auth/login -H 'Content-Type: application/json' -d '{"username":"testuser","password":"testpass123"}'` — returns 200 with JWT
- [x] `cd backend && cargo test` — all 22 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)