### PR TITLE
Rename wheels_id to wheel_id (FK naming convention)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -162,7 +162,7 @@ Flag any deviations from these conventions.
 
 #### Data Model Adherence
 - **UUID vs INTEGER**: User-generated data uses UUID; pre-seeded static data uses INTEGER. Flag mismatches.
-- **Inline vs normalized**: Race setup is stored inline (character_id, body_id, wheels_id, glider_id directly on runs/users). Don't suggest normalizing this — it's a deliberate design decision.
+- **Inline vs normalized**: Race setup is stored inline (character_id, body_id, wheel_id, glider_id directly on runs/users). Don't suggest normalizing this — it's a deliberate design decision.
 - **Derived vs stored**: "Previous" setup is derived from the most recent run, not stored. Flag any attempt to cache derived values on the users table.
 
 ## Review Etiquette

--- a/backend/migration/src/m20260330_000004_create_users.rs
+++ b/backend/migration/src/m20260330_000004_create_users.rs
@@ -28,7 +28,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Users::PasswordHash).text().not_null())
                     .col(ColumnDef::new(Users::PreferredCharacterId).integer())
                     .col(ColumnDef::new(Users::PreferredBodyId).integer())
-                    .col(ColumnDef::new(Users::PreferredWheelsId).integer())
+                    .col(ColumnDef::new(Users::PreferredWheelId).integer())
                     .col(ColumnDef::new(Users::PreferredGliderId).integer())
                     .col(ColumnDef::new(Users::PreferredDrinkTypeId).text())
                     .col(ColumnDef::new(Users::CreatedAt).text().not_null())
@@ -45,7 +45,7 @@ impl MigrationTrait for Migration {
                     )
                     .foreign_key(
                         ForeignKey::create()
-                            .from(Users::Table, Users::PreferredWheelsId)
+                            .from(Users::Table, Users::PreferredWheelId)
                             .to(Wheels::Table, Wheels::Id),
                     )
                     .foreign_key(
@@ -79,7 +79,7 @@ pub enum Users {
     PasswordHash,
     PreferredCharacterId,
     PreferredBodyId,
-    PreferredWheelsId,
+    PreferredWheelId,
     PreferredGliderId,
     PreferredDrinkTypeId,
     CreatedAt,

--- a/backend/migration/src/m20260330_000006_create_runs.rs
+++ b/backend/migration/src/m20260330_000006_create_runs.rs
@@ -24,7 +24,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Runs::TrackId).integer().not_null())
                     .col(ColumnDef::new(Runs::CharacterId).integer().not_null())
                     .col(ColumnDef::new(Runs::BodyId).integer().not_null())
-                    .col(ColumnDef::new(Runs::WheelsId).integer().not_null())
+                    .col(ColumnDef::new(Runs::WheelId).integer().not_null())
                     .col(ColumnDef::new(Runs::GliderId).integer().not_null())
                     .col(ColumnDef::new(Runs::TrackTime).integer().not_null())
                     .col(ColumnDef::new(Runs::Lap1Time).integer().not_null())
@@ -56,7 +56,7 @@ impl MigrationTrait for Migration {
                     )
                     .foreign_key(
                         ForeignKey::create()
-                            .from(Runs::Table, Runs::WheelsId)
+                            .from(Runs::Table, Runs::WheelId)
                             .to(Wheels::Table, Wheels::Id),
                     )
                     .foreign_key(
@@ -89,7 +89,7 @@ pub enum Runs {
     TrackId,
     CharacterId,
     BodyId,
-    WheelsId,
+    WheelId,
     GliderId,
     TrackTime,
     Lap1Time,

--- a/backend/src/entities/runs.rs
+++ b/backend/src/entities/runs.rs
@@ -12,7 +12,7 @@ pub struct Model {
     pub track_id: i32,
     pub character_id: i32,
     pub body_id: i32,
-    pub wheels_id: i32,
+    pub wheel_id: i32,
     pub glider_id: i32,
     pub track_time: i32,
     pub lap1_time: i32,
@@ -82,7 +82,7 @@ pub enum Relation {
     Users,
     #[sea_orm(
         belongs_to = "super::wheels::Entity",
-        from = "Column::WheelsId",
+        from = "Column::WheelId",
         to = "super::wheels::Column::Id",
         on_update = "NoAction",
         on_delete = "NoAction"

--- a/backend/src/entities/users.rs
+++ b/backend/src/entities/users.rs
@@ -15,7 +15,7 @@ pub struct Model {
     pub password_hash: String,
     pub preferred_character_id: Option<i32>,
     pub preferred_body_id: Option<i32>,
-    pub preferred_wheels_id: Option<i32>,
+    pub preferred_wheel_id: Option<i32>,
     pub preferred_glider_id: Option<i32>,
     #[sea_orm(column_type = "Text", nullable)]
     pub preferred_drink_type_id: Option<String>,
@@ -63,7 +63,7 @@ pub enum Relation {
     Runs,
     #[sea_orm(
         belongs_to = "super::wheels::Entity",
-        from = "Column::PreferredWheelsId",
+        from = "Column::PreferredWheelId",
         to = "super::wheels::Column::Id",
         on_update = "NoAction",
         on_delete = "NoAction"

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -124,7 +124,7 @@ pub async fn register(
         password_hash: Set(password_hash),
         preferred_character_id: Set(None),
         preferred_body_id: Set(None),
-        preferred_wheels_id: Set(None),
+        preferred_wheel_id: Set(None),
         preferred_glider_id: Set(None),
         preferred_drink_type_id: Set(None),
         created_at: Set(now.clone()),


### PR DESCRIPTION
## Summary
- Renames `wheels_id` → `wheel_id` and `preferred_wheels_id` → `preferred_wheel_id` across migrations, entities, and route code to follow the `{singular}_id` FK naming convention
- Updates the code-review skill reference to match
- Follows from the design consistency review (approved by Brendan, applied by Cowork to DESIGN.md)

## Breaking change
**Existing databases must be recreated.** Since the original migrations were modified (not a new migration added), delete `data/beerio-kart.db` and restart the server to re-run migrations.

## Test plan

### Automated (already passing)
- [x] `cargo check` passes
- [x] All 22 tests pass (`cargo test`)
- [x] Pre-commit hooks (rustfmt + clippy) pass

### Manual testing after merge

**1. Recreate the database and start the server**

```bash
# From WSL2
cd /mnt/c/Users/obiva/beerio-kart

# Delete the old database (it has the old column names)
rm data/beerio-kart.db

# Start the server — this re-runs all migrations from scratch
cd backend
cargo run
```

Expected: The server starts without errors. Look for log lines showing migrations running and the `listening on` message. No errors about missing columns or failed migrations.

**2. Verify the new column names exist in the database**

In a second terminal:

```bash
sqlite3 /mnt/c/Users/obiva/beerio-kart/data/beerio-kart.db ".schema users" | grep wheel
```

Expected output should contain `preferred_wheel_id` (NOT `preferred_wheels_id`):
```
preferred_wheel_id INTEGER REFERENCES wheels (id)
```

```bash
sqlite3 /mnt/c/Users/obiva/beerio-kart/data/beerio-kart.db ".schema runs" | grep wheel
```

Expected output should contain `wheel_id` (NOT `wheels_id`):
```
wheel_id INTEGER NOT NULL REFERENCES wheels (id)
```

**3. Register a new user (exercises the `preferred_wheel_id` column)**

With the server still running:

```bash
curl -s http://localhost:3000/api/v1/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "testpass123"}' | python3 -m json.tool
```

Expected: A `201 Created` response with a JSON body containing `token` and `user` fields:
```json
{
    "token": "eyJ...",
    "user": {
        "id": "some-uuid",
        "username": "testuser"
    }
}
```

If you see an error mentioning a column name (like `no such column: preferred_wheels_id`), the rename didn't work correctly.

**4. Log in with that user (sanity check)**

```bash
curl -s http://localhost:3000/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "testpass123"}' | python3 -m json.tool
```

Expected: A `200 OK` response with the same JSON shape as registration (token + user info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)