### PR TITLE
Phase 2: Production config + refresh token auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Required: signing key for JWT auth tokens (use a long random string)
 JWT_SECRET=
 
-# Optional: JWT token lifetime in hours (default: 24)
-# JWT_EXPIRY_HOURS=24
+# Optional: access token lifetime in minutes (default: 15)
+# JWT_ACCESS_EXPIRY_MINUTES=15
+
+# Optional: refresh token lifetime in days (default: 7)
+# JWT_REFRESH_EXPIRY_DAYS=7
 
 # Optional: UUID of the admin user (enables admin endpoints)
 # ADMIN_USER_ID=
@@ -18,3 +21,7 @@ JWT_SECRET=
 
 # Optional: directory for user-uploaded photos (default: ../uploads)
 # UPLOAD_DIR=../uploads
+
+# Optional: Secure flag on refresh cookie (default: true)
+# Set to false for local http://localhost development.
+# COOKIE_SECURE=true

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,9 @@
+JWT_SECRET=          # Required. Generate with: openssl rand -base64 32
+JWT_ACCESS_EXPIRY_MINUTES=15
+JWT_REFRESH_EXPIRY_DAYS=7
+ADMIN_USER_ID=       # UUID of admin user (optional)
+DATABASE_URL=sqlite:///app/db/beerio-kart.db?mode=rwc
+STATIC_DIR=/app/static
+UPLOAD_DIR=/app/uploads
+RUST_LOG=info
+COOKIE_SECURE=true

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -763,15 +763,14 @@ beerio-kart/
 - [ ] Set Cloudflare encryption mode to **Full (strict)** — Flexible encrypts browser-to-Cloudflare but forwards plaintext to the origin server, which means passwords travel unencrypted on the last hop
 - [ ] Verify HTTPS works end-to-end through Cloudflare
 - [ ] Test basic auth flow from phone over real network
-- [ ] Add .env / config for production vs development settings
-- [ ] Upgrade auth to refresh token flow (short-lived access token + HttpOnly refresh cookie + `refresh_token_version` on users)
+- [x] Add .env / config for production vs development settings
+- [x] Upgrade auth to refresh token flow (short-lived access token + HttpOnly refresh cookie + `refresh_token_version` on users)
 
 Note: Deploying early (before core features) keeps the deployment simple and catches infrastructure issues before application complexity grows. The Dockerfile and compose.yaml were created in Phase 1 for local development — Phase 2 validates they work on the actual Unraid server behind Cloudflare.
 
 ### Phase 3: Sessions & Run Recording
 - [ ] Session schema: sessions, session_participants, session_races tables + migrations
 - [ ] Add `session_race_id` and `disqualified` columns to runs table (migration)
-- [ ] Add `refresh_token_version` to users table (migration, if not done in Phase 2)
 - [ ] Session polling endpoint (`GET /sessions/:id` returns full session state; clients poll every 2-3 seconds)
 - [ ] Session lifecycle: create, join, leave, auto-close on inactivity (1 hour)
 - [ ] Host transfer on leave (earliest-joined remaining participant)
@@ -868,7 +867,11 @@ Required test scenarios per ruleset: normal flow, recusal by one player, recusal
 - **Frontend serving strategy:** Axum serves everything in a single container. The Vite build produces static files that Axum serves via `tower-http::ServeDir`, with SPA fallback to `index.html`. No nginx or separate frontend container. Rationale: simpler deployment for a small-scale app, no CORS (same origin), one container to manage. If static asset performance ever matters (it won't at this scale), a CDN or nginx can be added in front later.
 - **Auth token strategy:** Short-lived access token (15-30 min, Authorization header) + long-lived refresh token (7-30 days, HttpOnly/Secure/SameSite=Lax cookie scoped to `/api/v1/auth/refresh`). Lax (not Strict) because Strict blocks the cookie when navigating from an external link (e.g., a friend texts you the URL), which would force a re-login. Lax still protects against cross-origin POST attacks. A `refresh_token_version` column on `users` enables server-side revocation checked only on the refresh path, not every request. Frontend intercepts 401s, silently refreshes, and retries. Replaces the original 24-hour single JWT approach.
 - **Pagination:** Cursor-based (keyset) pagination using `created_at` + `id` for list endpoints, particularly `GET /runs` and run history views. Preferred over offset-based to avoid duplicate/skipped entries when new data is inserted during browsing. If implementation proves too complex relative to offset-based, revisit.
-- **Password change:** `PUT /auth/password` endpoint for users to change their own password. Slated for Phase 3.
+- **Password change:** `PUT /auth/password` endpoint for users to change their own password. Implemented in Phase 2 alongside refresh token auth.
+- **Refresh token format:** JWT (not opaque). Contains `sub`, `refresh_token_version`, `exp`, `iat`, `token_type`. Same signing key as access token. Simplest approach — no new table. Per-device revocation deferred; version-bump covers logout and password change.
+- **Refresh token rotation:** On each refresh, a new refresh JWT is issued with a fresh expiry. Does not bump `refresh_token_version` — rotation is about extending the session window, not revocation.
+- **Cloudflare Tunnel (not port forwarding)** for exposing the app. Outbound-only connection from Unraid to Cloudflare edge. No open ports on the home network.
+- **Docker Compose Manager plugin** on Unraid for container management. compose.yaml as the single source of truth for the deployment.
 
 ## Future Ideas (Not Committed)
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "axum",
  "axum-test",
  "chrono",
+ "cookie",
  "dotenvy",
  "jsonwebtoken",
  "migration",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,4 +28,5 @@ warnings = "deny"
 
 [dev-dependencies]
 axum-test = "19.1.1"
+cookie = "0.18"
 tower = "0.5.3"

--- a/backend/migration/src/m20260330_000004_create_users.rs
+++ b/backend/migration/src/m20260330_000004_create_users.rs
@@ -31,6 +31,12 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Users::PreferredWheelId).integer())
                     .col(ColumnDef::new(Users::PreferredGliderId).integer())
                     .col(ColumnDef::new(Users::PreferredDrinkTypeId).text())
+                    .col(
+                        ColumnDef::new(Users::RefreshTokenVersion)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .col(ColumnDef::new(Users::CreatedAt).text().not_null())
                     .col(ColumnDef::new(Users::UpdatedAt).text().not_null())
                     .foreign_key(
@@ -82,6 +88,7 @@ pub enum Users {
     PreferredWheelId,
     PreferredGliderId,
     PreferredDrinkTypeId,
+    RefreshTokenVersion,
     CreatedAt,
     UpdatedAt,
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -7,8 +7,17 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct AppConfig {
     pub jwt_secret: String,
-    pub jwt_expiry_hours: u64,
+    /// How long access tokens are valid (minutes). Short-lived because they
+    /// can't be revoked — if one leaks, it expires quickly.
+    pub jwt_access_expiry_minutes: u64,
+    /// How long refresh tokens are valid (days). Longer-lived because they're
+    /// stored in an HttpOnly cookie (no JavaScript access) and can be revoked
+    /// by bumping `refresh_token_version` in the database.
+    pub jwt_refresh_expiry_days: u64,
     pub admin_user_id: Option<String>,
+    /// Controls the `Secure` flag on the refresh cookie. Must be `false` for
+    /// local `http://localhost` development, `true` in production behind HTTPS.
+    pub cookie_secure: bool,
 }
 
 impl AppConfig {
@@ -20,17 +29,29 @@ impl AppConfig {
         let jwt_secret = std::env::var("JWT_SECRET")
             .expect("JWT_SECRET must be set — it's the signing key for auth tokens");
 
-        let jwt_expiry_hours = std::env::var("JWT_EXPIRY_HOURS")
+        let jwt_access_expiry_minutes = std::env::var("JWT_ACCESS_EXPIRY_MINUTES")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(24);
+            .unwrap_or(15);
+
+        let jwt_refresh_expiry_days = std::env::var("JWT_REFRESH_EXPIRY_DAYS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(7);
 
         let admin_user_id = std::env::var("ADMIN_USER_ID").ok();
 
+        let cookie_secure = std::env::var("COOKIE_SECURE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(true);
+
         Arc::new(Self {
             jwt_secret,
-            jwt_expiry_hours,
+            jwt_access_expiry_minutes,
+            jwt_refresh_expiry_days,
             admin_user_id,
+            cookie_secure,
         })
     }
 }

--- a/backend/src/entities/users.rs
+++ b/backend/src/entities/users.rs
@@ -19,6 +19,7 @@ pub struct Model {
     pub preferred_glider_id: Option<i32>,
     #[sea_orm(column_type = "Text", nullable)]
     pub preferred_drink_type_id: Option<String>,
+    pub refresh_token_version: i32,
     #[sea_orm(column_type = "Text")]
     pub created_at: String,
     #[sea_orm(column_type = "Text")]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,7 +2,7 @@ mod seed;
 
 use axum::{
     Json, Router,
-    routing::{get, post},
+    routing::{get, post, put},
 };
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
@@ -74,7 +74,9 @@ async fn main() {
         .route("/api/v1/hello", get(hello))
         .route("/api/v1/auth/register", post(routes::auth::register))
         .route("/api/v1/auth/login", post(routes::auth::login))
+        .route("/api/v1/auth/refresh", post(routes::auth::refresh))
         .route("/api/v1/auth/logout", post(routes::auth::logout))
+        .route("/api/v1/auth/password", put(routes::auth::change_password))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
         // Serve frontend static files. If no API route or static file matches,

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -6,6 +6,11 @@ use axum::{
 /// Extractor that validates the JWT from the `Authorization: Bearer <token>`
 /// header and makes the authenticated user's info available to handlers.
 ///
+/// Only accepts access tokens (`token_type == "access"`). Refresh tokens are
+/// valid JWTs signed with the same key, but they must NOT be usable as access
+/// tokens — that would let a stolen refresh cookie bypass the short-lived
+/// access token window.
+///
 /// Usage in a handler:
 /// ```ignore
 /// async fn protected(user: AuthUser) -> impl IntoResponse {
@@ -20,7 +25,8 @@ pub struct AuthUser {
 }
 
 /// Axum extractor implementation. Pulls `AppConfig` from state and validates
-/// the bearer token. Returns 401 if the token is missing, malformed, or expired.
+/// the bearer token. Returns 401 if the token is missing, malformed, expired,
+/// or not an access token.
 impl FromRequestParts<crate::AppState> for AuthUser {
     type Rejection = (StatusCode, &'static str);
 
@@ -39,8 +45,13 @@ impl FromRequestParts<crate::AppState> for AuthUser {
             "Invalid Authorization header format",
         ))?;
 
-        let claims = crate::services::auth::validate_token(token, &state.config)
+        let claims = crate::services::auth::validate_access_token(token, &state.config)
             .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
+
+        // Reject refresh tokens used as access tokens
+        if claims.token_type != "access" {
+            return Err((StatusCode::UNAUTHORIZED, "Invalid token type"));
+        }
 
         Ok(AuthUser {
             user_id: claims.sub,

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -1,10 +1,17 @@
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    response::IntoResponse,
+};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::AppState;
 use crate::entities::users;
+use crate::middleware::auth::AuthUser;
+use crate::services::auth as auth_service;
 
 // ── Request / Response types ────────────────────────────────────────
 
@@ -20,10 +27,21 @@ pub struct LoginRequest {
     pub password: String,
 }
 
+#[derive(Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
+
 #[derive(Serialize)]
 pub struct AuthResponse {
-    pub token: String,
+    pub access_token: String,
     pub user: UserInfo,
+}
+
+#[derive(Serialize)]
+pub struct RefreshResponse {
+    pub access_token: String,
 }
 
 #[derive(Serialize)]
@@ -37,11 +55,36 @@ struct ErrorBody {
     error: String,
 }
 
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// Build response headers that set the refresh token cookie.
+fn make_refresh_headers(refresh_token: &str, config: &crate::config::AppConfig) -> HeaderMap {
+    let max_age_seconds = config.jwt_refresh_expiry_days as i64 * 86400;
+    let cookie = auth_service::refresh_cookie(refresh_token, max_age_seconds, config);
+    let mut headers = HeaderMap::new();
+    headers.insert(header::SET_COOKIE, cookie.parse().unwrap());
+    headers
+}
+
+/// Extract the `refresh_token` value from the Cookie header.
+fn extract_refresh_cookie(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(header::COOKIE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .find_map(|pair| {
+            let pair = pair.trim();
+            pair.strip_prefix("refresh_token=").map(|v| v.to_string())
+        })
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
 /// POST /api/v1/auth/register
 ///
-/// Creates a new user account and returns a JWT.
+/// Creates a new user account. Returns an access token in the response body
+/// and sets a refresh token as an HttpOnly cookie.
 pub async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
@@ -98,7 +141,7 @@ pub async fn register(
     }
 
     // Hash password
-    let password_hash = match crate::services::auth::hash_password(&body.password) {
+    let password_hash = match auth_service::hash_password(&body.password) {
         Ok(h) => h,
         Err(e) => {
             error!(error = %e, "Failed to hash password");
@@ -127,6 +170,7 @@ pub async fn register(
         preferred_wheel_id: Set(None),
         preferred_glider_id: Set(None),
         preferred_drink_type_id: Set(None),
+        refresh_token_version: Set(0),
         created_at: Set(now.clone()),
         updated_at: Set(now),
     };
@@ -142,11 +186,11 @@ pub async fn register(
             .into_response();
     }
 
-    // Generate JWT
-    let token = match crate::services::auth::create_token(&user_id, username, &state.config) {
+    // Generate tokens
+    let access_token = match auth_service::create_access_token(&user_id, username, &state.config) {
         Ok(t) => t,
         Err(e) => {
-            error!(error = %e, "Failed to create JWT during registration");
+            error!(error = %e, "Failed to create access token");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
@@ -157,10 +201,27 @@ pub async fn register(
         }
     };
 
+    let refresh_token = match auth_service::create_refresh_token(&user_id, 0, &state.config) {
+        Ok(t) => t,
+        Err(e) => {
+            error!(error = %e, "Failed to create refresh token");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let headers = make_refresh_headers(&refresh_token, &state.config);
+
     (
         StatusCode::CREATED,
+        headers,
         Json(AuthResponse {
-            token,
+            access_token,
             user: UserInfo {
                 id: user_id,
                 username: username.to_string(),
@@ -172,21 +233,24 @@ pub async fn register(
 
 /// POST /api/v1/auth/login
 ///
-/// Authenticates with username + password and returns a JWT.
+/// Authenticates with username + password. Returns an access token in the
+/// response body and sets a refresh token as an HttpOnly cookie.
 pub async fn login(
     State(state): State<AppState>,
     Json(body): Json<LoginRequest>,
 ) -> impl IntoResponse {
     let username = body.username.trim();
 
-    // Look up user — use the same error message for "not found" and "wrong password"
+    // Use the same error message for "not found" and "wrong password"
     // to avoid leaking whether a username exists.
-    let invalid = (
-        StatusCode::UNAUTHORIZED,
-        Json(ErrorBody {
-            error: "Invalid username or password".to_string(),
-        }),
-    );
+    let invalid = || {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorBody {
+                error: "Invalid username or password".to_string(),
+            }),
+        )
+    };
 
     let user = match users::Entity::find()
         .filter(users::Column::Username.eq(username))
@@ -197,11 +261,11 @@ pub async fn login(
         Ok(None) => {
             // Hash a dummy password so the timing is similar to the "wrong password"
             // path. Prevents username enumeration via response-time analysis.
-            let _ = crate::services::auth::verify_password(
+            let _ = auth_service::verify_password(
                 "dummy",
                 "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             );
-            return invalid.into_response();
+            return invalid().into_response();
         }
         Err(e) => {
             error!(error = %e, "Failed to look up user during login");
@@ -216,9 +280,9 @@ pub async fn login(
     };
 
     // Verify password
-    match crate::services::auth::verify_password(&body.password, &user.password_hash) {
+    match auth_service::verify_password(&body.password, &user.password_hash) {
         Ok(true) => {}
-        Ok(false) => return invalid.into_response(),
+        Ok(false) => return invalid().into_response(),
         Err(e) => {
             error!(error = %e, "Password verification failed unexpectedly");
             return (
@@ -231,11 +295,30 @@ pub async fn login(
         }
     }
 
-    // Generate JWT
-    let token = match crate::services::auth::create_token(&user.id, &user.username, &state.config) {
+    // Generate tokens
+    let access_token =
+        match auth_service::create_access_token(&user.id, &user.username, &state.config) {
+            Ok(t) => t,
+            Err(e) => {
+                error!(error = %e, "Failed to create access token during login");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorBody {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+
+    let refresh_token = match auth_service::create_refresh_token(
+        &user.id,
+        user.refresh_token_version,
+        &state.config,
+    ) {
         Ok(t) => t,
         Err(e) => {
-            error!(error = %e, "Failed to create JWT during login");
+            error!(error = %e, "Failed to create refresh token during login");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
@@ -246,21 +329,318 @@ pub async fn login(
         }
     };
 
-    Json(AuthResponse {
-        token,
-        user: UserInfo {
-            id: user.id,
-            username: user.username,
-        },
-    })
-    .into_response()
+    let headers = make_refresh_headers(&refresh_token, &state.config);
+
+    (
+        headers,
+        Json(AuthResponse {
+            access_token,
+            user: UserInfo {
+                id: user.id,
+                username: user.username,
+            },
+        }),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/auth/refresh
+///
+/// Reads the refresh token from the HttpOnly cookie (NOT from the request body
+/// or Authorization header). If valid and the `refresh_token_version` matches
+/// the DB, returns a new access token and rotates the refresh cookie.
+///
+/// "Rotation" means issuing a fresh refresh JWT with a fresh expiry on every
+/// successful refresh. This extends the session window without bumping the
+/// version (which would invalidate other devices).
+pub async fn refresh(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    let cookie_value = match extract_refresh_cookie(&headers) {
+        Some(v) if !v.is_empty() => v,
+        _ => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorBody {
+                    error: "Missing refresh token".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Validate the JWT signature and expiry
+    let claims = match auth_service::validate_refresh_token(&cookie_value, &state.config) {
+        Ok(c) => c,
+        Err(_) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorBody {
+                    error: "Invalid or expired refresh token".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Reject if token_type is not "refresh"
+    if claims.token_type != "refresh" {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorBody {
+                error: "Invalid token type".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Look up user and check refresh_token_version
+    let user = match users::Entity::find_by_id(&claims.sub).one(&state.db).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorBody {
+                    error: "User not found".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to look up user during refresh");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Version mismatch means the token was revoked (logout or password change)
+    if claims.refresh_token_version != user.refresh_token_version {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorBody {
+                error: "Refresh token has been revoked".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Issue new tokens
+    let access_token =
+        match auth_service::create_access_token(&user.id, &user.username, &state.config) {
+            Ok(t) => t,
+            Err(e) => {
+                error!(error = %e, "Failed to create access token during refresh");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorBody {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+
+    // Rotate: issue a fresh refresh token with same version but new expiry
+    let new_refresh = match auth_service::create_refresh_token(
+        &user.id,
+        user.refresh_token_version,
+        &state.config,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            error!(error = %e, "Failed to rotate refresh token");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let resp_headers = make_refresh_headers(&new_refresh, &state.config);
+
+    (resp_headers, Json(RefreshResponse { access_token })).into_response()
 }
 
 /// POST /api/v1/auth/logout
 ///
-/// Client-side logout — the frontend discards the token. This endpoint exists
-/// so the API surface matches the design doc and the frontend has a consistent
-/// endpoint to call. Server-side token revocation can be added later.
-pub async fn logout() -> impl IntoResponse {
-    StatusCode::OK
+/// Requires authentication. Increments `refresh_token_version` in the database,
+/// which invalidates ALL refresh tokens for this user across all devices.
+/// Also clears the refresh cookie on the current browser.
+pub async fn logout(State(state): State<AppState>, user: AuthUser) -> impl IntoResponse {
+    // Look up user to get current version
+    let db_user = match users::Entity::find_by_id(&user.user_id)
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(u)) => u,
+        Ok(None) | Err(_) => {
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    // Increment version to invalidate all existing refresh tokens
+    let mut active: users::ActiveModel = db_user.into_active_model();
+    let current_version: i32 = active.refresh_token_version.clone().unwrap();
+    active.refresh_token_version = Set(current_version + 1);
+    active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+
+    if let Err(e) = active.update(&state.db).await {
+        error!(error = %e, "Failed to increment refresh_token_version");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Clear the refresh cookie
+    let cookie = auth_service::clear_refresh_cookie(&state.config);
+    let mut headers = HeaderMap::new();
+    headers.insert(header::SET_COOKIE, cookie.parse().unwrap());
+
+    (headers, StatusCode::OK).into_response()
+}
+
+/// PUT /api/v1/auth/password
+///
+/// Requires authentication. Validates the current password, updates the hash,
+/// and increments `refresh_token_version` to force re-login on all other devices.
+/// Returns new tokens for the current session so the user stays logged in.
+pub async fn change_password(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(body): Json<ChangePasswordRequest>,
+) -> impl IntoResponse {
+    // Validate new password length
+    if body.new_password.len() < 8 || body.new_password.len() > 128 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody {
+                error: "New password must be 8-128 characters".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Look up user
+    let db_user = match users::Entity::find_by_id(&user.user_id)
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorBody {
+                    error: "User not found".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to look up user for password change");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify current password
+    match auth_service::verify_password(&body.current_password, &db_user.password_hash) {
+        Ok(true) => {}
+        Ok(false) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorBody {
+                    error: "Current password is incorrect".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            error!(error = %e, "Password verification failed during change");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    }
+
+    // Hash new password
+    let new_hash = match auth_service::hash_password(&body.new_password) {
+        Ok(h) => h,
+        Err(e) => {
+            error!(error = %e, "Failed to hash new password");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Update password and bump version (invalidates all other sessions)
+    let new_version = db_user.refresh_token_version + 1;
+    let username = db_user.username.clone();
+    let user_id = db_user.id.clone();
+    let mut active: users::ActiveModel = db_user.into_active_model();
+    active.password_hash = Set(new_hash);
+    active.refresh_token_version = Set(new_version);
+    active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+
+    if let Err(e) = active.update(&state.db).await {
+        error!(error = %e, "Failed to update password");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorBody {
+                error: "Internal server error".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Issue new tokens for the current session
+    let access_token = match auth_service::create_access_token(&user_id, &username, &state.config) {
+        Ok(t) => t,
+        Err(e) => {
+            error!(error = %e, "Failed to create access token after password change");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorBody {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let refresh_token =
+        match auth_service::create_refresh_token(&user_id, new_version, &state.config) {
+            Ok(t) => t,
+            Err(e) => {
+                error!(error = %e, "Failed to create refresh token after password change");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorBody {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+
+    let headers = make_refresh_headers(&refresh_token, &state.config);
+
+    (headers, Json(RefreshResponse { access_token })).into_response()
 }

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -485,9 +485,9 @@ pub async fn logout(State(state): State<AppState>, user: AuthUser) -> impl IntoR
     };
 
     // Increment version to invalidate all existing refresh tokens
+    let new_version = db_user.refresh_token_version + 1;
     let mut active: users::ActiveModel = db_user.into_active_model();
-    let current_version: i32 = active.refresh_token_version.clone().unwrap();
-    active.refresh_token_version = Set(current_version + 1);
+    active.refresh_token_version = Set(new_version);
     active.updated_at = Set(chrono::Utc::now().to_rfc3339());
 
     if let Err(e) = active.update(&state.db).await {

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::AppConfig;
 
-/// JWT claims stored inside each token.
+/// Claims for short-lived access tokens (sent in response body, stored in JS memory).
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Claims {
+pub struct AccessClaims {
     /// User ID (UUID string)
     pub sub: String,
     /// Username — included so the frontend can display it without an extra API call
@@ -19,6 +19,26 @@ pub struct Claims {
     pub exp: i64,
     /// Issued-at as a Unix timestamp
     pub iat: i64,
+    /// Must be "access" — prevents a refresh token from being used as an access token
+    pub token_type: String,
+}
+
+/// Claims for long-lived refresh tokens (stored in an HttpOnly cookie).
+/// Contains `refresh_token_version` which must match the DB value — this is
+/// how we revoke all refresh tokens for a user (e.g., on logout or password change).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RefreshClaims {
+    /// User ID (UUID string)
+    pub sub: String,
+    /// Must match the user's `refresh_token_version` in the database.
+    /// Bumping this value in the DB invalidates all existing refresh tokens.
+    pub refresh_token_version: i32,
+    /// Expiry as a Unix timestamp (seconds)
+    pub exp: i64,
+    /// Issued-at as a Unix timestamp
+    pub iat: i64,
+    /// Must be "refresh"
+    pub token_type: String,
 }
 
 /// Hash a plaintext password using Argon2id (the recommended variant).
@@ -40,20 +60,21 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, argon2::passw
         .is_ok())
 }
 
-/// Create a signed JWT for the given user.
-pub fn create_token(
+/// Create a short-lived access token for the given user.
+pub fn create_access_token(
     user_id: &str,
     username: &str,
     config: &AppConfig,
 ) -> Result<String, jsonwebtoken::errors::Error> {
     let now = Utc::now();
-    let expiry = now + TimeDelta::hours(config.jwt_expiry_hours as i64);
+    let expiry = now + TimeDelta::minutes(config.jwt_access_expiry_minutes as i64);
 
-    let claims = Claims {
+    let claims = AccessClaims {
         sub: user_id.to_string(),
         username: username.to_string(),
         exp: expiry.timestamp(),
         iat: now.timestamp(),
+        token_type: "access".to_string(),
     };
 
     encode(
@@ -63,17 +84,67 @@ pub fn create_token(
     )
 }
 
-/// Validate a JWT and return its claims, or an error if invalid/expired.
-pub fn validate_token(
+/// Create a long-lived refresh token for the given user.
+pub fn create_refresh_token(
+    user_id: &str,
+    refresh_token_version: i32,
+    config: &AppConfig,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let now = Utc::now();
+    let expiry = now + TimeDelta::days(config.jwt_refresh_expiry_days as i64);
+
+    let claims = RefreshClaims {
+        sub: user_id.to_string(),
+        refresh_token_version,
+        exp: expiry.timestamp(),
+        iat: now.timestamp(),
+        token_type: "refresh".to_string(),
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(config.jwt_secret.as_bytes()),
+    )
+}
+
+/// Validate an access token and return its claims.
+pub fn validate_access_token(
     token: &str,
     config: &AppConfig,
-) -> Result<Claims, jsonwebtoken::errors::Error> {
-    let token_data = decode::<Claims>(
+) -> Result<AccessClaims, jsonwebtoken::errors::Error> {
+    let token_data = decode::<AccessClaims>(
         token,
         &DecodingKey::from_secret(config.jwt_secret.as_bytes()),
         &Validation::new(jsonwebtoken::Algorithm::HS256),
     )?;
     Ok(token_data.claims)
+}
+
+/// Validate a refresh token and return its claims.
+pub fn validate_refresh_token(
+    token: &str,
+    config: &AppConfig,
+) -> Result<RefreshClaims, jsonwebtoken::errors::Error> {
+    let token_data = decode::<RefreshClaims>(
+        token,
+        &DecodingKey::from_secret(config.jwt_secret.as_bytes()),
+        &Validation::new(jsonwebtoken::Algorithm::HS256),
+    )?;
+    Ok(token_data.claims)
+}
+
+/// Build the `Set-Cookie` header value for a refresh token.
+pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &AppConfig) -> String {
+    let secure = if config.cookie_secure { "Secure; " } else { "" };
+    format!(
+        "refresh_token={token}; HttpOnly; {secure}SameSite=Lax; Path=/api/v1/auth/refresh; Max-Age={max_age_seconds}"
+    )
+}
+
+/// Build a `Set-Cookie` header value that clears the refresh token cookie.
+pub fn clear_refresh_cookie(config: &AppConfig) -> String {
+    refresh_cookie("", 0, config)
 }
 
 #[cfg(test)]
@@ -84,15 +155,16 @@ mod tests {
     fn test_config() -> Arc<AppConfig> {
         Arc::new(AppConfig {
             jwt_secret: "test-secret-key-for-unit-tests".to_string(),
-            jwt_expiry_hours: 24,
+            jwt_access_expiry_minutes: 15,
+            jwt_refresh_expiry_days: 7,
             admin_user_id: None,
+            cookie_secure: false,
         })
     }
 
     #[test]
     fn test_hash_password_produces_argon2id_hash() {
         let hash = hash_password("mysecretpassword").unwrap();
-        // Argon2id hashes start with $argon2id$
         assert!(
             hash.starts_with("$argon2id$"),
             "Expected argon2id hash, got: {hash}"
@@ -103,7 +175,6 @@ mod tests {
     fn test_hash_password_produces_different_hashes_for_same_input() {
         let hash1 = hash_password("samepassword").unwrap();
         let hash2 = hash_password("samepassword").unwrap();
-        // Different salts should produce different hashes
         assert_ne!(hash1, hash2);
     }
 
@@ -120,48 +191,95 @@ mod tests {
     }
 
     #[test]
-    fn test_create_and_validate_token() {
+    fn test_create_and_validate_access_token() {
         let config = test_config();
-        let token = create_token("user-123", "testuser", &config).unwrap();
-        let claims = validate_token(&token, &config).unwrap();
+        let token = create_access_token("user-123", "testuser", &config).unwrap();
+        let claims = validate_access_token(&token, &config).unwrap();
 
         assert_eq!(claims.sub, "user-123");
         assert_eq!(claims.username, "testuser");
+        assert_eq!(claims.token_type, "access");
         assert!(claims.exp > claims.iat);
     }
 
     #[test]
-    fn test_validate_token_with_wrong_secret() {
+    fn test_create_and_validate_refresh_token() {
         let config = test_config();
-        let token = create_token("user-123", "testuser", &config).unwrap();
+        let token = create_refresh_token("user-123", 0, &config).unwrap();
+        let claims = validate_refresh_token(&token, &config).unwrap();
+
+        assert_eq!(claims.sub, "user-123");
+        assert_eq!(claims.refresh_token_version, 0);
+        assert_eq!(claims.token_type, "refresh");
+        assert!(claims.exp > claims.iat);
+    }
+
+    #[test]
+    fn test_validate_access_token_with_wrong_secret() {
+        let config = test_config();
+        let token = create_access_token("user-123", "testuser", &config).unwrap();
 
         let wrong_config = Arc::new(AppConfig {
             jwt_secret: "wrong-secret".to_string(),
-            jwt_expiry_hours: 24,
+            jwt_access_expiry_minutes: 15,
+            jwt_refresh_expiry_days: 7,
             admin_user_id: None,
+            cookie_secure: false,
         });
 
-        assert!(validate_token(&token, &wrong_config).is_err());
+        assert!(validate_access_token(&token, &wrong_config).is_err());
     }
 
     #[test]
     fn test_validate_token_garbage_input() {
         let config = test_config();
-        assert!(validate_token("not.a.valid.jwt", &config).is_err());
+        assert!(validate_access_token("not.a.valid.jwt", &config).is_err());
     }
 
     #[test]
-    fn test_token_contains_correct_expiry_window() {
+    fn test_access_token_contains_correct_expiry_window() {
         let config = Arc::new(AppConfig {
             jwt_secret: "test-secret".to_string(),
-            jwt_expiry_hours: 48,
+            jwt_access_expiry_minutes: 30,
+            jwt_refresh_expiry_days: 7,
             admin_user_id: None,
+            cookie_secure: false,
         });
-        let token = create_token("user-1", "alice", &config).unwrap();
-        let claims = validate_token(&token, &config).unwrap();
+        let token = create_access_token("user-1", "alice", &config).unwrap();
+        let claims = validate_access_token(&token, &config).unwrap();
 
         let duration_secs = claims.exp - claims.iat;
-        // Should be 48 hours = 172800 seconds (allow 5s tolerance for test execution time)
-        assert!((duration_secs - 172800).unsigned_abs() < 5);
+        // Should be 30 minutes = 1800 seconds (allow 5s tolerance)
+        assert!((duration_secs - 1800).unsigned_abs() < 5);
+    }
+
+    #[test]
+    fn test_refresh_cookie_format() {
+        let config = Arc::new(AppConfig {
+            jwt_secret: "s".to_string(),
+            jwt_access_expiry_minutes: 15,
+            jwt_refresh_expiry_days: 7,
+            admin_user_id: None,
+            cookie_secure: true,
+        });
+        let cookie = refresh_cookie("tok123", 3600, &config);
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains("Path=/api/v1/auth/refresh"));
+        assert!(cookie.contains("Max-Age=3600"));
+    }
+
+    #[test]
+    fn test_refresh_cookie_no_secure_in_dev() {
+        let config = Arc::new(AppConfig {
+            jwt_secret: "s".to_string(),
+            jwt_access_expiry_minutes: 15,
+            jwt_refresh_expiry_days: 7,
+            admin_user_id: None,
+            cookie_secure: false,
+        });
+        let cookie = refresh_cookie("tok123", 3600, &config);
+        assert!(!cookie.contains("Secure"));
     }
 }

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use axum::{Router, http::StatusCode, routing::post};
+use axum::{
+    Router,
+    http::StatusCode,
+    routing::{get, post, put},
+};
 use axum_test::TestServer;
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
@@ -9,6 +13,23 @@ use serde_json::{Value, json};
 use beerio_kart::AppState;
 use beerio_kart::config::AppConfig;
 use beerio_kart::routes;
+
+const TEST_SECRET: &str = "test-secret-for-integration-tests";
+
+fn test_config() -> Arc<AppConfig> {
+    Arc::new(AppConfig {
+        jwt_secret: TEST_SECRET.to_string(),
+        jwt_access_expiry_minutes: 15,
+        jwt_refresh_expiry_days: 7,
+        admin_user_id: None,
+        cookie_secure: false,
+    })
+}
+
+/// A trivial authenticated endpoint used to verify that the AuthUser extractor works.
+async fn protected_hello(user: beerio_kart::middleware::auth::AuthUser) -> axum::Json<Value> {
+    axum::Json(json!({ "hello": user.username }))
+}
 
 /// Create a fresh in-memory SQLite database with all migrations applied.
 async fn setup_test_app() -> TestServer {
@@ -24,25 +45,47 @@ async fn setup_test_app() -> TestServer {
         .await
         .expect("Failed to run migrations");
 
-    let config = Arc::new(AppConfig {
-        jwt_secret: "test-secret-for-integration-tests".to_string(),
-        jwt_expiry_hours: 24,
-        admin_user_id: None,
-    });
-
+    let config = test_config();
     let state = AppState { db, config };
 
     let app = Router::new()
         .route("/api/v1/auth/register", post(routes::auth::register))
         .route("/api/v1/auth/login", post(routes::auth::login))
+        .route("/api/v1/auth/refresh", post(routes::auth::refresh))
         .route("/api/v1/auth/logout", post(routes::auth::logout))
+        .route("/api/v1/auth/password", put(routes::auth::change_password))
+        .route("/api/v1/protected", get(protected_hello))
         .with_state(state);
 
     TestServer::new(app)
 }
 
+/// Helper: register a user and return the response body.
+async fn register_user(server: &TestServer, username: &str, password: &str) -> Value {
+    let response = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": username, "password": password }))
+        .await;
+    response.assert_status(StatusCode::CREATED);
+    response.json()
+}
+
+/// Helper: extract the refresh_token cookie value from a Set-Cookie header.
+fn extract_refresh_cookie(response: &axum_test::TestResponse) -> Option<String> {
+    let header = response.header("set-cookie");
+    let header_str = header.to_str().ok()?;
+    // Cookie format: refresh_token=<value>; HttpOnly; ...
+    header_str
+        .split(';')
+        .next()?
+        .strip_prefix("refresh_token=")
+        .map(|s| s.to_string())
+}
+
+// ── Existing tests (updated for new response format) ────────────────
+
 #[tokio::test]
-async fn test_register_success_returns_201_and_jwt() {
+async fn test_register_success_returns_201_with_access_token_and_refresh_cookie() {
     let server = setup_test_app().await;
 
     let response = server
@@ -53,22 +96,284 @@ async fn test_register_success_returns_201_and_jwt() {
     response.assert_status(StatusCode::CREATED);
 
     let body: Value = response.json();
-    assert!(body["token"].is_string());
+    assert!(
+        body["access_token"].is_string(),
+        "should return access_token"
+    );
     assert_eq!(body["user"]["username"], "alice");
     assert!(body["user"]["id"].is_string());
     let id = body["user"]["id"].as_str().unwrap();
     assert!(uuid::Uuid::parse_str(id).is_ok());
+
+    // Should set a refresh cookie
+    let cookie = extract_refresh_cookie(&response);
+    assert!(cookie.is_some(), "should set refresh_token cookie");
+    assert!(!cookie.unwrap().is_empty(), "cookie should not be empty");
 }
+
+#[tokio::test]
+async fn test_login_success_returns_access_token_and_refresh_cookie() {
+    let server = setup_test_app().await;
+    register_user(&server, "dave", "password123").await;
+
+    let response = server
+        .post("/api/v1/auth/login")
+        .json(&json!({ "username": "dave", "password": "password123" }))
+        .await;
+
+    response.assert_status(StatusCode::OK);
+
+    let body: Value = response.json();
+    assert!(
+        body["access_token"].is_string(),
+        "should return access_token"
+    );
+    assert_eq!(body["user"]["username"], "dave");
+
+    let cookie = extract_refresh_cookie(&response);
+    assert!(cookie.is_some(), "should set refresh_token cookie");
+}
+
+#[tokio::test]
+async fn test_refresh_with_valid_cookie_returns_new_access_token_and_rotated_cookie() {
+    let server = setup_test_app().await;
+
+    // Register to get a refresh cookie
+    let reg_response = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": "carol", "password": "password123" }))
+        .await;
+    let cookie = extract_refresh_cookie(&reg_response).unwrap();
+
+    // Use the refresh cookie to get a new access token
+    let refresh_response = server
+        .post("/api/v1/auth/refresh")
+        .add_cookie(cookie::Cookie::new("refresh_token", &cookie))
+        .await;
+
+    refresh_response.assert_status(StatusCode::OK);
+
+    let body: Value = refresh_response.json();
+    assert!(
+        body["access_token"].is_string(),
+        "should return new access_token"
+    );
+
+    // Should also rotate the refresh cookie
+    let new_cookie = extract_refresh_cookie(&refresh_response);
+    assert!(new_cookie.is_some(), "should set rotated refresh cookie");
+}
+
+#[tokio::test]
+async fn test_refresh_without_cookie_returns_401() {
+    let server = setup_test_app().await;
+
+    let response = server.post("/api/v1/auth/refresh").await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert!(body["error"].as_str().unwrap().contains("Missing"));
+}
+
+#[tokio::test]
+async fn test_refresh_with_wrong_version_returns_401() {
+    let server = setup_test_app().await;
+
+    // Register to get tokens
+    let reg_response = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": "mallory", "password": "password123" }))
+        .await;
+    let reg_body: Value = reg_response.json();
+    let access_token = reg_body["access_token"].as_str().unwrap();
+    let refresh_cookie_val = extract_refresh_cookie(&reg_response).unwrap();
+
+    // Logout bumps refresh_token_version, invalidating the cookie
+    server
+        .post("/api/v1/auth/logout")
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await
+        .assert_status(StatusCode::OK);
+
+    // Try to use the old refresh cookie — should fail
+    let response = server
+        .post("/api/v1/auth/refresh")
+        .add_cookie(cookie::Cookie::new("refresh_token", &refresh_cookie_val))
+        .await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert!(body["error"].as_str().unwrap().contains("revoked"));
+}
+
+#[tokio::test]
+async fn test_logout_increments_version_and_clears_cookie() {
+    let server = setup_test_app().await;
+
+    // Register and get tokens
+    let reg_response = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": "logan", "password": "password123" }))
+        .await;
+    let reg_body: Value = reg_response.json();
+    let access_token = reg_body["access_token"].as_str().unwrap();
+    let refresh_cookie_val = extract_refresh_cookie(&reg_response).unwrap();
+
+    // Logout
+    let logout_response = server
+        .post("/api/v1/auth/logout")
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    logout_response.assert_status(StatusCode::OK);
+
+    // The logout response should clear the cookie (Max-Age=0)
+    let header_val = logout_response.header("set-cookie");
+    let set_cookie = header_val.to_str().unwrap();
+    assert!(
+        set_cookie.contains("Max-Age=0"),
+        "should clear cookie with Max-Age=0"
+    );
+
+    // Old refresh cookie should now fail
+    let refresh_response = server
+        .post("/api/v1/auth/refresh")
+        .add_cookie(cookie::Cookie::new("refresh_token", &refresh_cookie_val))
+        .await;
+    refresh_response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_password_change_increments_version_and_returns_new_tokens() {
+    let server = setup_test_app().await;
+
+    // Register
+    let reg_response = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": "pat", "password": "oldpass123" }))
+        .await;
+    let reg_body: Value = reg_response.json();
+    let access_token = reg_body["access_token"].as_str().unwrap();
+    let old_refresh = extract_refresh_cookie(&reg_response).unwrap();
+
+    // Change password
+    let pw_response = server
+        .put("/api/v1/auth/password")
+        .json(&json!({
+            "current_password": "oldpass123",
+            "new_password": "newpass456"
+        }))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    pw_response.assert_status(StatusCode::OK);
+    let pw_body: Value = pw_response.json();
+    assert!(
+        pw_body["access_token"].is_string(),
+        "should return new access_token"
+    );
+
+    // New refresh cookie should be set
+    let new_refresh = extract_refresh_cookie(&pw_response);
+    assert!(new_refresh.is_some(), "should set new refresh cookie");
+
+    // Old refresh token should now fail (version was bumped)
+    let old_refresh_response = server
+        .post("/api/v1/auth/refresh")
+        .add_cookie(cookie::Cookie::new("refresh_token", &old_refresh))
+        .await;
+    old_refresh_response.assert_status(StatusCode::UNAUTHORIZED);
+
+    // Login with new password should work
+    let login_response = server
+        .post("/api/v1/auth/login")
+        .json(&json!({ "username": "pat", "password": "newpass456" }))
+        .await;
+    login_response.assert_status(StatusCode::OK);
+
+    // Login with old password should fail
+    let old_login = server
+        .post("/api/v1/auth/login")
+        .json(&json!({ "username": "pat", "password": "oldpass123" }))
+        .await;
+    old_login.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_refresh_token_in_authorization_header_rejected_by_middleware() {
+    let server = setup_test_app().await;
+
+    // Create a refresh token directly
+    let config = test_config();
+    let refresh_jwt =
+        beerio_kart::services::auth::create_refresh_token("fake-user-id", 0, &config).unwrap();
+
+    // Try to use it as a Bearer token on a protected endpoint
+    let response = server
+        .get("/api/v1/protected")
+        .add_header("Authorization", format!("Bearer {refresh_jwt}"))
+        .await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_access_token_with_type_refresh_rejected_by_middleware() {
+    let server = setup_test_app().await;
+
+    // Create a refresh token and try to pass it off as an access token.
+    // The middleware should check token_type and reject it.
+    let config = test_config();
+    let refresh_jwt =
+        beerio_kart::services::auth::create_refresh_token("fake-user-id", 0, &config).unwrap();
+
+    let response = server
+        .get("/api/v1/protected")
+        .add_header("Authorization", format!("Bearer {refresh_jwt}"))
+        .await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_expired_access_token_rejected_by_middleware() {
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use serde_json::json as json_val;
+
+    let server = setup_test_app().await;
+
+    // Create a token with exp 2 minutes in the past (beyond jsonwebtoken's
+    // default 60-second leeway).
+    let past = chrono::Utc::now().timestamp() - 120;
+    let claims = json_val!({
+        "sub": "user-1",
+        "username": "test",
+        "exp": past,
+        "iat": past - 60,
+        "token_type": "access",
+    });
+
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+    )
+    .unwrap();
+
+    let response = server
+        .get("/api/v1/protected")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// ── Preserved existing tests (updated for new API) ──────────────────
 
 #[tokio::test]
 async fn test_register_duplicate_username_returns_409() {
     let server = setup_test_app().await;
-
-    server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "bob", "password": "password123" }))
-        .await
-        .assert_status(StatusCode::CREATED);
+    register_user(&server, "bob", "password123").await;
 
     let response = server
         .post("/api/v1/auth/register")
@@ -118,36 +423,22 @@ async fn test_register_short_password_returns_400() {
 }
 
 #[tokio::test]
-async fn test_login_success_returns_200_and_jwt() {
+async fn test_register_long_password_returns_400() {
     let server = setup_test_app().await;
 
-    server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "dave", "password": "password123" }))
-        .await
-        .assert_status(StatusCode::CREATED);
-
+    let long_password = "a".repeat(129);
     let response = server
-        .post("/api/v1/auth/login")
-        .json(&json!({ "username": "dave", "password": "password123" }))
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": "testuser", "password": long_password }))
         .await;
 
-    response.assert_status(StatusCode::OK);
-
-    let body: Value = response.json();
-    assert!(body["token"].is_string());
-    assert_eq!(body["user"]["username"], "dave");
+    response.assert_status(StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
 async fn test_login_wrong_password_returns_401() {
     let server = setup_test_app().await;
-
-    server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "eve", "password": "password123" }))
-        .await
-        .assert_status(StatusCode::CREATED);
+    register_user(&server, "eve", "password123").await;
 
     let response = server
         .post("/api/v1/auth/login")
@@ -177,11 +468,7 @@ async fn test_login_nonexistent_user_returns_401() {
 async fn test_login_returns_same_user_id_as_register() {
     let server = setup_test_app().await;
 
-    let reg_response = server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "frank", "password": "password123" }))
-        .await;
-    let reg_body: Value = reg_response.json();
+    let reg_body = register_user(&server, "frank", "password123").await;
     let registered_id = reg_body["user"]["id"].as_str().unwrap().to_string();
 
     let login_response = server
@@ -195,48 +482,15 @@ async fn test_login_returns_same_user_id_as_register() {
 }
 
 #[tokio::test]
-async fn test_logout_returns_200() {
-    let server = setup_test_app().await;
-
-    let response = server.post("/api/v1/auth/logout").await;
-    response.assert_status(StatusCode::OK);
-}
-
-#[tokio::test]
-async fn test_jwt_contains_correct_sub_claim() {
-    let server = setup_test_app().await;
-
-    let response = server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "grace", "password": "password123" }))
-        .await;
-
-    let body: Value = response.json();
-    let token = body["token"].as_str().unwrap();
-    let user_id = body["user"]["id"].as_str().unwrap();
-
-    let config = AppConfig {
-        jwt_secret: "test-secret-for-integration-tests".to_string(),
-        jwt_expiry_hours: 24,
-        admin_user_id: None,
-    };
-    let claims = beerio_kart::services::auth::validate_token(token, &config).unwrap();
-    assert_eq!(claims.sub, user_id);
-    assert_eq!(claims.username, "grace");
-}
-
-#[tokio::test]
 async fn test_register_unicode_username_within_30_chars() {
     let server = setup_test_app().await;
 
-    // 30 Unicode characters (each is multibyte in UTF-8)
     let unicode_name: String = "é".repeat(30);
     let response = server
         .post("/api/v1/auth/register")
         .json(&json!({ "username": unicode_name, "password": "password123" }))
         .await;
 
-    // Should succeed — 30 characters even though >30 bytes
     response.assert_status(StatusCode::CREATED);
 }
 
@@ -244,14 +498,8 @@ async fn test_register_unicode_username_within_30_chars() {
 async fn test_login_trims_whitespace_like_register() {
     let server = setup_test_app().await;
 
-    // Register with whitespace-padded username
-    server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "  padded  ", "password": "password123" }))
-        .await
-        .assert_status(StatusCode::CREATED);
+    register_user(&server, "  padded  ", "password123").await;
 
-    // Login with the same whitespace — should still find the user
     let response = server
         .post("/api/v1/auth/login")
         .json(&json!({ "username": "  padded  ", "password": "password123" }))
@@ -260,17 +508,4 @@ async fn test_login_trims_whitespace_like_register() {
     response.assert_status(StatusCode::OK);
     let body: Value = response.json();
     assert_eq!(body["user"]["username"], "padded");
-}
-
-#[tokio::test]
-async fn test_register_long_password_returns_400() {
-    let server = setup_test_app().await;
-
-    let long_password = "a".repeat(129);
-    let response = server
-        .post("/api/v1/auth/register")
-        .json(&json!({ "username": "testuser", "password": long_password }))
-        .await;
-
-    response.assert_status(StatusCode::BAD_REQUEST);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.2",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -248,6 +249,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -450,6 +453,10 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-router": ["react-router@7.13.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA=="],
+
+    "react-router-dom": ["react-router-dom@7.13.2", "", { "dependencies": { "react-router": "7.13.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -461,6 +468,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,10 +5,12 @@ services:
       - "3000:3000"
     environment:
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set}
-      - JWT_EXPIRY_HOURS=${JWT_EXPIRY_HOURS:-24}
+      - JWT_ACCESS_EXPIRY_MINUTES=${JWT_ACCESS_EXPIRY_MINUTES:-15}
+      - JWT_REFRESH_EXPIRY_DAYS=${JWT_REFRESH_EXPIRY_DAYS:-7}
       - ADMIN_USER_ID=${ADMIN_USER_ID:-}
       - DATABASE_URL=sqlite:///app/db/beerio-kart.db?mode=rwc
       - RUST_LOG=${RUST_LOG:-info}
+      - COOKIE_SECURE=${COOKIE_SECURE:-true}
     volumes:
       - db-data:/app/db
       - uploads:/app/uploads

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,7 +16,3 @@ bun dev
 ```
 
 Dev server starts on `http://localhost:5173`. API requests to `/api` are proxied to the backend at `http://localhost:3000`.
-
-## Project Structure
-
-See [DESIGN.md](../docs/DESIGN.md) for the full frontend source layout under `frontend/src/`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,98 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { AuthProvider, useAuth } from './hooks/useAuth'
+import Login from './pages/Login'
+import Register from './pages/Register'
 import { useEffect, useState } from 'react'
+import { apiFetch } from './api/client'
 
-function App() {
+/** Shows a loading spinner while the initial silent refresh is in progress. */
+function AuthGate({ children }: { children: React.ReactNode }) {
+  const { isLoading } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    )
+  }
+
+  return children
+}
+
+/** Redirects to /login if not authenticated. */
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth()
+  if (!isAuthenticated) return <Navigate to="/login" replace />
+  return children
+}
+
+/** Redirects to / if already authenticated. */
+function GuestOnly({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth()
+  if (isAuthenticated) return <Navigate to="/" replace />
+  return children
+}
+
+/** Placeholder home page — shows the hello endpoint response + logout button. */
+function Home() {
+  const { user, logout } = useAuth()
   const [message, setMessage] = useState('Loading...')
 
   useEffect(() => {
-    fetch('/api/v1/hello')
+    apiFetch('/api/v1/hello')
       .then((res) => res.json())
       .then((data) => setMessage(data.message))
       .catch(() => setMessage('Failed to connect to backend'))
   }, [])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 gap-4">
       <h1 className="text-4xl font-bold text-white">{message}</h1>
+      <p className="text-gray-400">
+        Logged in as <span className="text-white font-semibold">{user?.username}</span>
+      </p>
+      <button onClick={logout} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+        Log Out
+      </button>
     </div>
+  )
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <AuthGate>
+          <Routes>
+            <Route
+              path="/login"
+              element={
+                <GuestOnly>
+                  <Login />
+                </GuestOnly>
+              }
+            />
+            <Route
+              path="/register"
+              element={
+                <GuestOnly>
+                  <Register />
+                </GuestOnly>
+              }
+            />
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <Home />
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </AuthGate>
+      </AuthProvider>
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,78 @@
+/**
+ * API client that handles access token management and automatic refresh.
+ *
+ * The access token is stored in a module-level variable — NOT localStorage or
+ * sessionStorage. This means it's lost on page refresh, which is intentional:
+ * the HttpOnly refresh cookie handles re-authentication transparently.
+ *
+ * On a 401 response, the client automatically attempts a token refresh (the
+ * browser sends the HttpOnly cookie automatically). If refresh succeeds, it
+ * retries the original request. If refresh also fails, it means the session
+ * is truly expired and the user needs to log in again.
+ */
+
+let accessToken: string | null = null
+
+export function setAccessToken(token: string | null) {
+  accessToken = token
+}
+
+export function getAccessToken(): string | null {
+  return accessToken
+}
+
+/** Callback set by AuthProvider so the API client can trigger a logout
+ *  (redirect to login) when a refresh fails. */
+let onAuthFailure: (() => void) | null = null
+
+export function setOnAuthFailure(callback: () => void) {
+  onAuthFailure = callback
+}
+
+/**
+ * Attempt to get a new access token using the refresh cookie.
+ * Returns true if successful, false otherwise.
+ */
+async function tryRefresh(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/v1/auth/refresh', {
+      method: 'POST',
+      // credentials: 'same-origin' is the default for same-origin requests,
+      // which means the browser automatically sends the HttpOnly cookie.
+    })
+    if (!res.ok) return false
+    const data = await res.json()
+    accessToken = data.access_token
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Wrapper around fetch() that adds the access token and handles 401 refresh.
+ */
+export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(options.headers)
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`)
+  }
+
+  let res = await fetch(url, { ...options, headers })
+
+  // If we get a 401 and we had a token, try refreshing
+  if (res.status === 401 && accessToken) {
+    const refreshed = await tryRefresh()
+    if (refreshed) {
+      // Retry the original request with the new token
+      headers.set('Authorization', `Bearer ${accessToken}`)
+      res = await fetch(url, { ...options, headers })
+    } else {
+      // Refresh failed — session is truly expired
+      accessToken = null
+      onAuthFailure?.()
+    }
+  }
+
+  return res
+}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -38,7 +38,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setAccessToken(data.access_token)
           // Decode the access token to get user info (the payload is the
           // middle segment, base64url-encoded). This avoids an extra API call.
-          const payload = JSON.parse(atob(data.access_token.split('.')[1]))
+          // JWT payloads use base64url encoding (- and _ instead of + and /),
+          // but atob() only handles standard base64 — convert before decoding.
+          const base64 = data.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
+          const payload = JSON.parse(atob(base64))
           setUser({ id: payload.sub, username: payload.username })
         }
       } catch {

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,121 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { getAccessToken, setAccessToken, setOnAuthFailure } from '../api/client'
+
+interface User {
+  id: string
+  username: string
+}
+
+interface AuthContextValue {
+  user: User | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  login: (username: string, password: string) => Promise<string | null>
+  register: (username: string, password: string) => Promise<string | null>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const clearAuth = useCallback(() => {
+    setAccessToken(null)
+    setUser(null)
+  }, [])
+
+  // On mount: attempt silent refresh to restore session from the HttpOnly cookie.
+  useEffect(() => {
+    setOnAuthFailure(clearAuth)
+
+    async function silentRefresh() {
+      try {
+        const res = await fetch('/api/v1/auth/refresh', { method: 'POST' })
+        if (res.ok) {
+          const data = await res.json()
+          setAccessToken(data.access_token)
+          // Decode the access token to get user info (the payload is the
+          // middle segment, base64url-encoded). This avoids an extra API call.
+          const payload = JSON.parse(atob(data.access_token.split('.')[1]))
+          setUser({ id: payload.sub, username: payload.username })
+        }
+      } catch {
+        // No valid refresh cookie — user needs to log in
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    silentRefresh()
+  }, [clearAuth])
+
+  /** Returns an error message on failure, or null on success. */
+  const login = useCallback(async (username: string, password: string) => {
+    const res = await fetch('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+
+    const data = await res.json()
+    if (!res.ok) return data.error || 'Login failed'
+
+    setAccessToken(data.access_token)
+    setUser(data.user)
+    return null
+  }, [])
+
+  /** Returns an error message on failure, or null on success. */
+  const register = useCallback(async (username: string, password: string) => {
+    const res = await fetch('/api/v1/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+
+    const data = await res.json()
+    if (!res.ok) return data.error || 'Registration failed'
+
+    setAccessToken(data.access_token)
+    setUser(data.user)
+    return null
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      // Send the access token so the server can bump refresh_token_version
+      const token = getAccessToken()
+      await fetch('/api/v1/auth/logout', {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+    } catch {
+      // Even if the server call fails, clear local state
+    }
+    clearAuth()
+  }, [clearAuth])
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: user !== null,
+        isLoading,
+        login,
+        register,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- co-located with AuthProvider by convention
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
+  return ctx
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,85 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function Login() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    const err = await login(username, password)
+    setSubmitting(false)
+
+    if (err) {
+      setError(err)
+    } else {
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 bg-gray-800 p-6 rounded-lg"
+      >
+        <h1 className="text-2xl font-bold text-white text-center">Log In</h1>
+
+        {error && <p className="text-red-400 text-sm text-center">{error}</p>}
+
+        <div>
+          <label htmlFor="username" className="block text-sm text-gray-300 mb-1">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 text-white rounded border border-gray-600 focus:outline-none focus:border-blue-500"
+            autoComplete="username"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm text-gray-300 mb-1">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 text-white rounded border border-gray-600 focus:outline-none focus:border-blue-500"
+            autoComplete="current-password"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? 'Logging in...' : 'Log In'}
+        </button>
+
+        <p className="text-sm text-gray-400 text-center">
+          Don't have an account?{' '}
+          <Link to="/register" className="text-blue-400 hover:underline">
+            Register
+          </Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function Register() {
+  const { register } = useAuth()
+  const navigate = useNavigate()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    const err = await register(username, password)
+    setSubmitting(false)
+
+    if (err) {
+      setError(err)
+    } else {
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 bg-gray-800 p-6 rounded-lg"
+      >
+        <h1 className="text-2xl font-bold text-white text-center">Register</h1>
+
+        {error && <p className="text-red-400 text-sm text-center">{error}</p>}
+
+        <div>
+          <label htmlFor="username" className="block text-sm text-gray-300 mb-1">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 text-white rounded border border-gray-600 focus:outline-none focus:border-blue-500"
+            autoComplete="username"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm text-gray-300 mb-1">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 text-white rounded border border-gray-600 focus:outline-none focus:border-blue-500"
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+          <p className="text-xs text-gray-500 mt-1">Must be at least 8 characters</p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? 'Creating account...' : 'Register'}
+        </button>
+
+        <p className="text-sm text-gray-400 text-center">
+          Already have an account?{' '}
+          <Link to="/login" className="text-blue-400 hover:underline">
+            Log In
+          </Link>
+        </p>
+      </form>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaces the single 24-hour JWT with a short-lived access token (15 min) + long-lived refresh token (7 days, HttpOnly cookie) flow
- Adds `refresh_token_version` to users table for server-side revocation (logout invalidates all devices)
- New endpoints: `POST /auth/refresh` (token rotation), `PUT /auth/password` (change password + revoke other sessions)
- Frontend: Login/Register pages, react-router-dom routing, API client with automatic 401 → refresh → retry
- Production config: `JWT_ACCESS_EXPIRY_MINUTES`, `JWT_REFRESH_EXPIRY_DAYS`, `COOKIE_SECURE` env vars + `.env.production.example`

## What changed

### Backend
- **config.rs**: `jwt_expiry_hours` → `jwt_access_expiry_minutes` + `jwt_refresh_expiry_days` + `cookie_secure`
- **services/auth.rs**: Separate `AccessClaims`/`RefreshClaims` structs with `token_type` field, cookie helpers
- **routes/auth.rs**: Register/login now return `access_token` (not `token`) and set refresh cookie. New `refresh` and `change_password` handlers. Logout requires auth and bumps `refresh_token_version`
- **middleware/auth.rs**: Validates `token_type == "access"` — prevents refresh tokens from being used as access tokens
- **Migration**: `refresh_token_version INTEGER NOT NULL DEFAULT 0` added to users table (modified original migration, not a new one)

### Frontend
- **api/client.ts**: Token management + auto-refresh on 401
- **hooks/useAuth.tsx**: AuthProvider with login/register/logout + silent refresh on mount
- **pages/Login.tsx, Register.tsx**: Auth forms with error handling
- **App.tsx**: Protected routes with react-router-dom

### Config
- `.env`: Updated with new vars, `COOKIE_SECURE=false` for dev
- `.env.production.example`: New file with production defaults
- `compose.yaml`: Updated env vars

## Breaking changes
- **Response shape changed**: `token` → `access_token` in auth responses
- **Logout requires authentication**: Must send access token in Authorization header
- **Database must be recreated**: Delete `data/beerio-kart.db` and restart (original migration was modified)

## Test plan

### Automated (all passing)
- [x] 11 unit tests (password hashing, token creation/validation, cookie formatting)
- [x] 20 integration tests covering all 10 required scenarios plus existing validation tests
- [x] Pre-commit hooks: rustfmt, clippy, prettier, eslint all pass

### Manual testing after merge

**1. Recreate database and start the server**
```bash
rm data/beerio-kart.db
cd backend && cargo run
```
Expected: Server starts, migrations run, seeding completes.

**2. Open the app in a browser**
```
http://localhost:3000
```
Expected: Redirects to `/login` (not authenticated).

**3. Register a new user**
- Click "Register" link
- Enter username `testuser`, password `testpass123`
- Click Register

Expected: Redirected to `/` showing "Hello from Beerio Kart!" and "Logged in as testuser".

**4. Test logout**
- Click "Log Out"

Expected: Redirected to `/login`.

**5. Test login**
- Enter `testuser` / `testpass123`
- Click Log In

Expected: Redirected to `/` showing logged-in state.

**6. Test session persistence (refresh cookie)**
- While logged in, hard-refresh the page (Ctrl+Shift+R / Cmd+Shift+R)

Expected: Still logged in (silent refresh via HttpOnly cookie restored the session).

**7. Test from phone (if Cloudflare tunnel is set up)**
- Navigate to the app URL on your phone
- Register or log in
- Verify the full flow works over HTTPS

**8. Verify refresh cookie is scoped correctly**
```bash
# Register a user and check the Set-Cookie header
curl -v http://localhost:3000/api/v1/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username": "curluser", "password": "testpass123"}' 2>&1 | grep -i set-cookie
```
Expected: Cookie has `HttpOnly`, `SameSite=Lax`, `Path=/api/v1/auth/refresh`. No `Secure` flag in dev (COOKIE_SECURE=false).

**9. Verify refresh endpoint works with cookie**
```bash
# Extract the refresh cookie from step 8, then:
curl -s http://localhost:3000/api/v1/auth/refresh \
  -X POST \
  -b "refresh_token=<paste_cookie_value_here>" | python3 -m json.tool
```
Expected: Returns `{"access_token": "eyJ..."}`.

**10. Verify password change**
```bash
# Using the access_token from registration:
curl -s http://localhost:3000/api/v1/auth/password \
  -X PUT \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <access_token>" \
  -d '{"current_password": "testpass123", "new_password": "newpass456"}' | python3 -m json.tool
```
Expected: Returns `{"access_token": "eyJ..."}` and sets a new refresh cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)