### PR TITLE
Add unified AppError type for route error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ target/
 # Assistant handoff files (ephemeral)
 .claude/*-handoff.md
 
+# Tool state (tokens, cookies)
+tools/.state/
+
 # Code review files
 reviews/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,10 +66,24 @@ Consideration of these principles should go into every design decision made. If 
 
 ### Error response pattern
 
-Internal error details are never exposed to clients. When an unexpected error occurs:
-1. Log the real error server-side with `tracing::error!` (including the error value for diagnostics)
-2. Return a generic `"Internal server error"` message in the JSON response body
-3. Keep the appropriate HTTP status code (e.g., 500)
+All route handlers return `Result<impl IntoResponse, AppError>` where `AppError` (`src/error.rs`) is a unified error type that implements Axum's `IntoResponse` trait. This enables idiomatic `?` error propagation instead of verbose match arms.
+
+**`AppError` variants:**
+
+| Variant | HTTP Status | User-facing message |
+|---------|-------------|---------------------|
+| `BadRequest(msg)` | 400 | The provided `msg` |
+| `Unauthorized(msg)` | 401 | The provided `msg` |
+| `NotFound(msg)` | 404 | The provided `msg` |
+| `Conflict(msg)` | 409 | The provided `msg` |
+| `Internal(log_msg)` | 500 | Generic `"Internal server error"` |
+
+**Key behaviors:**
+- `Internal` logs the real error via `tracing::error!` but returns a generic message to the client — internal details are never exposed.
+- `From` impls for `sea_orm::DbErr`, `jsonwebtoken::errors::Error`, and `argon2::password_hash::Error` auto-convert library errors into `Internal`, so `?` works directly on DB queries, token operations, and password hashing.
+- Client-facing errors (`BadRequest`, `Unauthorized`, etc.) are always constructed explicitly — they require human judgment about the appropriate status code and message.
+
+**Response format:** All errors return JSON: `{ "error": "<message>" }`
 
 ### Configuration
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,0 +1,77 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use tracing::error;
+
+#[derive(Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+/// Unified error type for all route handlers.
+///
+/// Implements Axum's `IntoResponse`, so handlers can return
+/// `Result<impl IntoResponse, AppError>` and use `?` directly
+/// instead of writing match arms for every fallible call.
+pub enum AppError {
+    /// 400 — validation failures, malformed input
+    BadRequest(String),
+    /// 401 — wrong credentials, expired/missing token
+    Unauthorized(String),
+    /// 404 — resource not found
+    NotFound(String),
+    /// 409 — duplicate username, etc.
+    Conflict(String),
+    /// 500 — unexpected internal failures (DB, crypto, etc.)
+    /// The String is a log-only message; the user sees "Internal server error".
+    Internal(String),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, user_message) = match &self {
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            AppError::Internal(log_msg) => {
+                error!("{log_msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
+            }
+        };
+
+        (
+            status,
+            Json(ErrorBody {
+                error: user_message,
+            }),
+        )
+            .into_response()
+    }
+}
+
+// ── From impls for common error types ──────────────────────────────
+
+impl From<sea_orm::DbErr> for AppError {
+    fn from(e: sea_orm::DbErr) -> Self {
+        AppError::Internal(format!("Database error: {e}"))
+    }
+}
+
+impl From<jsonwebtoken::errors::Error> for AppError {
+    fn from(e: jsonwebtoken::errors::Error) -> Self {
+        AppError::Internal(format!("Token error: {e}"))
+    }
+}
+
+impl From<argon2::password_hash::Error> for AppError {
+    fn from(e: argon2::password_hash::Error) -> Self {
+        AppError::Internal(format!("Password hashing error: {e}"))
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 #[allow(unused_imports)]
 pub mod entities;
+pub mod error;
 pub mod middleware;
 pub mod routes;
 pub mod services;

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -6,10 +6,10 @@ use axum::{
 };
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
 use crate::AppState;
 use crate::entities::users;
+use crate::error::AppError;
 use crate::middleware::auth::AuthUser;
 use crate::services::auth as auth_service;
 
@@ -50,20 +50,23 @@ pub struct UserInfo {
     pub username: String,
 }
 
-#[derive(Serialize)]
-struct ErrorBody {
-    error: String,
-}
-
 // ── Helpers ────────────────────────────────────────────────────────
 
 /// Build response headers that set the refresh token cookie.
-fn make_refresh_headers(refresh_token: &str, config: &crate::config::AppConfig) -> HeaderMap {
+fn make_refresh_headers(
+    refresh_token: &str,
+    config: &crate::config::AppConfig,
+) -> Result<HeaderMap, AppError> {
     let max_age_seconds = config.jwt_refresh_expiry_days as i64 * 86400;
     let cookie = auth_service::refresh_cookie(refresh_token, max_age_seconds, config);
     let mut headers = HeaderMap::new();
-    headers.insert(header::SET_COOKIE, cookie.parse().unwrap());
-    headers
+    headers.insert(
+        header::SET_COOKIE,
+        cookie
+            .parse()
+            .map_err(|_| AppError::Internal("Failed to build Set-Cookie header".to_string()))?,
+    );
+    Ok(headers)
 }
 
 /// Extract the `refresh_token` value from the Cookie header.
@@ -88,72 +91,32 @@ fn extract_refresh_cookie(headers: &HeaderMap) -> Option<String> {
 pub async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
-) -> impl IntoResponse {
-    // Validate input
+) -> Result<impl IntoResponse, AppError> {
     let username = body.username.trim();
     if username.is_empty() || username.chars().count() > 30 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorBody {
-                error: "Username must be 1-30 characters".to_string(),
-            }),
-        )
-            .into_response();
+        return Err(AppError::BadRequest(
+            "Username must be 1-30 characters".into(),
+        ));
     }
 
     if body.password.len() < 8 || body.password.len() > 128 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorBody {
-                error: "Password must be 8-128 characters".to_string(),
-            }),
-        )
-            .into_response();
+        return Err(AppError::BadRequest(
+            "Password must be 8-128 characters".into(),
+        ));
     }
 
     // Check if username already exists (nicer error than a DB constraint violation)
     let existing = users::Entity::find()
         .filter(users::Column::Username.eq(username))
         .one(&state.db)
-        .await;
+        .await?;
 
-    match existing {
-        Ok(Some(_)) => {
-            return (
-                StatusCode::CONFLICT,
-                Json(ErrorBody {
-                    error: "Username already taken".to_string(),
-                }),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to check username availability");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-        Ok(None) => {} // username is available
+    if existing.is_some() {
+        return Err(AppError::Conflict("Username already taken".into()));
     }
 
     // Hash password
-    let password_hash = match auth_service::hash_password(&body.password) {
-        Ok(h) => h,
-        Err(e) => {
-            error!(error = %e, "Failed to hash password");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let password_hash = auth_service::hash_password(&body.password)?;
 
     // Generate user ID and timestamps
     let user_id = uuid::Uuid::new_v4().to_string();
@@ -175,49 +138,14 @@ pub async fn register(
         updated_at: Set(now),
     };
 
-    if let Err(e) = new_user.insert(&state.db).await {
-        error!(error = %e, "Failed to insert user");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorBody {
-                error: "Internal server error".to_string(),
-            }),
-        )
-            .into_response();
-    }
+    new_user.insert(&state.db).await?;
 
     // Generate tokens
-    let access_token = match auth_service::create_access_token(&user_id, username, &state.config) {
-        Ok(t) => t,
-        Err(e) => {
-            error!(error = %e, "Failed to create access token");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let access_token = auth_service::create_access_token(&user_id, username, &state.config)?;
+    let refresh_token = auth_service::create_refresh_token(&user_id, 0, &state.config)?;
+    let headers = make_refresh_headers(&refresh_token, &state.config)?;
 
-    let refresh_token = match auth_service::create_refresh_token(&user_id, 0, &state.config) {
-        Ok(t) => t,
-        Err(e) => {
-            error!(error = %e, "Failed to create refresh token");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
-
-    let headers = make_refresh_headers(&refresh_token, &state.config);
-
-    (
+    Ok((
         StatusCode::CREATED,
         headers,
         Json(AuthResponse {
@@ -227,8 +155,7 @@ pub async fn register(
                 username: username.to_string(),
             },
         }),
-    )
-        .into_response()
+    ))
 }
 
 /// POST /api/v1/auth/login
@@ -238,100 +165,46 @@ pub async fn register(
 pub async fn login(
     State(state): State<AppState>,
     Json(body): Json<LoginRequest>,
-) -> impl IntoResponse {
+) -> Result<impl IntoResponse, AppError> {
     let username = body.username.trim();
-
-    // Use the same error message for "not found" and "wrong password"
-    // to avoid leaking whether a username exists.
-    let invalid = || {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorBody {
-                error: "Invalid username or password".to_string(),
-            }),
-        )
-    };
 
     let user = match users::Entity::find()
         .filter(users::Column::Username.eq(username))
         .one(&state.db)
-        .await
+        .await?
     {
-        Ok(Some(u)) => u,
-        Ok(None) => {
+        Some(u) => u,
+        None => {
             // Hash a dummy password so the timing is similar to the "wrong password"
             // path. Prevents username enumeration via response-time analysis.
             let _ = auth_service::verify_password(
                 "dummy",
                 "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             );
-            return invalid().into_response();
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to look up user during login");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
+            return Err(AppError::Unauthorized(
+                "Invalid username or password".into(),
+            ));
         }
     };
 
     // Verify password
     match auth_service::verify_password(&body.password, &user.password_hash) {
         Ok(true) => {}
-        Ok(false) => return invalid().into_response(),
-        Err(e) => {
-            error!(error = %e, "Password verification failed unexpectedly");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
+        Ok(false) => {
+            return Err(AppError::Unauthorized(
+                "Invalid username or password".into(),
+            ));
         }
+        Err(e) => return Err(AppError::from(e)),
     }
 
     // Generate tokens
-    let access_token =
-        match auth_service::create_access_token(&user.id, &user.username, &state.config) {
-            Ok(t) => t,
-            Err(e) => {
-                error!(error = %e, "Failed to create access token during login");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorBody {
-                        error: "Internal server error".to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
+    let access_token = auth_service::create_access_token(&user.id, &user.username, &state.config)?;
+    let refresh_token =
+        auth_service::create_refresh_token(&user.id, user.refresh_token_version, &state.config)?;
+    let headers = make_refresh_headers(&refresh_token, &state.config)?;
 
-    let refresh_token = match auth_service::create_refresh_token(
-        &user.id,
-        user.refresh_token_version,
-        &state.config,
-    ) {
-        Ok(t) => t,
-        Err(e) => {
-            error!(error = %e, "Failed to create refresh token during login");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
-
-    let headers = make_refresh_headers(&refresh_token, &state.config);
-
-    (
+    Ok((
         headers,
         Json(AuthResponse {
             access_token,
@@ -340,8 +213,7 @@ pub async fn login(
                 username: user.username,
             },
         }),
-    )
-        .into_response()
+    ))
 }
 
 /// POST /api/v1/auth/refresh
@@ -353,118 +225,46 @@ pub async fn login(
 /// "Rotation" means issuing a fresh refresh JWT with a fresh expiry on every
 /// successful refresh. This extends the session window without bumping the
 /// version (which would invalidate other devices).
-pub async fn refresh(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+pub async fn refresh(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
     let cookie_value = match extract_refresh_cookie(&headers) {
         Some(v) if !v.is_empty() => v,
-        _ => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorBody {
-                    error: "Missing refresh token".to_string(),
-                }),
-            )
-                .into_response();
-        }
+        _ => return Err(AppError::Unauthorized("Missing refresh token".into())),
     };
 
     // Validate the JWT signature and expiry
-    let claims = match auth_service::validate_refresh_token(&cookie_value, &state.config) {
-        Ok(c) => c,
-        Err(_) => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorBody {
-                    error: "Invalid or expired refresh token".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let claims = auth_service::validate_refresh_token(&cookie_value, &state.config)
+        .map_err(|_| AppError::Unauthorized("Invalid or expired refresh token".into()))?;
 
     // Reject if token_type is not "refresh"
     if claims.token_type != "refresh" {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorBody {
-                error: "Invalid token type".to_string(),
-            }),
-        )
-            .into_response();
+        return Err(AppError::Unauthorized("Invalid token type".into()));
     }
 
     // Look up user and check refresh_token_version
-    let user = match users::Entity::find_by_id(&claims.sub).one(&state.db).await {
-        Ok(Some(u)) => u,
-        Ok(None) => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorBody {
-                    error: "User not found".to_string(),
-                }),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to look up user during refresh");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let user = users::Entity::find_by_id(&claims.sub)
+        .one(&state.db)
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
 
     // Version mismatch means the token was revoked (logout or password change)
     if claims.refresh_token_version != user.refresh_token_version {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorBody {
-                error: "Refresh token has been revoked".to_string(),
-            }),
-        )
-            .into_response();
+        return Err(AppError::Unauthorized(
+            "Refresh token has been revoked".into(),
+        ));
     }
 
     // Issue new tokens
-    let access_token =
-        match auth_service::create_access_token(&user.id, &user.username, &state.config) {
-            Ok(t) => t,
-            Err(e) => {
-                error!(error = %e, "Failed to create access token during refresh");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorBody {
-                        error: "Internal server error".to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
+    let access_token = auth_service::create_access_token(&user.id, &user.username, &state.config)?;
 
     // Rotate: issue a fresh refresh token with same version but new expiry
-    let new_refresh = match auth_service::create_refresh_token(
-        &user.id,
-        user.refresh_token_version,
-        &state.config,
-    ) {
-        Ok(t) => t,
-        Err(e) => {
-            error!(error = %e, "Failed to rotate refresh token");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let new_refresh =
+        auth_service::create_refresh_token(&user.id, user.refresh_token_version, &state.config)?;
+    let resp_headers = make_refresh_headers(&new_refresh, &state.config)?;
 
-    let resp_headers = make_refresh_headers(&new_refresh, &state.config);
-
-    (resp_headers, Json(RefreshResponse { access_token })).into_response()
+    Ok((resp_headers, Json(RefreshResponse { access_token })))
 }
 
 /// POST /api/v1/auth/logout
@@ -472,17 +272,15 @@ pub async fn refresh(State(state): State<AppState>, headers: HeaderMap) -> impl 
 /// Requires authentication. Increments `refresh_token_version` in the database,
 /// which invalidates ALL refresh tokens for this user across all devices.
 /// Also clears the refresh cookie on the current browser.
-pub async fn logout(State(state): State<AppState>, user: AuthUser) -> impl IntoResponse {
+pub async fn logout(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<impl IntoResponse, AppError> {
     // Look up user to get current version
-    let db_user = match users::Entity::find_by_id(&user.user_id)
+    let db_user = users::Entity::find_by_id(&user.user_id)
         .one(&state.db)
-        .await
-    {
-        Ok(Some(u)) => u,
-        Ok(None) | Err(_) => {
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
+        .await?
+        .ok_or_else(|| AppError::Internal("Authenticated user not found in database".into()))?;
 
     // Increment version to invalidate all existing refresh tokens
     let new_version = db_user.refresh_token_version + 1;
@@ -490,17 +288,19 @@ pub async fn logout(State(state): State<AppState>, user: AuthUser) -> impl IntoR
     active.refresh_token_version = Set(new_version);
     active.updated_at = Set(chrono::Utc::now().to_rfc3339());
 
-    if let Err(e) = active.update(&state.db).await {
-        error!(error = %e, "Failed to increment refresh_token_version");
-        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
+    active.update(&state.db).await?;
 
     // Clear the refresh cookie
     let cookie = auth_service::clear_refresh_cookie(&state.config);
     let mut headers = HeaderMap::new();
-    headers.insert(header::SET_COOKIE, cookie.parse().unwrap());
+    headers.insert(
+        header::SET_COOKIE,
+        cookie
+            .parse()
+            .map_err(|_| AppError::Internal("Failed to build Set-Cookie header".to_string()))?,
+    );
 
-    (headers, StatusCode::OK).into_response()
+    Ok((headers, StatusCode::OK))
 }
 
 /// PUT /api/v1/auth/password
@@ -512,83 +312,33 @@ pub async fn change_password(
     State(state): State<AppState>,
     user: AuthUser,
     Json(body): Json<ChangePasswordRequest>,
-) -> impl IntoResponse {
+) -> Result<impl IntoResponse, AppError> {
     // Validate new password length
     if body.new_password.len() < 8 || body.new_password.len() > 128 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorBody {
-                error: "New password must be 8-128 characters".to_string(),
-            }),
-        )
-            .into_response();
+        return Err(AppError::BadRequest(
+            "New password must be 8-128 characters".into(),
+        ));
     }
 
     // Look up user
-    let db_user = match users::Entity::find_by_id(&user.user_id)
+    let db_user = users::Entity::find_by_id(&user.user_id)
         .one(&state.db)
-        .await
-    {
-        Ok(Some(u)) => u,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorBody {
-                    error: "User not found".to_string(),
-                }),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to look up user for password change");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found".into()))?;
 
     // Verify current password
     match auth_service::verify_password(&body.current_password, &db_user.password_hash) {
         Ok(true) => {}
         Ok(false) => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorBody {
-                    error: "Current password is incorrect".to_string(),
-                }),
-            )
-                .into_response();
+            return Err(AppError::Unauthorized(
+                "Current password is incorrect".into(),
+            ));
         }
-        Err(e) => {
-            error!(error = %e, "Password verification failed during change");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
+        Err(e) => return Err(AppError::from(e)),
     }
 
     // Hash new password
-    let new_hash = match auth_service::hash_password(&body.new_password) {
-        Ok(h) => h,
-        Err(e) => {
-            error!(error = %e, "Failed to hash new password");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let new_hash = auth_service::hash_password(&body.new_password)?;
 
     // Update password and bump version (invalidates all other sessions)
     let new_version = db_user.refresh_token_version + 1;
@@ -599,48 +349,12 @@ pub async fn change_password(
     active.refresh_token_version = Set(new_version);
     active.updated_at = Set(chrono::Utc::now().to_rfc3339());
 
-    if let Err(e) = active.update(&state.db).await {
-        error!(error = %e, "Failed to update password");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorBody {
-                error: "Internal server error".to_string(),
-            }),
-        )
-            .into_response();
-    }
+    active.update(&state.db).await?;
 
     // Issue new tokens for the current session
-    let access_token = match auth_service::create_access_token(&user_id, &username, &state.config) {
-        Ok(t) => t,
-        Err(e) => {
-            error!(error = %e, "Failed to create access token after password change");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-                .into_response();
-        }
-    };
+    let access_token = auth_service::create_access_token(&user_id, &username, &state.config)?;
+    let refresh_token = auth_service::create_refresh_token(&user_id, new_version, &state.config)?;
+    let headers = make_refresh_headers(&refresh_token, &state.config)?;
 
-    let refresh_token =
-        match auth_service::create_refresh_token(&user_id, new_version, &state.config) {
-            Ok(t) => t,
-            Err(e) => {
-                error!(error = %e, "Failed to create refresh token after password change");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorBody {
-                        error: "Internal server error".to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
-
-    let headers = make_refresh_headers(&refresh_token, &state.config);
-
-    (headers, Json(RefreshResponse { access_token })).into_response()
+    Ok((headers, Json(RefreshResponse { access_token })))
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,129 @@
+# API Tools
+
+Command-line tools for interacting with the Beerio Kart API. Each tool does one thing and saves its state (access token, refresh cookie) so the next tool can pick it up.
+
+## Prerequisites
+
+- The server must be running (`cd backend && cargo run`)
+- `curl` (pre-installed on most systems)
+- `jq` (optional — pretty-prints JSON output; without it you'll see raw JSON)
+
+## Tools
+
+| Tool | Usage |
+|------|-------|
+| `register` | `./tools/register <username> <password>` |
+| `login` | `./tools/login <username> <password>` |
+| `refresh` | `./tools/refresh` |
+| `logout` | `./tools/logout` |
+| `change-password` | `./tools/change-password <current> <new>` |
+| `clear-state` | `./tools/clear-state` |
+
+## How state works
+
+When you `register` or `login`, the tool saves two things to `tools/.state/` (gitignored):
+
+- **Access token** — used by `logout` and `change-password` for the `Authorization: Bearer` header
+- **Cookie jar** — holds the refresh token cookie, used by `refresh`
+
+This means you don't have to copy-paste tokens between commands. Each tool reads from and writes to the same state, so they compose naturally.
+
+`logout` and `clear-state` both wipe the saved state. The difference is that `logout` calls the server (revoking all refresh tokens) while `clear-state` just deletes the local files.
+
+## Configuration
+
+By default, tools point at `http://localhost:3000`. To use a different server:
+
+```bash
+export BASE_URL=http://192.168.1.50:3000
+./tools/login alice password123
+```
+
+The env var persists for your terminal session, so you only need to set it once.
+
+## Examples
+
+### Register and log in
+
+```bash
+$ ./tools/register alice password123
+{
+  "access_token": "eyJ...",
+  "user": {
+    "id": "550e8400-...",
+    "username": "alice"
+  }
+}
+HTTP status: 201
+```
+
+You're now authenticated. Other tools will use the saved token automatically.
+
+### Refresh the access token
+
+```bash
+$ ./tools/refresh
+{
+  "access_token": "eyJ..."
+}
+HTTP status: 200
+```
+
+### Change your password
+
+```bash
+$ ./tools/change-password password123 newpassword456
+{
+  "access_token": "eyJ..."
+}
+HTTP status: 200
+```
+
+This saves the new access token, so subsequent commands continue to work.
+
+### Log out
+
+```bash
+$ ./tools/logout
+HTTP/1.1 200 OK
+set-cookie: refresh_token=; HttpOnly; ...Max-Age=0
+...
+
+(Local token and cookie cleared)
+```
+
+### Testing error responses
+
+The tools show the HTTP status code on every response, so you can verify errors by intentionally triggering them:
+
+```bash
+# Duplicate username (409)
+$ ./tools/register alice password123
+$ ./tools/register alice password123
+{ "error": "Username already taken" }
+HTTP status: 409
+
+# Wrong password (401)
+$ ./tools/login alice wrongpassword
+{ "error": "Invalid username or password" }
+HTTP status: 401
+
+# Refresh without logging in first
+$ ./tools/clear-state
+$ ./tools/refresh
+{ "error": "Missing refresh token" }
+HTTP status: 401
+
+# Refresh after logout (revoked)
+$ ./tools/login alice password123
+$ ./tools/logout
+$ ./tools/refresh
+{ "error": "Refresh token has been revoked" }
+HTTP status: 401
+
+# Password too short (400)
+$ ./tools/login alice password123
+$ ./tools/change-password password123 short
+{ "error": "New password must be 8-128 characters" }
+HTTP status: 400
+```

--- a/tools/change-password
+++ b/tools/change-password
@@ -16,10 +16,8 @@ CURRENT="$1"
 NEW="$2"
 TOKEN=$(require_token)
 
-curl -s -w "\nHTTP status: %{http_code}\n" \
-    -c "$COOKIE_JAR" \
+api_call -c "$COOKIE_JAR" \
     -X PUT "$API/auth/password" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
-    -d "{\"current_password\": \"$CURRENT\", \"new_password\": \"$NEW\"}" \
-    | save_token | pretty
+    -d "{\"current_password\": \"$CURRENT\", \"new_password\": \"$NEW\"}"

--- a/tools/change-password
+++ b/tools/change-password
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Change the current user's password.
+# Usage: ./tools/change-password <current_password> <new_password>
+#
+# Updates the stored access token and refresh cookie.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: ./tools/change-password <current_password> <new_password>" >&2
+    exit 1
+fi
+
+CURRENT="$1"
+NEW="$2"
+TOKEN=$(require_token)
+
+curl -s -w "\nHTTP status: %{http_code}\n" \
+    -c "$COOKIE_JAR" \
+    -X PUT "$API/auth/password" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "{\"current_password\": \"$CURRENT\", \"new_password\": \"$NEW\"}" \
+    | save_token | pretty

--- a/tools/clear-state
+++ b/tools/clear-state
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Clear saved tokens and cookies without calling the server.
+# Usage: ./tools/clear-state
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+rm -f "$TOKEN_FILE" "$COOKIE_JAR"
+echo "Cleared access token and cookie jar."

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Shared environment for API tools.
+# Source this file — don't run it directly.
+#
+# Override BASE_URL before sourcing if the server isn't on localhost:3000:
+#   export BASE_URL=http://192.168.1.50:3000
+#   source tools/env.sh
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+API="${BASE_URL}/api/v1"
+
+# State directory — holds the access token and cookie jar between calls.
+STATE_DIR="${STATE_DIR:-tools/.state}"
+mkdir -p "$STATE_DIR"
+
+TOKEN_FILE="$STATE_DIR/access_token"
+COOKIE_JAR="$STATE_DIR/cookies.txt"
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+# Print the stored access token, or exit with a message.
+require_token() {
+    if [[ ! -f "$TOKEN_FILE" ]]; then
+        echo "No access token found. Run ./tools/login or ./tools/register first." >&2
+        exit 1
+    fi
+    cat "$TOKEN_FILE"
+}
+
+# Save an access token from a JSON response on stdin.
+# Expects the response body piped in; prints it back out unchanged.
+save_token() {
+    local body
+    body=$(cat)
+    local token
+    token=$(echo "$body" | jq -r '.access_token // empty')
+    if [[ -n "$token" ]]; then
+        echo "$token" > "$TOKEN_FILE"
+    fi
+    echo "$body"
+}
+
+# Pretty-print JSON if jq is available, otherwise pass through.
+pretty() {
+    if command -v jq &>/dev/null; then
+        jq .
+    else
+        cat
+    fi
+}

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -48,3 +48,16 @@ pretty() {
         cat
     fi
 }
+
+# Run a curl command, print the JSON body (pretty-printed) and HTTP status
+# separately. Pipes the body through save_token so tokens are captured.
+# Usage: api_call [curl args...]
+api_call() {
+    local response status body
+    # -w appends the status code after a newline; we split on it.
+    response=$(curl -s -w "\n%{http_code}" "$@")
+    status="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+    echo "$body" | save_token | pretty
+    echo "HTTP status: $status"
+}

--- a/tools/login
+++ b/tools/login
@@ -15,9 +15,7 @@ fi
 USERNAME="$1"
 PASSWORD="$2"
 
-curl -s -w "\nHTTP status: %{http_code}\n" \
-    -c "$COOKIE_JAR" \
+api_call -c "$COOKIE_JAR" \
     -X POST "$API/auth/login" \
     -H "Content-Type: application/json" \
-    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}" \
-    | save_token | pretty
+    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}"

--- a/tools/login
+++ b/tools/login
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Log in as an existing user.
+# Usage: ./tools/login <username> <password>
+#
+# Saves the access token and refresh cookie for use by other tools.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: ./tools/login <username> <password>" >&2
+    exit 1
+fi
+
+USERNAME="$1"
+PASSWORD="$2"
+
+curl -s -w "\nHTTP status: %{http_code}\n" \
+    -c "$COOKIE_JAR" \
+    -X POST "$API/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}" \
+    | save_token | pretty

--- a/tools/logout
+++ b/tools/logout
@@ -7,11 +7,16 @@ source "$SCRIPT_DIR/env.sh"
 
 TOKEN=$(require_token)
 
-curl -s -w "\nHTTP status: %{http_code}\n" -D - \
+# Logout returns no JSON body, so we print response headers to show
+# the set-cookie clearing header.
+local_response=$(curl -s -w "\n%{http_code}" -D - \
     -X POST "$API/auth/logout" \
-    -H "Authorization: Bearer $TOKEN"
+    -H "Authorization: Bearer $TOKEN")
+local_status="${local_response##*$'\n'}"
+local_headers="${local_response%$'\n'*}"
+echo "$local_headers"
+echo "HTTP status: $local_status"
 
 # Clean up local state since the tokens are now invalid.
 rm -f "$TOKEN_FILE" "$COOKIE_JAR"
-echo ""
 echo "(Local token and cookie cleared)"

--- a/tools/logout
+++ b/tools/logout
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Log out the current user. Revokes all refresh tokens and clears local state.
+# Usage: ./tools/logout
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+TOKEN=$(require_token)
+
+curl -s -w "\nHTTP status: %{http_code}\n" -D - \
+    -X POST "$API/auth/logout" \
+    -H "Authorization: Bearer $TOKEN"
+
+# Clean up local state since the tokens are now invalid.
+rm -f "$TOKEN_FILE" "$COOKIE_JAR"
+echo ""
+echo "(Local token and cookie cleared)"

--- a/tools/refresh
+++ b/tools/refresh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Refresh the access token using the stored refresh cookie.
+# Usage: ./tools/refresh
+#
+# Updates both the access token and the refresh cookie.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+if [[ ! -f "$COOKIE_JAR" ]]; then
+    echo "No cookie jar found. Run ./tools/login or ./tools/register first." >&2
+    exit 1
+fi
+
+curl -s -w "\nHTTP status: %{http_code}\n" \
+    -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "$API/auth/refresh" \
+    | save_token | pretty

--- a/tools/refresh
+++ b/tools/refresh
@@ -12,7 +12,5 @@ if [[ ! -f "$COOKIE_JAR" ]]; then
     exit 1
 fi
 
-curl -s -w "\nHTTP status: %{http_code}\n" \
-    -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
-    -X POST "$API/auth/refresh" \
-    | save_token | pretty
+api_call -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "$API/auth/refresh"

--- a/tools/register
+++ b/tools/register
@@ -15,9 +15,7 @@ fi
 USERNAME="$1"
 PASSWORD="$2"
 
-curl -s -w "\nHTTP status: %{http_code}\n" \
-    -c "$COOKIE_JAR" \
+api_call -c "$COOKIE_JAR" \
     -X POST "$API/auth/register" \
     -H "Content-Type: application/json" \
-    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}" \
-    | save_token | pretty
+    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}"

--- a/tools/register
+++ b/tools/register
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Register a new user.
+# Usage: ./tools/register <username> <password>
+#
+# Saves the access token and refresh cookie for use by other tools.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: ./tools/register <username> <password>" >&2
+    exit 1
+fi
+
+USERNAME="$1"
+PASSWORD="$2"
+
+curl -s -w "\nHTTP status: %{http_code}\n" \
+    -c "$COOKIE_JAR" \
+    -X POST "$API/auth/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}" \
+    | save_token | pretty


### PR DESCRIPTION
## Summary
- Adds `AppError` enum in `backend/src/error.rs` with variants for `BadRequest` (400), `Unauthorized` (401), `NotFound` (404), `Conflict` (409), and `Internal` (500)
- Implements `IntoResponse` so handlers return `Result<impl IntoResponse, AppError>` and use `?` for error propagation
- `From` impls for `DbErr`, `jsonwebtoken::Error`, and `argon2::password_hash::Error` auto-convert library errors into logged 500s
- Refactors all 5 auth handlers — `routes/auth.rs` drops from 646 to ~370 lines with identical behavior
- Fixes two `.parse().unwrap()` calls on cookie headers that could panic (now return 500 via `AppError`)
- Updates DESIGN.md "Error response pattern" section to document `AppError`
- Adds reusable API tools in `tools/` for manual testing (see `tools/README.md`)

## Test plan

### Automated
- [x] All 11 unit tests pass (`cargo test`)
- [x] All 20 integration tests pass unchanged — response shapes and status codes are identical
- [x] `rustfmt` and `clippy` pass (verified by pre-commit hooks)

### Manual testing

Start the server first:

```bash
cd backend
cargo run
```

Then open a **second terminal** from the repo root and run the tests below. Each tool prints the JSON response and HTTP status code.

> **Tip:** `jq` is optional — if installed, output is pretty-printed automatically.

---

#### 1. Register — happy path (expect 201)

```bash
./tools/register testuser password123
```

Expected: HTTP 201, body has `access_token`, `user.id`, and `user.username`. Token and refresh cookie are saved automatically.

---

#### 2. Register — duplicate username (expect 409)

```bash
./tools/register testuser password123
```

Expected: HTTP 409, `{ "error": "Username already taken" }`

---

#### 3. Register — empty username (expect 400)

```bash
./tools/register "  " password123
```

Expected: HTTP 400, `{ "error": "Username must be 1-30 characters" }`

---

#### 4. Register — short password (expect 400)

```bash
./tools/register newuser short
```

Expected: HTTP 400, `{ "error": "Password must be 8-128 characters" }`

---

#### 5. Login — happy path (expect 200)

```bash
./tools/login testuser password123
```

Expected: HTTP 200, body has `access_token` and `user`. Saves token for subsequent tools.

---

#### 6. Login — wrong password (expect 401)

```bash
./tools/login testuser wrongpassword
```

Expected: HTTP 401, `{ "error": "Invalid username or password" }`

---

#### 7. Login — nonexistent user (expect 401)

```bash
./tools/login nobody password123
```

Expected: HTTP 401, `{ "error": "Invalid username or password" }` (same message — intentional to prevent username enumeration).

---

#### 8. Refresh — happy path (expect 200)

First log in to save a refresh cookie, then refresh:

```bash
./tools/login testuser password123
./tools/refresh
```

Expected: HTTP 200, body has `access_token`.

---

#### 9. Refresh — no cookie (expect 401)

```bash
./tools/clear-state
./tools/refresh
```

Expected: HTTP 401, `{ "error": "Missing refresh token" }`

---

#### 10. Change password — happy path (expect 200)

```bash
./tools/login testuser password123
./tools/change-password password123 newpass456
```

Expected: HTTP 200, body has `access_token` (new token for current session).

---

#### 11. Change password — wrong current password (expect 401)

```bash
./tools/change-password wrongpassword newpass456
```

Expected: HTTP 401, `{ "error": "Current password is incorrect" }`

---

#### 12. Change password — new password too short (expect 400)

```bash
./tools/change-password newpass456 short
```

Expected: HTTP 400, `{ "error": "New password must be 8-128 characters" }`

---

#### 13. Logout — happy path (expect 200)

```bash
./tools/login testuser newpass456
./tools/logout
```

Expected: HTTP 200. Response headers show `set-cookie` with `Max-Age=0`. Local token and cookie are cleared automatically.

---

#### 14. Refresh after logout — revoked token (expect 401)

Log in, save the cookie, then logout and try to refresh:

```bash
./tools/login testuser newpass456
./tools/logout
./tools/refresh
```

Expected: HTTP 401, `{ "error": "Missing refresh token" }` (local cookie was cleared by logout).

To test server-side revocation specifically (cookie exists but version was bumped), you'd need to save the cookie file before logout and restore it after — the integration tests cover this case automatically.

---

#### Cleanup

```bash
./tools/clear-state
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)