### PR TITLE
Add Phase 3B: session lifecycle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -256,6 +256,8 @@ Notes:
 - Ruleset-specific config uses explicit nullable columns rather than a JSON blob. With four well-defined rulesets, explicit columns are safer (database can enforce CHECK constraints) and queryable. New config options require a migration, but that's the right tradeoff for known rulesets.
 - Session auto-closes after 1 hour of no activity. No further run submissions accepted after close. A lightweight Tokio background task checks for and closes stale sessions periodically (e.g., every 5 minutes) so they don't linger in the active sessions list. Actions that update `last_activity_at`: run submission, track selection (next-track, choose-track), join, leave, skip-turn.
 - Future consideration: `password_hash` column for session passwords. Deferred — the `POST /sessions/:id/join` endpoint is designed as a dedicated action so password checking can be added later without restructuring the join flow.
+- A user can only be active in one session at a time (enforced by a partial unique index on `session_participants(user_id) WHERE left_at IS NULL`).
+- **Session UI icons:** The host is indicated by a 🏠 (house) icon, not a crown. The 👑 (crown) is reserved for the player with the most fastest track times in the session — an earned distinction, not a role.
 
 ### Session Participants
 

--- a/backend/migration/src/m20260330_000008_create_sessions.rs
+++ b/backend/migration/src/m20260330_000008_create_sessions.rs
@@ -23,6 +23,16 @@ impl MigrationTrait for Migration {
                 ) STRICT",
             )
             .await?;
+
+        // Index for list_active_sessions and close_stale_sessions queries
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX idx_sessions_status_last_activity
+                 ON sessions(status, last_activity_at)",
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/backend/migration/src/m20260330_000009_create_session_participants.rs
+++ b/backend/migration/src/m20260330_000009_create_session_participants.rs
@@ -20,6 +20,16 @@ impl MigrationTrait for Migration {
                 ) STRICT",
             )
             .await?;
+
+        // Index for the most common query pattern: filter by session + active status
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX idx_session_participants_session_active
+                 ON session_participants(session_id, left_at)",
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/backend/migration/src/m20260330_000009_create_session_participants.rs
+++ b/backend/migration/src/m20260330_000009_create_session_participants.rs
@@ -30,6 +30,16 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
+        // A user can only be active in one session at a time.
+        // Partial unique index: only applies to rows where left_at IS NULL.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE UNIQUE INDEX idx_session_participants_one_active_session
+                 ON session_participants(user_id) WHERE left_at IS NULL",
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -16,6 +16,7 @@ struct ErrorBody {
 /// Implements Axum's `IntoResponse`, so handlers can return
 /// `Result<impl IntoResponse, AppError>` and use `?` directly
 /// instead of writing match arms for every fallible call.
+#[derive(Debug)]
 pub enum AppError {
     /// 400 — validation failures, malformed input
     BadRequest(String),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -117,6 +117,7 @@ async fn main() {
             "/api/v1/sessions",
             get(routes::sessions::list_sessions).post(routes::sessions::create_session),
         )
+        .route("/api/v1/sessions/mine", get(routes::sessions::my_session))
         .route("/api/v1/sessions/{id}", get(routes::sessions::get_session))
         .route(
             "/api/v1/sessions/{id}/join",

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,7 @@
 mod seed;
 
+use std::time::Duration;
+
 use axum::{
     Json, Router,
     routing::{get, post, put},
@@ -14,6 +16,7 @@ use tracing_subscriber::EnvFilter;
 use beerio_kart::AppState;
 use beerio_kart::config::AppConfig;
 use beerio_kart::routes;
+use beerio_kart::services;
 
 #[derive(Serialize)]
 struct HelloResponse {
@@ -66,6 +69,10 @@ async fn main() {
 
     let state = AppState { db, config };
 
+    // Clone the DB connection for the background cleanup task before `state`
+    // is moved into the router.
+    let cleanup_db = state.db.clone();
+
     // STATIC_DIR defaults to ../frontend/dist for local dev (running from backend/).
     // In Docker, set to /app/static where the built frontend is copied.
     let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_| "../frontend/dist".to_string());
@@ -105,6 +112,20 @@ async fn main() {
             "/api/v1/drink-types/{id}",
             get(routes::drink_types::get_drink_type),
         )
+        // Sessions
+        .route(
+            "/api/v1/sessions",
+            get(routes::sessions::list_sessions).post(routes::sessions::create_session),
+        )
+        .route("/api/v1/sessions/{id}", get(routes::sessions::get_session))
+        .route(
+            "/api/v1/sessions/{id}/join",
+            post(routes::sessions::join_session),
+        )
+        .route(
+            "/api/v1/sessions/{id}/leave",
+            post(routes::sessions::leave_session),
+        )
         .layer(TraceLayer::new_for_http())
         .with_state(state)
         // Serve frontend static files. If no API route or static file matches,
@@ -114,6 +135,19 @@ async fn main() {
             ServeDir::new(&static_dir)
                 .fallback(ServeFile::new(format!("{}/index.html", static_dir))),
         );
+
+    // Spawn background task to close stale sessions (no activity for 1 hour).
+    // Runs every 5 minutes.
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+            match services::sessions::close_stale_sessions(&cleanup_db).await {
+                Ok(0) => {}
+                Ok(n) => tracing::info!("Closed {n} stale session(s)"),
+                Err(_) => tracing::error!("Stale session cleanup failed"),
+            }
+        }
+    });
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     tracing::info!("Listening on http://localhost:3000");

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
 pub mod drink_types;
 pub mod game_data;
+pub mod sessions;
 pub mod users;

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -4,7 +4,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::error::AppError;
@@ -24,6 +24,20 @@ pub async fn create_session(
 ) -> Result<impl IntoResponse, AppError> {
     let detail = sessions::create_session(&state.db, &user.user_id, &body.ruleset).await?;
     Ok((StatusCode::CREATED, Json(detail)))
+}
+
+#[derive(Serialize)]
+pub struct MySessionResponse {
+    pub session_id: Option<String>,
+}
+
+/// GET /sessions/mine — get the user's current active session ID.
+pub async fn my_session(
+    user: AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<MySessionResponse>, AppError> {
+    let session_id = sessions::get_active_session_id(&state.db, &user.user_id).await?;
+    Ok(Json(MySessionResponse { session_id }))
 }
 
 /// GET /sessions — list active sessions.

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -4,7 +4,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::AppState;
 use crate::error::AppError;
@@ -16,34 +16,14 @@ pub struct CreateSessionRequest {
     pub ruleset: String,
 }
 
-#[derive(Serialize)]
-pub struct CreateSessionResponse {
-    pub id: String,
-    pub created_by: String,
-    pub host_id: String,
-    pub ruleset: String,
-    pub status: String,
-    pub created_at: String,
-    pub last_activity_at: String,
-}
-
-/// POST /sessions — create a new session.
+/// POST /sessions — create a new session. Returns full session detail.
 pub async fn create_session(
     user: AuthUser,
     State(state): State<AppState>,
     Json(body): Json<CreateSessionRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let session = sessions::create_session(&state.db, &user.user_id, &body.ruleset).await?;
-    let response = CreateSessionResponse {
-        id: session.id,
-        created_by: session.created_by,
-        host_id: session.host_id,
-        ruleset: session.ruleset,
-        status: session.status,
-        created_at: session.created_at,
-        last_activity_at: session.last_activity_at,
-    };
-    Ok((StatusCode::CREATED, Json(response)))
+    let detail = sessions::create_session(&state.db, &user.user_id, &body.ruleset).await?;
+    Ok((StatusCode::CREATED, Json(detail)))
 }
 
 /// GET /sessions — list active sessions.

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -1,0 +1,86 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::error::AppError;
+use crate::middleware::auth::AuthUser;
+use crate::services::sessions;
+
+#[derive(Deserialize)]
+pub struct CreateSessionRequest {
+    pub ruleset: String,
+}
+
+#[derive(Serialize)]
+pub struct CreateSessionResponse {
+    pub id: String,
+    pub created_by: String,
+    pub host_id: String,
+    pub ruleset: String,
+    pub status: String,
+    pub created_at: String,
+    pub last_activity_at: String,
+}
+
+/// POST /sessions — create a new session.
+pub async fn create_session(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Json(body): Json<CreateSessionRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = sessions::create_session(&state.db, &user.user_id, &body.ruleset).await?;
+    let response = CreateSessionResponse {
+        id: session.id,
+        created_by: session.created_by,
+        host_id: session.host_id,
+        ruleset: session.ruleset,
+        status: session.status,
+        created_at: session.created_at,
+        last_activity_at: session.last_activity_at,
+    };
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+/// GET /sessions — list active sessions.
+pub async fn list_sessions(
+    _user: AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<sessions::SessionSummary>>, AppError> {
+    let summaries = sessions::list_active_sessions(&state.db).await?;
+    Ok(Json(summaries))
+}
+
+/// GET /sessions/:id — full session state for polling.
+pub async fn get_session(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<sessions::SessionDetail>, AppError> {
+    let detail = sessions::get_session_detail(&state.db, &id).await?;
+    Ok(Json(detail))
+}
+
+/// POST /sessions/:id/join — join a session.
+pub async fn join_session(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    sessions::join_session(&state.db, &id, &user.user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// POST /sessions/:id/leave — leave a session.
+pub async fn leave_session(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    sessions::leave_session(&state.db, &id, &user.user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod sessions;

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -36,6 +36,23 @@ async fn check_not_in_any_session(
     Ok(())
 }
 
+/// Returns the session ID the user is currently active in, or None.
+pub async fn get_active_session_id(
+    db: &DatabaseConnection,
+    user_id: &str,
+) -> Result<Option<String>, AppError> {
+    let row = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?;
+
+    Ok(row.map(|r| r.session_id))
+}
+
 /// Create a new session. The creator becomes both the host and the first
 /// participant. Returns the full session detail.
 pub async fn create_session(

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -11,6 +11,31 @@ use crate::error::AppError;
 /// Allowed rulesets for this PR. Only "random" is supported.
 const VALID_RULESETS: &[&str] = &["random"];
 
+/// Check that the user is not already active in any session. Returns an error
+/// with the existing session ID if they are.
+async fn check_not_in_any_session(
+    db: &impl ConnectionTrait,
+    user_id: &str,
+) -> Result<(), AppError> {
+    let existing = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?;
+
+    if let Some(row) = existing {
+        return Err(AppError::Conflict(format!(
+            "Already in session {}",
+            row.session_id
+        )));
+    }
+
+    Ok(())
+}
+
 /// Create a new session. The creator becomes both the host and the first
 /// participant. Returns the full session detail.
 pub async fn create_session(
@@ -24,6 +49,8 @@ pub async fn create_session(
             VALID_RULESETS.join(", ")
         )));
     }
+
+    check_not_in_any_session(db, user_id).await?;
 
     let now = Utc::now().to_rfc3339();
     let session_id = Uuid::new_v4().to_string();
@@ -235,20 +262,8 @@ pub async fn join_session(
         ));
     }
 
-    // Check if user already has an active row (left_at IS NULL)
-    let existing = session_participants::Entity::find()
-        .filter(
-            Condition::all()
-                .add(session_participants::Column::SessionId.eq(session_id))
-                .add(session_participants::Column::UserId.eq(user_id))
-                .add(session_participants::Column::LeftAt.is_null()),
-        )
-        .one(db)
-        .await?;
-
-    if existing.is_some() {
-        return Err(AppError::Conflict("Already in this session".to_string()));
-    }
+    // Check user isn't already active in any session (including this one)
+    check_not_in_any_session(db, user_id).await?;
 
     let now = Utc::now().to_rfc3339();
     let txn = db.begin().await?;
@@ -543,28 +558,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_active_sessions_uses_single_query() {
+    async fn test_list_active_sessions_returns_correct_counts() {
         let db = setup_db().await;
         let host_id = create_user(&db, "host").await;
         let user2_id = create_user(&db, "user2").await;
+        let user3_id = create_user(&db, "user3").await;
 
-        // Create two sessions
+        // host creates s1, user2 creates s2
         let s1 = create_session(&db, &host_id, "random").await.unwrap();
         let _s2 = create_session(&db, &user2_id, "random").await.unwrap();
 
-        // user2 joins s1
-        join_session(&db, &s1.id, &user2_id).await.unwrap();
+        // user3 joins s1 (user3 is not in any session yet)
+        join_session(&db, &s1.id, &user3_id).await.unwrap();
 
         let summaries = list_active_sessions(&db).await.unwrap();
         assert_eq!(summaries.len(), 2);
 
-        // Find s1 — should have 2 participants
         let s1_summary = summaries.iter().find(|s| s.id == s1.id).unwrap();
         assert_eq!(s1_summary.participant_count, 2);
         assert_eq!(s1_summary.host_username, "host");
         assert_eq!(s1_summary.race_number, 1);
 
-        // s2 — should have 1 participant
         let s2_summary = summaries.iter().find(|s| s.id != s1.id).unwrap();
         assert_eq!(s2_summary.participant_count, 1);
         assert_eq!(s2_summary.host_username, "user2");
@@ -584,7 +598,6 @@ mod tests {
         assert_eq!(detail.host_username, "host");
         assert_eq!(detail.race_number, 1);
 
-        // Participants should have real usernames, not "Unknown"
         let usernames: Vec<&str> = detail
             .participants
             .iter()
@@ -592,5 +605,54 @@ mod tests {
             .collect();
         assert!(usernames.contains(&"host"));
         assert!(usernames.contains(&"user2"));
+    }
+
+    #[tokio::test]
+    async fn test_cannot_join_another_session_while_active_in_one() {
+        let db = setup_db().await;
+        let host1_id = create_user(&db, "host1").await;
+        let host2_id = create_user(&db, "host2").await;
+        let user_id = create_user(&db, "user").await;
+
+        let s1 = create_session(&db, &host1_id, "random").await.unwrap();
+        let s2 = create_session(&db, &host2_id, "random").await.unwrap();
+
+        join_session(&db, &s1.id, &user_id).await.unwrap();
+
+        // Should fail — already active in s1
+        let result = join_session(&db, &s2.id, &user_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cannot_create_session_while_active_in_one() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_id).await.unwrap();
+
+        // Should fail — user is already active in a session
+        let result = create_session(&db, &user_id, "random").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_can_join_new_session_after_leaving_previous() {
+        let db = setup_db().await;
+        let host1_id = create_user(&db, "host1").await;
+        let host2_id = create_user(&db, "host2").await;
+        let user_id = create_user(&db, "user").await;
+
+        let s1 = create_session(&db, &host1_id, "random").await.unwrap();
+        let s2 = create_session(&db, &host2_id, "random").await.unwrap();
+
+        join_session(&db, &s1.id, &user_id).await.unwrap();
+        leave_session(&db, &s1.id, &user_id).await.unwrap();
+
+        // Should succeed — left s1, now free to join s2
+        let result = join_session(&db, &s2.id, &user_id).await;
+        assert!(result.is_ok());
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -61,7 +61,7 @@ pub struct SessionSummary {
     pub id: String,
     pub host_username: String,
     pub participant_count: usize,
-    pub race_count: usize,
+    pub race_number: usize,
     pub ruleset: String,
     pub last_activity_at: String,
 }
@@ -96,17 +96,19 @@ pub async fn list_active_sessions(
             .count(db)
             .await? as usize;
 
-        // Count races
-        let race_count = session_races::Entity::find()
+        // Current race number (1-indexed). Before any track is picked
+        // this is 1; once a track is selected it stays at the count.
+        let races_created = session_races::Entity::find()
             .filter(session_races::Column::SessionId.eq(&session.id))
             .count(db)
             .await? as usize;
+        let race_number = races_created.max(1);
 
         summaries.push(SessionSummary {
             id: session.id,
             host_username: host,
             participant_count,
-            race_count,
+            race_number,
             ruleset: session.ruleset,
             last_activity_at: session.last_activity_at,
         });
@@ -136,7 +138,7 @@ pub struct SessionDetail {
     pub created_at: String,
     pub last_activity_at: String,
     pub participants: Vec<ParticipantInfo>,
-    pub race_count: usize,
+    pub race_number: usize,
 }
 
 /// Get full session detail — the polling endpoint.
@@ -178,10 +180,11 @@ pub async fn get_session_detail(
         });
     }
 
-    let race_count = session_races::Entity::find()
+    let races_created = session_races::Entity::find()
         .filter(session_races::Column::SessionId.eq(session_id))
         .count(db)
         .await? as usize;
+    let race_number = races_created.max(1);
 
     Ok(SessionDetail {
         id: session.id,
@@ -193,7 +196,7 @@ pub async fn get_session_detail(
         created_at: session.created_at,
         last_activity_at: session.last_activity_at,
         participants,
-        race_count,
+        race_number,
     })
 }
 

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, Set,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
+    FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -12,12 +12,12 @@ use crate::error::AppError;
 const VALID_RULESETS: &[&str] = &["random"];
 
 /// Create a new session. The creator becomes both the host and the first
-/// participant.
+/// participant. Returns the full session detail.
 pub async fn create_session(
     db: &DatabaseConnection,
     user_id: &str,
     ruleset: &str,
-) -> Result<sessions::Model, AppError> {
+) -> Result<SessionDetail, AppError> {
     if !VALID_RULESETS.contains(&ruleset) {
         return Err(AppError::BadRequest(format!(
             "Invalid ruleset: '{ruleset}'. Valid options: {}",
@@ -28,7 +28,9 @@ pub async fn create_session(
     let now = Utc::now().to_rfc3339();
     let session_id = Uuid::new_v4().to_string();
 
-    let session = sessions::ActiveModel {
+    let txn = db.begin().await?;
+
+    sessions::ActiveModel {
         id: Set(session_id.clone()),
         created_by: Set(user_id.to_string()),
         host_id: Set(user_id.to_string()),
@@ -38,21 +40,22 @@ pub async fn create_session(
         created_at: Set(now.clone()),
         last_activity_at: Set(now.clone()),
     }
-    .insert(db)
+    .insert(&txn)
     .await?;
 
-    // Add creator as first participant
     session_participants::ActiveModel {
         id: Set(Uuid::new_v4().to_string()),
-        session_id: Set(session_id),
+        session_id: Set(session_id.clone()),
         user_id: Set(user_id.to_string()),
         joined_at: Set(now),
         left_at: Set(None),
     }
-    .insert(db)
+    .insert(&txn)
     .await?;
 
-    Ok(session)
+    txn.commit().await?;
+
+    get_session_detail(db, &session_id).await
 }
 
 /// Summary info for listing active sessions.
@@ -60,61 +63,62 @@ pub async fn create_session(
 pub struct SessionSummary {
     pub id: String,
     pub host_username: String,
-    pub participant_count: usize,
-    pub race_number: usize,
+    pub participant_count: i64,
+    pub race_number: i64,
     pub ruleset: String,
     pub last_activity_at: String,
 }
 
+/// Row shape returned by the list-sessions JOIN query.
+#[derive(Debug, FromQueryResult)]
+struct SessionSummaryRow {
+    id: String,
+    host_username: String,
+    participant_count: i64,
+    race_count: i64,
+    ruleset: String,
+    last_activity_at: String,
+}
+
 /// List active sessions sorted by last_activity_at DESC.
+/// Uses a single JOIN query instead of N+1 queries.
 pub async fn list_active_sessions(
     db: &DatabaseConnection,
 ) -> Result<Vec<SessionSummary>, AppError> {
-    let active_sessions = sessions::Entity::find()
-        .filter(sessions::Column::Status.eq("active"))
-        .order_by_desc(sessions::Column::LastActivityAt)
-        .all(db)
-        .await?;
+    let rows = SessionSummaryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT
+            s.id,
+            u.username AS host_username,
+            COUNT(DISTINCT CASE WHEN sp.left_at IS NULL THEN sp.id END) AS participant_count,
+            COUNT(DISTINCT sr.id) AS race_count,
+            s.ruleset,
+            s.last_activity_at
+        FROM sessions s
+        JOIN users u ON s.host_id = u.id
+        LEFT JOIN session_participants sp ON sp.session_id = s.id
+        LEFT JOIN session_races sr ON sr.session_id = s.id
+        WHERE s.status = 'active'
+        GROUP BY s.id
+        ORDER BY s.last_activity_at DESC
+        "#,
+        [],
+    ))
+    .all(db)
+    .await?;
 
-    let mut summaries = Vec::with_capacity(active_sessions.len());
-
-    for session in active_sessions {
-        // Get host username
-        let host = users::Entity::find_by_id(&session.host_id)
-            .one(db)
-            .await?
-            .map(|u| u.username)
-            .unwrap_or_else(|| "Unknown".to_string());
-
-        // Count active participants (left_at IS NULL)
-        let participant_count = session_participants::Entity::find()
-            .filter(
-                Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::LeftAt.is_null()),
-            )
-            .count(db)
-            .await? as usize;
-
-        // Current race number (1-indexed). Before any track is picked
-        // this is 1; once a track is selected it stays at the count.
-        let races_created = session_races::Entity::find()
-            .filter(session_races::Column::SessionId.eq(&session.id))
-            .count(db)
-            .await? as usize;
-        let race_number = races_created.max(1);
-
-        summaries.push(SessionSummary {
-            id: session.id,
-            host_username: host,
-            participant_count,
-            race_number,
-            ruleset: session.ruleset,
-            last_activity_at: session.last_activity_at,
-        });
-    }
-
-    Ok(summaries)
+    Ok(rows
+        .into_iter()
+        .map(|r| SessionSummary {
+            id: r.id,
+            host_username: r.host_username,
+            participant_count: r.participant_count,
+            race_number: r.race_count.max(1),
+            ruleset: r.ruleset,
+            last_activity_at: r.last_activity_at,
+        })
+        .collect())
 }
 
 /// Participant info for the detail response.
@@ -124,6 +128,15 @@ pub struct ParticipantInfo {
     pub username: String,
     pub joined_at: String,
     pub left_at: Option<String>,
+}
+
+/// Row shape returned by the participant JOIN query.
+#[derive(Debug, FromQueryResult)]
+struct ParticipantRow {
+    user_id: String,
+    username: String,
+    joined_at: String,
+    left_at: Option<String>,
 }
 
 /// Full session detail for polling.
@@ -142,6 +155,7 @@ pub struct SessionDetail {
 }
 
 /// Get full session detail — the polling endpoint.
+/// Uses JOINs to fetch participants with usernames in a single query.
 pub async fn get_session_detail(
     db: &DatabaseConnection,
     session_id: &str,
@@ -157,28 +171,31 @@ pub async fn get_session_detail(
         .map(|u| u.username)
         .unwrap_or_else(|| "Unknown".to_string());
 
-    // Get all participants with usernames
-    let participant_rows = session_participants::Entity::find()
-        .filter(session_participants::Column::SessionId.eq(session_id))
-        .order_by_asc(session_participants::Column::JoinedAt)
+    // Fetch all participants with usernames in a single JOIN query
+    let participant_rows =
+        ParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            db.get_database_backend(),
+            r#"
+        SELECT sp.user_id, u.username, sp.joined_at, sp.left_at
+        FROM session_participants sp
+        JOIN users u ON sp.user_id = u.id
+        WHERE sp.session_id = $1
+        ORDER BY sp.joined_at ASC
+        "#,
+            [session_id.into()],
+        ))
         .all(db)
         .await?;
 
-    let mut participants = Vec::with_capacity(participant_rows.len());
-    for p in participant_rows {
-        let username = users::Entity::find_by_id(&p.user_id)
-            .one(db)
-            .await?
-            .map(|u| u.username)
-            .unwrap_or_else(|| "Unknown".to_string());
-
-        participants.push(ParticipantInfo {
-            user_id: p.user_id,
-            username,
-            joined_at: p.joined_at,
-            left_at: p.left_at,
-        });
-    }
+    let participants: Vec<ParticipantInfo> = participant_rows
+        .into_iter()
+        .map(|r| ParticipantInfo {
+            user_id: r.user_id,
+            username: r.username,
+            joined_at: r.joined_at,
+            left_at: r.left_at,
+        })
+        .collect();
 
     let races_created = session_races::Entity::find()
         .filter(session_races::Column::SessionId.eq(session_id))
@@ -234,8 +251,8 @@ pub async fn join_session(
     }
 
     let now = Utc::now().to_rfc3339();
+    let txn = db.begin().await?;
 
-    // Create new participant row (handles rejoin after leaving)
     session_participants::ActiveModel {
         id: Set(Uuid::new_v4().to_string()),
         session_id: Set(session_id.to_string()),
@@ -243,13 +260,14 @@ pub async fn join_session(
         joined_at: Set(now.clone()),
         left_at: Set(None),
     }
-    .insert(db)
+    .insert(&txn)
     .await?;
 
-    // Update last_activity_at
     let mut active_session: sessions::ActiveModel = session.into();
     active_session.last_activity_at = Set(now);
-    active_session.update(db).await?;
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
 
     Ok(())
 }
@@ -278,11 +296,12 @@ pub async fn leave_session(
         .ok_or_else(|| AppError::BadRequest("Not currently in this session".to_string()))?;
 
     let now = Utc::now().to_rfc3339();
+    let txn = db.begin().await?;
 
     // Set left_at
     let mut active_participant: session_participants::ActiveModel = participant.into();
     active_participant.left_at = Set(Some(now.clone()));
-    active_participant.update(db).await?;
+    active_participant.update(&txn).await?;
 
     // Check if host is leaving
     let mut active_session: sessions::ActiveModel = session.clone().into();
@@ -297,7 +316,7 @@ pub async fn leave_session(
                     .add(session_participants::Column::LeftAt.is_null()),
             )
             .order_by_asc(session_participants::Column::JoinedAt)
-            .one(db)
+            .one(&txn)
             .await?;
 
         match next_host {
@@ -305,7 +324,6 @@ pub async fn leave_session(
                 active_session.host_id = Set(new_host.user_id);
             }
             None => {
-                // No participants remain — close the session
                 active_session.status = Set("closed".to_string());
             }
         }
@@ -317,7 +335,7 @@ pub async fn leave_session(
                     .add(session_participants::Column::SessionId.eq(session_id))
                     .add(session_participants::Column::LeftAt.is_null()),
             )
-            .count(db)
+            .count(&txn)
             .await?;
 
         if remaining == 0 {
@@ -326,7 +344,9 @@ pub async fn leave_session(
     }
 
     active_session.last_activity_at = Set(now);
-    active_session.update(db).await?;
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
 
     Ok(())
 }
@@ -347,11 +367,13 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppErr
 
     let count = stale.len() as u64;
 
+    let txn = db.begin().await?;
     for session in stale {
         let mut active: sessions::ActiveModel = session.into();
         active.status = Set("closed".to_string());
-        active.update(db).await?;
+        active.update(&txn).await?;
     }
+    txn.commit().await?;
 
     Ok(count)
 }
@@ -360,7 +382,7 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppErr
 mod tests {
     use super::*;
     use migration::{Migrator, MigratorTrait};
-    use sea_orm::{ConnectionTrait, Database};
+    use sea_orm::Database;
 
     async fn setup_db() -> DatabaseConnection {
         let db = Database::connect("sqlite::memory:").await.expect("connect");
@@ -374,7 +396,6 @@ mod tests {
     async fn create_user(db: &DatabaseConnection, username: &str) -> String {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
-        // Use a valid argon2 hash for test users
         let hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
         users::ActiveModel {
             id: Set(id.clone()),
@@ -403,17 +424,13 @@ mod tests {
         let user2_id = create_user(&db, "user2").await;
         let user3_id = create_user(&db, "user3").await;
 
-        // Create session (host is automatically a participant)
         let session = create_session(&db, &host_id, "random").await.unwrap();
 
-        // user2 joins, then user3 joins
         join_session(&db, &session.id, &user2_id).await.unwrap();
         join_session(&db, &session.id, &user3_id).await.unwrap();
 
-        // Host leaves
         leave_session(&db, &session.id, &host_id).await.unwrap();
 
-        // user2 should be the new host (earliest joined)
         let updated = sessions::Entity::find_by_id(&session.id)
             .one(&db)
             .await
@@ -430,7 +447,6 @@ mod tests {
 
         let session = create_session(&db, &host_id, "random").await.unwrap();
 
-        // Only participant (host) leaves
         leave_session(&db, &session.id, &host_id).await.unwrap();
 
         let updated = sessions::Entity::find_by_id(&session.id)
@@ -448,7 +464,7 @@ mod tests {
         let user2_id = create_user(&db, "user2").await;
 
         let session = create_session(&db, &host_id, "random").await.unwrap();
-        leave_session(&db, &session.id, &host_id).await.unwrap(); // closes it
+        leave_session(&db, &session.id, &host_id).await.unwrap();
 
         let result = join_session(&db, &session.id, &user2_id).await;
         assert!(result.is_err());
@@ -477,7 +493,6 @@ mod tests {
         join_session(&db, &session.id, &user2_id).await.unwrap();
         leave_session(&db, &session.id, &user2_id).await.unwrap();
 
-        // Should be able to rejoin
         let result = join_session(&db, &session.id, &user2_id).await;
         assert!(result.is_ok());
     }
@@ -491,10 +506,8 @@ mod tests {
         let session = create_session(&db, &host_id, "random").await.unwrap();
         join_session(&db, &session.id, &user2_id).await.unwrap();
 
-        // user2 leaves
         leave_session(&db, &session.id, &user2_id).await.unwrap();
 
-        // user2's row should have left_at set
         let user2_row = session_participants::Entity::find()
             .filter(
                 Condition::all()
@@ -507,7 +520,6 @@ mod tests {
             .unwrap();
         assert!(user2_row.left_at.is_some());
 
-        // host's row should still be active
         let host_row = session_participants::Entity::find()
             .filter(
                 Condition::all()
@@ -528,5 +540,57 @@ mod tests {
 
         let result = create_session(&db, &host_id, "invalid_ruleset").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_active_sessions_uses_single_query() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        // Create two sessions
+        let s1 = create_session(&db, &host_id, "random").await.unwrap();
+        let _s2 = create_session(&db, &user2_id, "random").await.unwrap();
+
+        // user2 joins s1
+        join_session(&db, &s1.id, &user2_id).await.unwrap();
+
+        let summaries = list_active_sessions(&db).await.unwrap();
+        assert_eq!(summaries.len(), 2);
+
+        // Find s1 — should have 2 participants
+        let s1_summary = summaries.iter().find(|s| s.id == s1.id).unwrap();
+        assert_eq!(s1_summary.participant_count, 2);
+        assert_eq!(s1_summary.host_username, "host");
+        assert_eq!(s1_summary.race_number, 1);
+
+        // s2 — should have 1 participant
+        let s2_summary = summaries.iter().find(|s| s.id != s1.id).unwrap();
+        assert_eq!(s2_summary.participant_count, 1);
+        assert_eq!(s2_summary.host_username, "user2");
+    }
+
+    #[tokio::test]
+    async fn test_get_session_detail_returns_participants_with_usernames() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+
+        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        assert_eq!(detail.participants.len(), 2);
+        assert_eq!(detail.host_username, "host");
+        assert_eq!(detail.race_number, 1);
+
+        // Participants should have real usernames, not "Unknown"
+        let usernames: Vec<&str> = detail
+            .participants
+            .iter()
+            .map(|p| p.username.as_str())
+            .collect();
+        assert!(usernames.contains(&"host"));
+        assert!(usernames.contains(&"user2"));
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1,0 +1,529 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, Set,
+};
+use uuid::Uuid;
+
+use crate::entities::{session_participants, session_races, sessions, users};
+use crate::error::AppError;
+
+/// Allowed rulesets for this PR. Only "random" is supported.
+const VALID_RULESETS: &[&str] = &["random"];
+
+/// Create a new session. The creator becomes both the host and the first
+/// participant.
+pub async fn create_session(
+    db: &DatabaseConnection,
+    user_id: &str,
+    ruleset: &str,
+) -> Result<sessions::Model, AppError> {
+    if !VALID_RULESETS.contains(&ruleset) {
+        return Err(AppError::BadRequest(format!(
+            "Invalid ruleset: '{ruleset}'. Valid options: {}",
+            VALID_RULESETS.join(", ")
+        )));
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let session_id = Uuid::new_v4().to_string();
+
+    let session = sessions::ActiveModel {
+        id: Set(session_id.clone()),
+        created_by: Set(user_id.to_string()),
+        host_id: Set(user_id.to_string()),
+        ruleset: Set(ruleset.to_string()),
+        least_played_drink_category: Set(None),
+        status: Set("active".to_string()),
+        created_at: Set(now.clone()),
+        last_activity_at: Set(now.clone()),
+    }
+    .insert(db)
+    .await?;
+
+    // Add creator as first participant
+    session_participants::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        session_id: Set(session_id),
+        user_id: Set(user_id.to_string()),
+        joined_at: Set(now),
+        left_at: Set(None),
+    }
+    .insert(db)
+    .await?;
+
+    Ok(session)
+}
+
+/// Summary info for listing active sessions.
+#[derive(serde::Serialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub host_username: String,
+    pub participant_count: usize,
+    pub race_count: usize,
+    pub ruleset: String,
+    pub last_activity_at: String,
+}
+
+/// List active sessions sorted by last_activity_at DESC.
+pub async fn list_active_sessions(
+    db: &DatabaseConnection,
+) -> Result<Vec<SessionSummary>, AppError> {
+    let active_sessions = sessions::Entity::find()
+        .filter(sessions::Column::Status.eq("active"))
+        .order_by_desc(sessions::Column::LastActivityAt)
+        .all(db)
+        .await?;
+
+    let mut summaries = Vec::with_capacity(active_sessions.len());
+
+    for session in active_sessions {
+        // Get host username
+        let host = users::Entity::find_by_id(&session.host_id)
+            .one(db)
+            .await?
+            .map(|u| u.username)
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        // Count active participants (left_at IS NULL)
+        let participant_count = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::LeftAt.is_null()),
+            )
+            .count(db)
+            .await? as usize;
+
+        // Count races
+        let race_count = session_races::Entity::find()
+            .filter(session_races::Column::SessionId.eq(&session.id))
+            .count(db)
+            .await? as usize;
+
+        summaries.push(SessionSummary {
+            id: session.id,
+            host_username: host,
+            participant_count,
+            race_count,
+            ruleset: session.ruleset,
+            last_activity_at: session.last_activity_at,
+        });
+    }
+
+    Ok(summaries)
+}
+
+/// Participant info for the detail response.
+#[derive(serde::Serialize)]
+pub struct ParticipantInfo {
+    pub user_id: String,
+    pub username: String,
+    pub joined_at: String,
+    pub left_at: Option<String>,
+}
+
+/// Full session detail for polling.
+#[derive(serde::Serialize)]
+pub struct SessionDetail {
+    pub id: String,
+    pub created_by: String,
+    pub host_id: String,
+    pub host_username: String,
+    pub ruleset: String,
+    pub status: String,
+    pub created_at: String,
+    pub last_activity_at: String,
+    pub participants: Vec<ParticipantInfo>,
+    pub race_count: usize,
+}
+
+/// Get full session detail — the polling endpoint.
+pub async fn get_session_detail(
+    db: &DatabaseConnection,
+    session_id: &str,
+) -> Result<SessionDetail, AppError> {
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    let host_username = users::Entity::find_by_id(&session.host_id)
+        .one(db)
+        .await?
+        .map(|u| u.username)
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    // Get all participants with usernames
+    let participant_rows = session_participants::Entity::find()
+        .filter(session_participants::Column::SessionId.eq(session_id))
+        .order_by_asc(session_participants::Column::JoinedAt)
+        .all(db)
+        .await?;
+
+    let mut participants = Vec::with_capacity(participant_rows.len());
+    for p in participant_rows {
+        let username = users::Entity::find_by_id(&p.user_id)
+            .one(db)
+            .await?
+            .map(|u| u.username)
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        participants.push(ParticipantInfo {
+            user_id: p.user_id,
+            username,
+            joined_at: p.joined_at,
+            left_at: p.left_at,
+        });
+    }
+
+    let race_count = session_races::Entity::find()
+        .filter(session_races::Column::SessionId.eq(session_id))
+        .count(db)
+        .await? as usize;
+
+    Ok(SessionDetail {
+        id: session.id,
+        created_by: session.created_by,
+        host_id: session.host_id,
+        host_username,
+        ruleset: session.ruleset,
+        status: session.status,
+        created_at: session.created_at,
+        last_activity_at: session.last_activity_at,
+        participants,
+        race_count,
+    })
+}
+
+/// Join a session. Creates a new participant row.
+pub async fn join_session(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    // Check session exists and is active
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    if session.status != "active" {
+        return Err(AppError::BadRequest(
+            "Cannot join a closed session".to_string(),
+        ));
+    }
+
+    // Check if user already has an active row (left_at IS NULL)
+    let existing = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?;
+
+    if existing.is_some() {
+        return Err(AppError::Conflict("Already in this session".to_string()));
+    }
+
+    let now = Utc::now().to_rfc3339();
+
+    // Create new participant row (handles rejoin after leaving)
+    session_participants::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        session_id: Set(session_id.to_string()),
+        user_id: Set(user_id.to_string()),
+        joined_at: Set(now.clone()),
+        left_at: Set(None),
+    }
+    .insert(db)
+    .await?;
+
+    // Update last_activity_at
+    let mut active_session: sessions::ActiveModel = session.into();
+    active_session.last_activity_at = Set(now);
+    active_session.update(db).await?;
+
+    Ok(())
+}
+
+/// Leave a session. Sets left_at and handles host transfer.
+pub async fn leave_session(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    // Find user's active participant row
+    let participant = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::BadRequest("Not currently in this session".to_string()))?;
+
+    let now = Utc::now().to_rfc3339();
+
+    // Set left_at
+    let mut active_participant: session_participants::ActiveModel = participant.into();
+    active_participant.left_at = Set(Some(now.clone()));
+    active_participant.update(db).await?;
+
+    // Check if host is leaving
+    let mut active_session: sessions::ActiveModel = session.clone().into();
+
+    if session.host_id == user_id {
+        // Find earliest-joined remaining participant
+        let next_host = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(session_id))
+                    .add(session_participants::Column::UserId.ne(user_id))
+                    .add(session_participants::Column::LeftAt.is_null()),
+            )
+            .order_by_asc(session_participants::Column::JoinedAt)
+            .one(db)
+            .await?;
+
+        match next_host {
+            Some(new_host) => {
+                active_session.host_id = Set(new_host.user_id);
+            }
+            None => {
+                // No participants remain — close the session
+                active_session.status = Set("closed".to_string());
+            }
+        }
+    } else {
+        // Check if any active participants remain at all
+        let remaining = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(session_id))
+                    .add(session_participants::Column::LeftAt.is_null()),
+            )
+            .count(db)
+            .await?;
+
+        if remaining == 0 {
+            active_session.status = Set("closed".to_string());
+        }
+    }
+
+    active_session.last_activity_at = Set(now);
+    active_session.update(db).await?;
+
+    Ok(())
+}
+
+/// Close sessions that have had no activity for over an hour.
+/// Returns the number of sessions closed.
+pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppError> {
+    let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+
+    let stale = sessions::Entity::find()
+        .filter(
+            Condition::all()
+                .add(sessions::Column::Status.eq("active"))
+                .add(sessions::Column::LastActivityAt.lt(&one_hour_ago)),
+        )
+        .all(db)
+        .await?;
+
+    let count = stale.len() as u64;
+
+    for session in stale {
+        let mut active: sessions::ActiveModel = session.into();
+        active.status = Set("closed".to_string());
+        active.update(db).await?;
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use migration::{Migrator, MigratorTrait};
+    use sea_orm::{ConnectionTrait, Database};
+
+    async fn setup_db() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("pragma");
+        Migrator::up(&db, None).await.expect("migrate");
+        db
+    }
+
+    async fn create_user(db: &DatabaseConnection, username: &str) -> String {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        // Use a valid argon2 hash for test users
+        let hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
+        users::ActiveModel {
+            id: Set(id.clone()),
+            username: Set(username.to_string()),
+            email: Set(None),
+            password_hash: Set(hash.to_string()),
+            preferred_character_id: Set(None),
+            preferred_body_id: Set(None),
+            preferred_wheel_id: Set(None),
+            preferred_glider_id: Set(None),
+            preferred_drink_type_id: Set(None),
+            refresh_token_version: Set(0),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .expect("insert user");
+        id
+    }
+
+    #[tokio::test]
+    async fn test_host_transfer_goes_to_earliest_joined_participant() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+        let user3_id = create_user(&db, "user3").await;
+
+        // Create session (host is automatically a participant)
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // user2 joins, then user3 joins
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+        join_session(&db, &session.id, &user3_id).await.unwrap();
+
+        // Host leaves
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        // user2 should be the new host (earliest joined)
+        let updated = sessions::Entity::find_by_id(&session.id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.host_id, user2_id);
+        assert_eq!(updated.status, "active");
+    }
+
+    #[tokio::test]
+    async fn test_host_transfer_closes_session_when_last_participant_leaves() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // Only participant (host) leaves
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let updated = sessions::Entity::find_by_id(&session.id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.status, "closed");
+    }
+
+    #[tokio::test]
+    async fn test_cannot_join_closed_session() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        leave_session(&db, &session.id, &host_id).await.unwrap(); // closes it
+
+        let result = join_session(&db, &session.id, &user2_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cannot_join_twice_while_active() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+
+        let result = join_session(&db, &session.id, &user2_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_can_rejoin_after_leaving() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+        leave_session(&db, &session.id, &user2_id).await.unwrap();
+
+        // Should be able to rejoin
+        let result = join_session(&db, &session.id, &user2_id).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_leave_sets_left_at_without_affecting_others() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+
+        // user2 leaves
+        leave_session(&db, &session.id, &user2_id).await.unwrap();
+
+        // user2's row should have left_at set
+        let user2_row = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&user2_id)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(user2_row.left_at.is_some());
+
+        // host's row should still be active
+        let host_row = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&host_id)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(host_row.left_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_with_invalid_ruleset_returns_error() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+
+        let result = create_session(&db, &host_id, "invalid_ruleset").await;
+        assert!(result.is_err());
+    }
+}

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -202,7 +202,7 @@ async fn test_list_sessions_returns_only_active_sorted_by_last_activity() {
 }
 
 #[tokio::test]
-async fn test_get_session_returns_participants_and_race_count() {
+async fn test_get_session_returns_participants_and_race_number() {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "host").await;
 
@@ -223,7 +223,7 @@ async fn test_get_session_returns_participants_and_race_count() {
 
     assert!(detail["participants"].is_array());
     assert_eq!(detail["participants"].as_array().unwrap().len(), 1);
-    assert_eq!(detail["race_count"], 0);
+    assert_eq!(detail["race_number"], 1);
     assert!(detail["host_username"].is_string());
 }
 

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -1,0 +1,396 @@
+//! Integration tests for session lifecycle endpoints.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    http::header::{HeaderName, HeaderValue},
+    routing::{get, post},
+};
+use axum_test::TestServer;
+use migration::{Migrator, MigratorTrait};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
+use serde_json::{Value, json};
+
+use beerio_kart::AppState;
+use beerio_kart::config::AppConfig;
+use beerio_kart::routes;
+
+const TEST_SECRET: &str = "test-secret-for-session-tests";
+
+fn test_config() -> Arc<AppConfig> {
+    Arc::new(AppConfig {
+        jwt_secret: TEST_SECRET.to_string(),
+        jwt_access_expiry_minutes: 15,
+        jwt_refresh_expiry_days: 7,
+        admin_user_id: None,
+        cookie_secure: false,
+    })
+}
+
+async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect to in-memory SQLite");
+
+    db.execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .expect("Failed to enable foreign keys");
+
+    Migrator::up(&db, None)
+        .await
+        .expect("Failed to run migrations");
+
+    let config = test_config();
+    let state = AppState {
+        db: db.clone(),
+        config,
+    };
+
+    let app = Router::new()
+        // Auth (needed for registration/login)
+        .route("/api/v1/auth/register", post(routes::auth::register))
+        .route("/api/v1/auth/login", post(routes::auth::login))
+        // Sessions
+        .route(
+            "/api/v1/sessions",
+            get(routes::sessions::list_sessions).post(routes::sessions::create_session),
+        )
+        .route("/api/v1/sessions/{id}", get(routes::sessions::get_session))
+        .route(
+            "/api/v1/sessions/{id}/join",
+            post(routes::sessions::join_session),
+        )
+        .route(
+            "/api/v1/sessions/{id}/leave",
+            post(routes::sessions::leave_session),
+        )
+        .with_state(state);
+
+    (TestServer::new(app), db)
+}
+
+const AUTH_HEADER: HeaderName = HeaderName::from_static("authorization");
+
+fn auth_value(token: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!("Bearer {token}")).unwrap()
+}
+
+async fn register_and_get_token(server: &TestServer, username: &str) -> (String, String) {
+    let res = server
+        .post("/api/v1/auth/register")
+        .json(&json!({ "username": username, "password": "testpass123" }))
+        .await;
+    res.assert_status(axum::http::StatusCode::CREATED);
+    let body: Value = res.json();
+    let token = body["access_token"].as_str().unwrap().to_string();
+    let user_id = body["user"]["id"].as_str().unwrap().to_string();
+    (token, user_id)
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Session Lifecycle
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_full_session_lifecycle() {
+    let (server, _db) = setup_test_app().await;
+    let (token_host, _host_id) = register_and_get_token(&server, "host").await;
+    let (token_user2, _user2_id) = register_and_get_token(&server, "user2").await;
+
+    // 1. Create session
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    res.assert_status(axum::http::StatusCode::CREATED);
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap();
+    assert_eq!(session["ruleset"], "random");
+    assert_eq!(session["status"], "active");
+
+    // 2. user2 joins
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // 3. Verify session detail
+    let res = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let detail: Value = res.json();
+    let participants = detail["participants"].as_array().unwrap();
+    let active_count = participants
+        .iter()
+        .filter(|p| p["left_at"].is_null())
+        .count();
+    assert_eq!(active_count, 2);
+
+    // 4. Host leaves — host transfer to user2
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    let res = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    let detail: Value = res.json();
+    assert_eq!(detail["host_id"], _user2_id);
+    assert_eq!(detail["status"], "active");
+
+    // 5. Last participant leaves — session closes
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    let res = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    let detail: Value = res.json();
+    assert_eq!(detail["status"], "closed");
+}
+
+#[tokio::test]
+async fn test_list_sessions_returns_only_active_sorted_by_last_activity() {
+    let (server, _db) = setup_test_app().await;
+    let (token, _) = register_and_get_token(&server, "host").await;
+
+    // Create two sessions
+    let res1 = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let s1: Value = res1.json();
+    let s1_id = s1["id"].as_str().unwrap();
+
+    // Leave first session (closes it since solo)
+    server
+        .post(&format!("/api/v1/sessions/{s1_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+
+    // Create second session (stays active)
+    let res2 = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let s2: Value = res2.json();
+    let s2_id = s2["id"].as_str().unwrap();
+
+    // List — should only show the active one
+    let res = server
+        .get("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let list: Vec<Value> = res.json();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["id"], s2_id);
+}
+
+#[tokio::test]
+async fn test_get_session_returns_participants_and_race_count() {
+    let (server, _db) = setup_test_app().await;
+    let (token, _) = register_and_get_token(&server, "host").await;
+
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap();
+
+    let res = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let detail: Value = res.json();
+
+    assert!(detail["participants"].is_array());
+    assert_eq!(detail["participants"].as_array().unwrap().len(), 1);
+    assert_eq!(detail["race_count"], 0);
+    assert!(detail["host_username"].is_string());
+}
+
+#[tokio::test]
+async fn test_join_closed_session_returns_400() {
+    let (server, _db) = setup_test_app().await;
+    let (token_host, _) = register_and_get_token(&server, "host").await;
+    let (token_user2, _) = register_and_get_token(&server, "user2").await;
+
+    // Create and close session
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap();
+
+    server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .await;
+
+    // Try to join closed session
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_create_session_with_invalid_ruleset_returns_400() {
+    let (server, _db) = setup_test_app().await;
+    let (token, _) = register_and_get_token(&server, "host").await;
+
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "invalid_thing" }))
+        .await;
+    res.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_join_session_twice_returns_409() {
+    let (server, _db) = setup_test_app().await;
+    let (token_host, _) = register_and_get_token(&server, "host").await;
+    let (token_user2, _) = register_and_get_token(&server, "user2").await;
+
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap();
+
+    // First join succeeds
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // Second join returns 409
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_rejoin_after_leaving() {
+    let (server, _db) = setup_test_app().await;
+    let (token_host, _) = register_and_get_token(&server, "host").await;
+    let (token_user2, _) = register_and_get_token(&server, "user2").await;
+
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap();
+
+    // Join, leave, rejoin
+    server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_sessions_require_auth() {
+    let (server, _db) = setup_test_app().await;
+
+    let res = server.get("/api/v1/sessions").await;
+    res.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+
+    let res = server
+        .post("/api/v1/sessions")
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    res.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_get_nonexistent_session_returns_404() {
+    let (server, _db) = setup_test_app().await;
+    let (token, _) = register_and_get_token(&server, "host").await;
+
+    let res = server
+        .get("/api/v1/sessions/nonexistent-id")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_stale_session_cleanup() {
+    let (server, db) = setup_test_app().await;
+    let (token, _) = register_and_get_token(&server, "host").await;
+
+    // Create session
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    // Manually set last_activity_at to 2 hours ago
+    let two_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+    use beerio_kart::entities::sessions;
+    use sea_orm::EntityTrait;
+    let session_model = sessions::Entity::find_by_id(&session_id)
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut active: sessions::ActiveModel = session_model.into();
+    active.last_activity_at = Set(two_hours_ago);
+    active.update(&db).await.unwrap();
+
+    // Run cleanup
+    let closed = beerio_kart::services::sessions::close_stale_sessions(&db)
+        .await
+        .unwrap();
+    assert_eq!(closed, 1);
+
+    // Verify session is closed
+    let res = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let detail: Value = res.json();
+    assert_eq!(detail["status"], "closed");
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Register from './pages/Register'
 import Onboarding from './pages/Onboarding'
 import Home from './pages/Home'
 import Profile from './pages/Profile'
+import Session from './pages/Session'
 
 /** Shows a loading spinner while the initial silent refresh is in progress. */
 function AuthGate({ children }: { children: React.ReactNode }) {
@@ -63,6 +64,14 @@ function App() {
               element={
                 <RequireAuth>
                   <Profile />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/session/:id"
+              element={
+                <RequireAuth>
+                  <Session />
                 </RequireAuth>
               }
             />

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,6 +1,13 @@
 import { apiFetch } from './client'
 import type { SessionSummary, SessionDetail } from './types'
 
+export async function getMySession(): Promise<string | null> {
+  const res = await apiFetch('/api/v1/sessions/mine')
+  if (!res.ok) return null
+  const data = await res.json()
+  return data.session_id ?? null
+}
+
 export async function createSession(ruleset: string): Promise<SessionDetail> {
   const res = await apiFetch('/api/v1/sessions', {
     method: 'POST',

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from './client'
+import type { SessionSummary, SessionDetail } from './types'
+
+export async function createSession(ruleset: string): Promise<SessionDetail> {
+  const res = await apiFetch('/api/v1/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ruleset }),
+  })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to create session')
+  }
+  return res.json()
+}
+
+export async function listSessions(): Promise<SessionSummary[]> {
+  const res = await apiFetch('/api/v1/sessions')
+  if (!res.ok) return []
+  return res.json()
+}
+
+export async function getSession(id: string): Promise<SessionDetail | null> {
+  const res = await apiFetch(`/api/v1/sessions/${id}`)
+  if (res.status === 404) return null
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function joinSession(id: string): Promise<void> {
+  const res = await apiFetch(`/api/v1/sessions/${id}/join`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to join session')
+  }
+}
+
+export async function leaveSession(id: string): Promise<void> {
+  const res = await apiFetch(`/api/v1/sessions/${id}/leave`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to leave session')
+  }
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -66,7 +66,7 @@ export interface SessionSummary {
   id: string
   host_username: string
   participant_count: number
-  race_count: number
+  race_number: number
   ruleset: string
   last_activity_at: string
 }
@@ -88,5 +88,5 @@ export interface SessionDetail {
   created_at: string
   last_activity_at: string
   participants: ParticipantInfo[]
-  race_count: number
+  race_number: number
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -61,3 +61,32 @@ export interface RaceSetup {
   preferred_wheel_id: number
   preferred_glider_id: number
 }
+
+export interface SessionSummary {
+  id: string
+  host_username: string
+  participant_count: number
+  race_count: number
+  ruleset: string
+  last_activity_at: string
+}
+
+export interface ParticipantInfo {
+  user_id: string
+  username: string
+  joined_at: string
+  left_at: string | null
+}
+
+export interface SessionDetail {
+  id: string
+  created_by: string
+  host_id: string
+  host_username: string
+  ruleset: string
+  status: string
+  created_at: string
+  last_activity_at: string
+  participants: ParticipantInfo[]
+  race_count: number
+}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,20 +1,31 @@
+import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { getMySession } from '../api/sessions'
 
 export default function BottomNav() {
   const location = useLocation()
   const navigate = useNavigate()
+  const [mySessionId, setMySessionId] = useState<string | null>(null)
 
-  // Detect if we're on a session page
+  // Re-check active session on navigation so the tab stays in sync
+  useEffect(() => {
+    getMySession().then(setMySessionId)
+  }, [location.pathname])
+
   const sessionMatch = location.pathname.match(/^\/session\/(.+)$/)
-  const inSession = !!sessionMatch
+  const sessionPath = sessionMatch
+    ? location.pathname
+    : mySessionId
+      ? `/session/${mySessionId}`
+      : null
 
   const tabs = [
     { path: '/', label: 'Home', icon: '\uD83C\uDFE0', disabled: false },
     {
-      path: sessionMatch ? location.pathname : '/session',
+      path: sessionPath ?? '/session',
       label: 'Session',
       icon: '\uD83C\uDFAE',
-      disabled: !inSession,
+      disabled: !sessionPath,
     },
     { path: '/profile', label: 'Profile', icon: '\uD83D\uDC64', disabled: false },
   ]
@@ -23,10 +34,7 @@ export default function BottomNav() {
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-pb">
       <div className="flex max-w-lg mx-auto">
         {tabs.map((tab) => {
-          const isActive =
-            inSession && tab.label === 'Session'
-              ? true
-              : !inSession && location.pathname === tab.path
+          const isActive = tab.label === 'Session' ? !!sessionMatch : location.pathname === tab.path
 
           return (
             <button

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,31 +1,42 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 
-const TABS = [
-  { path: '/', label: 'Home', icon: '\uD83C\uDFE0' },
-  { path: '/session', label: 'Session', icon: '\uD83C\uDFAE', disabled: true },
-  { path: '/profile', label: 'Profile', icon: '\uD83D\uDC64' },
-] as const
-
 export default function BottomNav() {
   const location = useLocation()
   const navigate = useNavigate()
 
+  // Detect if we're on a session page
+  const sessionMatch = location.pathname.match(/^\/session\/(.+)$/)
+  const inSession = !!sessionMatch
+
+  const tabs = [
+    { path: '/', label: 'Home', icon: '\uD83C\uDFE0', disabled: false },
+    {
+      path: sessionMatch ? location.pathname : '/session',
+      label: 'Session',
+      icon: '\uD83C\uDFAE',
+      disabled: !inSession,
+    },
+    { path: '/profile', label: 'Profile', icon: '\uD83D\uDC64', disabled: false },
+  ]
+
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-pb">
       <div className="flex max-w-lg mx-auto">
-        {TABS.map((tab) => {
-          const isActive = location.pathname === tab.path
-          const isDisabled = 'disabled' in tab && tab.disabled
+        {tabs.map((tab) => {
+          const isActive =
+            inSession && tab.label === 'Session'
+              ? true
+              : !inSession && location.pathname === tab.path
 
           return (
             <button
-              key={tab.path}
-              onClick={() => !isDisabled && navigate(tab.path)}
-              disabled={isDisabled}
+              key={tab.label}
+              onClick={() => !tab.disabled && navigate(tab.path)}
+              disabled={tab.disabled}
               className={`flex-1 flex flex-col items-center py-2 min-h-[52px] transition-colors ${
                 isActive
                   ? 'text-blue-500'
-                  : isDisabled
+                  : tab.disabled
                     ? 'text-gray-300 cursor-not-allowed'
                     : 'text-gray-400 hover:text-gray-600'
               }`}

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -7,37 +7,42 @@ const POLL_INTERVAL_MS = 2500
 /**
  * Polls GET /sessions/:id every 2.5 seconds.
  * Pauses polling when the tab is backgrounded (Page Visibility API).
- * Returns null if session not found or closed.
+ * Stops polling once the session ends (closed or not found).
  */
 export function useSession(id: string) {
   const [session, setSession] = useState<SessionDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [ended, setEnded] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const endedRef = useRef(false)
 
   useEffect(() => {
     let cancelled = false
-
-    const doFetch = async () => {
-      const data = await getSession(id)
-      if (cancelled) return
-      if (data === null || data.status === 'closed') {
-        setEnded(true)
-      }
-      setSession(data)
-      setLoading(false)
-    }
-
-    const startPolling = () => {
-      if (intervalRef.current) return
-      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
-    }
+    endedRef.current = false
 
     const stopPolling = () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current)
         intervalRef.current = null
       }
+    }
+
+    const doFetch = async () => {
+      if (endedRef.current) return
+      const data = await getSession(id)
+      if (cancelled) return
+      if (data === null || data.status === 'closed') {
+        endedRef.current = true
+        setEnded(true)
+        stopPolling()
+      }
+      setSession(data)
+      setLoading(false)
+    }
+
+    const startPolling = () => {
+      if (intervalRef.current || endedRef.current) return
+      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
     }
 
     const handleVisibility = () => {

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react'
+import { getSession } from '../api/sessions'
+import type { SessionDetail } from '../api/types'
+
+const POLL_INTERVAL_MS = 2500
+
+/**
+ * Polls GET /sessions/:id every 2.5 seconds.
+ * Pauses polling when the tab is backgrounded (Page Visibility API).
+ * Returns null if session not found or closed.
+ */
+export function useSession(id: string) {
+  const [session, setSession] = useState<SessionDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [ended, setEnded] = useState(false)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const doFetch = async () => {
+      const data = await getSession(id)
+      if (cancelled) return
+      if (data === null || data.status === 'closed') {
+        setEnded(true)
+      }
+      setSession(data)
+      setLoading(false)
+    }
+
+    const startPolling = () => {
+      if (intervalRef.current) return
+      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
+    }
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        doFetch()
+        startPolling()
+      } else {
+        stopPolling()
+      }
+    }
+
+    doFetch()
+    startPolling()
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      cancelled = true
+      stopPolling()
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [id])
+
+  return { session, loading, ended }
+}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from 'react'
+import { listSessions } from '../api/sessions'
+import type { SessionSummary } from '../api/types'
+
+/** Fetches the active session list and polls every 5 seconds. */
+export function useSessions() {
+  const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(() => {
+    listSessions().then((data) => {
+      setSessions(data)
+      setLoading(false)
+    })
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const interval = setInterval(refresh, 5000)
+    return () => clearInterval(interval)
+  }, [refresh])
+
+  return { sessions, loading, refresh }
+}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,24 +1,56 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { listSessions } from '../api/sessions'
 import type { SessionSummary } from '../api/types'
 
-/** Fetches the active session list and polls every 5 seconds. */
+const POLL_INTERVAL_MS = 5000
+
+/**
+ * Fetches the active session list and polls every 5 seconds.
+ * Pauses polling when the tab is backgrounded (Page Visibility API).
+ */
 export function useSessions() {
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [loading, setLoading] = useState(true)
-
-  const refresh = useCallback(() => {
-    listSessions().then((data) => {
-      setSessions(data)
-      setLoading(false)
-    })
-  }, [])
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
-    refresh()
-    const interval = setInterval(refresh, 5000)
-    return () => clearInterval(interval)
-  }, [refresh])
+    const doFetch = () => {
+      listSessions().then((data) => {
+        setSessions(data)
+        setLoading(false)
+      })
+    }
 
-  return { sessions, loading, refresh }
+    const startPolling = () => {
+      if (intervalRef.current) return
+      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
+    }
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        doFetch()
+        startPolling()
+      } else {
+        stopPolling()
+      }
+    }
+
+    doFetch()
+    startPolling()
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      stopPolling()
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [])
+
+  return { sessions, loading }
 }

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,22 +1,24 @@
 import { useEffect, useRef, useState } from 'react'
-import { listSessions } from '../api/sessions'
+import { getMySession, listSessions } from '../api/sessions'
 import type { SessionSummary } from '../api/types'
 
 const POLL_INTERVAL_MS = 5000
 
 /**
- * Fetches the active session list and polls every 5 seconds.
- * Pauses polling when the tab is backgrounded (Page Visibility API).
+ * Fetches the active session list and the user's current session ID.
+ * Polls every 5 seconds. Pauses when the tab is backgrounded.
  */
 export function useSessions() {
   const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [mySessionId, setMySessionId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     const doFetch = () => {
-      listSessions().then((data) => {
-        setSessions(data)
+      Promise.all([listSessions(), getMySession()]).then(([sessionList, activeId]) => {
+        setSessions(sessionList)
+        setMySessionId(activeId)
         setLoading(false)
       })
     }
@@ -52,5 +54,5 @@ export function useSessions() {
     }
   }, [])
 
-  return { sessions, loading }
+  return { sessions, mySessionId, loading }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../hooks/useAuth'
 import { useUserProfile } from '../hooks/useUserProfile'
 import { useCharacters } from '../hooks/useGameData'
 import { useSessions } from '../hooks/useSessions'
-import { createSession, joinSession } from '../api/sessions'
+import { createSession } from '../api/sessions'
 import BottomNav from '../components/BottomNav'
 
 export default function Home() {
@@ -16,7 +16,6 @@ export default function Home() {
 
   const [showCreate, setShowCreate] = useState(false)
   const [creating, setCreating] = useState(false)
-  const [joining, setJoining] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const preferredChar = characters.find((c) => c.id === profile?.preferred_character_id)
@@ -30,18 +29,6 @@ export default function Home() {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create session')
       setCreating(false)
-    }
-  }
-
-  const handleJoin = async (sessionId: string) => {
-    setJoining(sessionId)
-    setError(null)
-    try {
-      await joinSession(sessionId)
-      navigate(`/session/${sessionId}`)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to join session')
-      setJoining(null)
     }
   }
 
@@ -122,9 +109,8 @@ export default function Home() {
             {sessions.map((s) => (
               <button
                 key={s.id}
-                onClick={() => handleJoin(s.id)}
-                disabled={joining === s.id}
-                className="w-full bg-white rounded-xl border border-gray-200 p-4 text-left active:bg-gray-50 transition-colors disabled:opacity-50"
+                onClick={() => navigate(`/session/${s.id}`)}
+                className="w-full bg-white rounded-xl border border-gray-200 p-4 text-left active:bg-gray-50 transition-colors"
               >
                 <div className="flex items-center justify-between">
                   <div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const { user } = useAuth()
   const { profile } = useUserProfile(user?.id)
   const { items: characters } = useCharacters()
-  const { sessions, loading: sessionsLoading } = useSessions()
+  const { sessions, mySessionId, loading: sessionsLoading } = useSessions()
   const navigate = useNavigate()
 
   const [showCreate, setShowCreate] = useState(false)
@@ -19,6 +19,14 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null)
 
   const preferredChar = characters.find((c) => c.id === profile?.preferred_character_id)
+
+  const handleStartButton = () => {
+    if (mySessionId) {
+      navigate(`/session/${mySessionId}`)
+    } else {
+      setShowCreate(true)
+    }
+  }
 
   const handleCreate = async () => {
     setCreating(true)
@@ -58,12 +66,12 @@ export default function Home() {
 
       {/* Content */}
       <div className="px-4 pt-4 space-y-3">
-        {/* Start Session button */}
+        {/* Start / Jump to session button */}
         <button
-          onClick={() => setShowCreate(true)}
+          onClick={handleStartButton}
           className="w-full py-4 bg-blue-500 text-white rounded-xl text-sm font-semibold active:bg-blue-600 transition-colors"
         >
-          Start a Session
+          {mySessionId ? 'Jump to Current Session' : 'Start a Session'}
         </button>
 
         {/* Create session modal */}
@@ -114,32 +122,44 @@ export default function Home() {
             <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1">
               Active Sessions
             </h2>
-            {sessions.map((s) => (
-              <button
-                key={s.id}
-                onClick={() => navigate(`/session/${s.id}`)}
-                className="w-full bg-white rounded-xl border border-gray-200 p-4 text-left active:bg-gray-50 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-semibold text-gray-900">
-                      {s.host_username}&apos;s session
-                    </p>
-                    <div className="flex items-center gap-2 mt-1">
-                      <span className="text-xs text-gray-400">
-                        {s.participant_count} player{s.participant_count !== 1 ? 's' : ''}
-                      </span>
-                      <span className="text-xs text-gray-400">
-                        {'\u00B7'} Race {s.race_number}
-                      </span>
+            {sessions.map((s) => {
+              const isMySession = s.id === mySessionId
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => navigate(`/session/${s.id}`)}
+                  className={`w-full rounded-xl border p-4 text-left active:bg-gray-50 transition-colors ${
+                    isMySession ? 'bg-blue-50 border-blue-200' : 'bg-white border-gray-200'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-semibold text-gray-900">
+                          {s.host_username}&apos;s session
+                        </p>
+                        {isMySession && (
+                          <span className="text-[10px] font-medium text-green-600 bg-green-50 px-1.5 py-0.5 rounded-full">
+                            Joined
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-1">
+                        <span className="text-xs text-gray-400">
+                          {s.participant_count} player{s.participant_count !== 1 ? 's' : ''}
+                        </span>
+                        <span className="text-xs text-gray-400">
+                          {'\u00B7'} Race {s.race_number}
+                        </span>
+                      </div>
                     </div>
+                    <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
+                      {s.ruleset}
+                    </span>
                   </div>
-                  <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
-                    {s.ruleset}
-                  </span>
-                </div>
-              </button>
-            ))}
+                </button>
+              )
+            })}
           </div>
         ) : (
           <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -135,11 +135,9 @@ export default function Home() {
                       <span className="text-xs text-gray-400">
                         {s.participant_count} player{s.participant_count !== 1 ? 's' : ''}
                       </span>
-                      {s.race_count > 0 && (
-                        <span className="text-xs text-gray-400">
-                          {'\u00B7'} Race {s.race_count}
-                        </span>
-                      )}
+                      <span className="text-xs text-gray-400">
+                        {'\u00B7'} Race {s.race_number}
+                      </span>
                     </div>
                   </div>
                   <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -69,8 +69,17 @@ export default function Home() {
 
         {/* Create session modal */}
         {showCreate && (
-          <div className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center">
-            <div className="bg-white w-full max-w-lg rounded-t-2xl p-5 space-y-4">
+          <div
+            className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center"
+            onClick={() => {
+              setShowCreate(false)
+              setError(null)
+            }}
+          >
+            <div
+              className="bg-white w-full max-w-lg rounded-t-2xl p-5 space-y-4"
+              onClick={(e) => e.stopPropagation()}
+            >
               <h2 className="text-base font-bold text-gray-900">Pick a Ruleset</h2>
               <button
                 onClick={handleCreate}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,14 +1,49 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useUserProfile } from '../hooks/useUserProfile'
 import { useCharacters } from '../hooks/useGameData'
+import { useSessions } from '../hooks/useSessions'
+import { createSession, joinSession } from '../api/sessions'
 import BottomNav from '../components/BottomNav'
 
 export default function Home() {
   const { user } = useAuth()
   const { profile } = useUserProfile(user?.id)
   const { items: characters } = useCharacters()
+  const { sessions, loading: sessionsLoading } = useSessions()
+  const navigate = useNavigate()
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [joining, setJoining] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   const preferredChar = characters.find((c) => c.id === profile?.preferred_character_id)
+
+  const handleCreate = async () => {
+    setCreating(true)
+    setError(null)
+    try {
+      const session = await createSession('random')
+      navigate(`/session/${session.id}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create session')
+      setCreating(false)
+    }
+  }
+
+  const handleJoin = async (sessionId: string) => {
+    setJoining(sessionId)
+    setError(null)
+    try {
+      await joinSession(sessionId)
+      navigate(`/session/${sessionId}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to join session')
+      setJoining(null)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -37,20 +72,92 @@ export default function Home() {
 
       {/* Content */}
       <div className="px-4 pt-4 space-y-3">
-        {/* Start Session button (placeholder) */}
+        {/* Start Session button */}
         <button
-          disabled
-          className="w-full py-4 bg-gray-200 text-gray-400 rounded-xl text-sm font-semibold cursor-not-allowed"
+          onClick={() => setShowCreate(true)}
+          className="w-full py-4 bg-blue-500 text-white rounded-xl text-sm font-semibold active:bg-blue-600 transition-colors"
         >
           Start a Session
         </button>
 
-        {/* Empty state */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
-          <p className="text-3xl mb-2">{'\uD83C\uDFCE\uFE0F'}</p>
-          <p className="text-sm text-gray-500">No active sessions yet</p>
-          <p className="text-xs text-gray-400 mt-1">Sessions will appear here once you start one</p>
-        </div>
+        {/* Create session modal */}
+        {showCreate && (
+          <div className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center">
+            <div className="bg-white w-full max-w-lg rounded-t-2xl p-5 space-y-4">
+              <h2 className="text-base font-bold text-gray-900">Pick a Ruleset</h2>
+              <button
+                onClick={handleCreate}
+                disabled={creating}
+                className="w-full py-3 bg-blue-500 text-white rounded-xl text-sm font-semibold disabled:opacity-50 active:bg-blue-600 transition-colors"
+              >
+                {creating ? 'Creating...' : 'Random'}
+              </button>
+              <p className="text-xs text-gray-400 text-center">
+                Tracks are chosen randomly each round
+              </p>
+              {error && <p className="text-xs text-red-500 text-center">{error}</p>}
+              <button
+                onClick={() => {
+                  setShowCreate(false)
+                  setError(null)
+                }}
+                className="w-full py-2 text-sm text-gray-500"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Active sessions list */}
+        {sessionsLoading ? (
+          <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
+            <p className="text-sm text-gray-400">Loading sessions...</p>
+          </div>
+        ) : sessions.length > 0 ? (
+          <div className="space-y-2">
+            <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1">
+              Active Sessions
+            </h2>
+            {sessions.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => handleJoin(s.id)}
+                disabled={joining === s.id}
+                className="w-full bg-white rounded-xl border border-gray-200 p-4 text-left active:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">
+                      {s.host_username}&apos;s session
+                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-xs text-gray-400">
+                        {s.participant_count} player{s.participant_count !== 1 ? 's' : ''}
+                      </span>
+                      {s.race_count > 0 && (
+                        <span className="text-xs text-gray-400">
+                          {'\u00B7'} Race {s.race_count}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
+                    {s.ruleset}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
+            <p className="text-3xl mb-2">{'\uD83C\uDFCE\uFE0F'}</p>
+            <p className="text-sm text-gray-500">No active sessions yet</p>
+            <p className="text-xs text-gray-400 mt-1">Start one and invite your friends to join</p>
+          </div>
+        )}
+
+        {error && !showCreate && <p className="text-xs text-red-500 text-center">{error}</p>}
       </div>
 
       <BottomNav />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -52,7 +52,6 @@ export default function Home() {
             <h1 className="text-lg font-bold text-gray-900">
               Hey, {profile?.username ?? user?.username}!
             </h1>
-            {preferredChar && <p className="text-xs text-gray-400">{preferredChar.name} main</p>}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -61,9 +61,7 @@ export default function Session() {
             <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
               {session.ruleset}
             </span>
-            <span className="text-sm font-semibold text-gray-900">
-              Race {session.race_count || 0}
-            </span>
+            <span className="text-sm font-semibold text-gray-900">Race {session.race_number}</span>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-xs text-gray-400">
@@ -97,7 +95,7 @@ export default function Session() {
             <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
           </div>
           <p className="text-sm text-gray-500">Waiting for host to pick...</p>
-          {isHost && session.race_count === 0 && (
+          {isHost && session.race_number === 0 && (
             <p className="text-xs text-gray-400 mt-1">Track selection coming in a future update</p>
           )}
         </div>

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSession } from '../hooks/useSession'
-import { leaveSession } from '../api/sessions'
+import { joinSession, leaveSession } from '../api/sessions'
 import BottomNav from '../components/BottomNav'
 
 export default function Session() {
@@ -11,6 +11,8 @@ export default function Session() {
   const { session, loading, ended } = useSession(id!)
   const navigate = useNavigate()
   const [leaving, setLeaving] = useState(false)
+  const [joiningSession, setJoiningSession] = useState(false)
+  const [joinError, setJoinError] = useState<string | null>(null)
   const [headerExpanded, setHeaderExpanded] = useState(false)
 
   const handleLeave = async () => {
@@ -20,6 +22,17 @@ export default function Session() {
       navigate('/')
     } catch {
       setLeaving(false)
+    }
+  }
+
+  const handleJoin = async () => {
+    setJoiningSession(true)
+    setJoinError(null)
+    try {
+      await joinSession(id!)
+    } catch (e) {
+      setJoinError(e instanceof Error ? e.message : 'Failed to join session')
+      setJoiningSession(false)
     }
   }
 
@@ -47,6 +60,7 @@ export default function Session() {
   }
 
   const activeParticipants = session.participants.filter((p) => !p.left_at)
+  const isParticipant = activeParticipants.some((p) => p.user_id === user?.id)
   const isHost = user?.id === session.host_id
 
   return (
@@ -131,14 +145,28 @@ export default function Session() {
           </div>
         </div>
 
-        {/* Leave button */}
-        <button
-          onClick={handleLeave}
-          disabled={leaving}
-          className="w-full py-3 text-sm font-medium text-red-500 bg-white border border-red-200 rounded-xl disabled:opacity-50 active:bg-red-50 transition-colors"
-        >
-          {leaving ? 'Leaving...' : 'Leave Session'}
-        </button>
+        {isParticipant ? (
+          /* Leave button — only shown to participants */
+          <button
+            onClick={handleLeave}
+            disabled={leaving}
+            className="w-full py-3 text-sm font-medium text-red-500 bg-white border border-red-200 rounded-xl disabled:opacity-50 active:bg-red-50 transition-colors"
+          >
+            {leaving ? 'Leaving...' : 'Leave Session'}
+          </button>
+        ) : (
+          /* Join button — shown to non-participants */
+          <div className="space-y-2">
+            <button
+              onClick={handleJoin}
+              disabled={joiningSession}
+              className="w-full py-3 text-sm font-semibold text-white bg-blue-500 rounded-xl disabled:opacity-50 active:bg-blue-600 transition-colors"
+            >
+              {joiningSession ? 'Joining...' : 'Join Session'}
+            </button>
+            {joinError && <p className="text-xs text-red-500 text-center">{joinError}</p>}
+          </div>
+        )}
       </div>
 
       <BottomNav />

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -92,7 +92,7 @@ export default function Session() {
               <div key={p.user_id} className="flex items-center justify-between py-1">
                 <div className="flex items-center gap-2">
                   {p.user_id === session.host_id && (
-                    <span className="text-xs">{'\uD83D\uDC51'}</span>
+                    <span className="text-xs">{'\uD83C\uDFE0'}</span>
                   )}
                   <span className="text-sm text-gray-900">{p.username}</span>
                 </div>
@@ -127,7 +127,7 @@ export default function Session() {
               <div key={p.user_id} className="px-4 py-3 flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   {p.user_id === session.host_id && (
-                    <span className="text-xs">{'\uD83D\uDC51'}</span>
+                    <span className="text-xs">{'\uD83C\uDFE0'}</span>
                   )}
                   <span className="text-sm font-medium text-gray-900">{p.username}</span>
                 </div>

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { useSession } from '../hooks/useSession'
+import { leaveSession } from '../api/sessions'
+import BottomNav from '../components/BottomNav'
+
+export default function Session() {
+  const { id } = useParams<{ id: string }>()
+  const { user } = useAuth()
+  const { session, loading, ended } = useSession(id!)
+  const navigate = useNavigate()
+  const [leaving, setLeaving] = useState(false)
+  const [headerExpanded, setHeaderExpanded] = useState(false)
+
+  const handleLeave = async () => {
+    setLeaving(true)
+    try {
+      await leaveSession(id!)
+      navigate('/')
+    } catch {
+      setLeaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-gray-400">Loading session...</p>
+      </div>
+    )
+  }
+
+  if (ended || !session) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-4 px-4">
+        <p className="text-3xl">{'\uD83C\uDFC1'}</p>
+        <p className="text-base font-semibold text-gray-900">Session ended</p>
+        <button
+          onClick={() => navigate('/')}
+          className="px-6 py-2 bg-blue-500 text-white rounded-xl text-sm font-semibold"
+        >
+          Back to Home
+        </button>
+      </div>
+    )
+  }
+
+  const activeParticipants = session.participants.filter((p) => !p.left_at)
+  const isHost = user?.id === session.host_id
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      {/* Zone 1 — Session Header (sticky top) */}
+      <div className="sticky top-0 z-10 bg-white border-b border-gray-200">
+        <button
+          onClick={() => setHeaderExpanded(!headerExpanded)}
+          className="w-full px-4 py-3 flex items-center justify-between"
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
+              {session.ruleset}
+            </span>
+            <span className="text-sm font-semibold text-gray-900">
+              Race {session.race_count || 0}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-400">
+              {activeParticipants.length} player{activeParticipants.length !== 1 ? 's' : ''}
+            </span>
+            <span className="text-gray-400 text-xs">{headerExpanded ? '\u25B2' : '\u25BC'}</span>
+          </div>
+        </button>
+
+        {/* Expanded participant list */}
+        {headerExpanded && (
+          <div className="px-4 pb-3 border-t border-gray-100 pt-2 space-y-1.5">
+            {activeParticipants.map((p) => (
+              <div key={p.user_id} className="flex items-center justify-between py-1">
+                <div className="flex items-center gap-2">
+                  {p.user_id === session.host_id && (
+                    <span className="text-xs">{'\uD83D\uDC51'}</span>
+                  )}
+                  <span className="text-sm text-gray-900">{p.username}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Zone 2 — Track Card */}
+      <div className="px-4 pt-4">
+        <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
+          <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-lg flex items-center justify-center">
+            <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
+          </div>
+          <p className="text-sm text-gray-500">Waiting for host to pick...</p>
+          {isHost && session.race_count === 0 && (
+            <p className="text-xs text-gray-400 mt-1">Track selection coming in a future update</p>
+          )}
+        </div>
+      </div>
+
+      {/* Zone 3 — Action Area */}
+      <div className="px-4 pt-4 space-y-3">
+        {/* Participant cards */}
+        <div>
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1 mb-2">
+            Players
+          </h3>
+          <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
+            {activeParticipants.map((p) => (
+              <div key={p.user_id} className="px-4 py-3 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {p.user_id === session.host_id && (
+                    <span className="text-xs">{'\uD83D\uDC51'}</span>
+                  )}
+                  <span className="text-sm font-medium text-gray-900">{p.username}</span>
+                </div>
+                <span className="text-xs text-gray-400">{'\u23F3'} waiting</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Session info */}
+        <div className="bg-white rounded-xl border border-gray-200 p-4">
+          <div className="flex justify-between text-xs text-gray-400">
+            <span>Host: {session.host_username}</span>
+            <span>Ruleset: {session.ruleset}</span>
+          </div>
+        </div>
+
+        {/* Leave button */}
+        <button
+          onClick={handleLeave}
+          disabled={leaving}
+          className="w-full py-3 text-sm font-medium text-red-500 bg-white border border-red-200 rounded-xl disabled:opacity-50 active:bg-red-50 transition-colors"
+        >
+          {leaving ? 'Leaving...' : 'Leave Session'}
+        </button>
+      </div>
+
+      <BottomNav />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Backend session service** (`services/sessions.rs`): create, join, leave, host transfer, stale cleanup
  - Create session generates UUID, adds creator as host + first participant, validates ruleset (only "random" for now)
  - Join validates session is active, prevents double-join, supports rejoin after leaving
  - Leave sets `left_at`, transfers host to earliest-joined remaining participant, closes session if empty
  - Background task closes sessions inactive for 1+ hour (runs every 5 minutes)
  - All multi-table writes wrapped in transactions for atomicity
  - N+1 queries replaced with JOINs in list and detail endpoints
- **Session routes** under `/api/v1/sessions`: POST create, GET list, GET detail, POST join, POST leave
  - Create endpoint returns full `SessionDetail` (matches the GET detail response shape)
- **Database indexes** added on `session_participants(session_id, left_at)` and `sessions(status, last_activity_at)`
- **Frontend session screen** with three-zone layout (sticky header, track card in waiting state, action area with participant list and join/leave buttons)
- **Home page** upgraded with "Start a Session" bottom-sheet flow (dismisses on backdrop tap) and active sessions list (polls every 5s, pauses when tab is backgrounded)
- **Session polling** via `useSession` hook (2.5s interval, pauses when tab is backgrounded via Page Visibility API, stops after session ends — works on Firefox)
- **BottomNav** updated to show/highlight Session tab when on a session page
- Tapping a session from the home screen navigates to the session screen without auto-joining; a "Join Session" button is shown to non-participants
- **9 unit tests** for session service (host transfer, join validation, leave behavior, JOIN query correctness)
- **10 integration tests** for full lifecycle, auth requirements, stale cleanup, edge cases
- Added `Debug` derive to `AppError` to support `.unwrap()` in tests

## Test plan

### Automated tests

1. `cd backend && cargo test` — all 60 tests should pass (23 unit + 27 API + 20 auth + 10 session)
2. `cd backend && cargo clippy` — should produce no warnings
3. `cd frontend && bun run build` — should compile cleanly with no errors

### Manual: create a session

4. Start the backend: `cd backend && cargo run`
5. In another terminal, start the frontend: `cd frontend && bun run dev`
6. Open http://localhost:5173 in your browser (or phone)
7. Log in (or register a new user if needed)
8. On the home screen, tap **"Start a Session"** — a bottom sheet should slide up
9. The bottom sheet shows one option: **"Random"** — tap it
10. You should be navigated to the session screen at `/session/<some-uuid>`
11. The session screen should show: a sticky header with "Random" badge, "Race 1", "1 player"; a track card saying "Waiting for host to pick..."; a Players section showing your username with a 👑 crown icon; and a red "Leave Session" button at the bottom

### Manual: bottom sheet dismisses on backdrop tap

12. Tap **"Start a Session"** again to open the bottom sheet
13. Tap the dark semi-transparent area **above** the sheet (the backdrop)
14. The sheet should close — you should be back on the home screen without creating a session
15. Tap **"Start a Session"** once more, then tap inside the white sheet area — the sheet should **not** close (only the backdrop dismisses it)

### Manual: view a session without joining

16. Open a second browser (or incognito window) and go to http://localhost:5173
17. Log in as a different user
18. On the home screen, you should see the session listed under "Active Sessions" — it shows the host's name, "1 player", and a "random" badge
19. Tap the session card — you should be navigated to the session screen
20. You should see the session details (header, track card, player list) but instead of a "Leave Session" button, you should see a blue **"Join Session"** button
21. You are viewing the session but have NOT joined it yet — verify the player count still shows "1 player"

### Manual: join from the session screen

22. Tap the **"Join Session"** button
23. The button should change to a red **"Leave Session"** button
24. Both browsers should now show "2 players" in the header (within a few seconds as polling updates)

### Manual: expand participant list

25. On either browser's session screen, tap the header bar (the row with "Random", "Race 1", "2 players")
26. The participant list should expand, showing both usernames
27. The host should have a 👑 crown icon next to their name
28. Tap the header again to collapse

### Manual: host transfer

29. On the **host's** browser, tap **"Leave Session"**
30. The host's browser should navigate back to the home screen
31. On the **other user's** browser, within a few seconds (next poll), the header should update:
    - "1 player" instead of "2 players"
    - The remaining user should now have the 👑 crown icon (they are the new host)
32. Verify the session info at the bottom also shows the new host's name

### Manual: session closes when last player leaves

33. On the remaining user's browser, tap **"Leave Session"**
34. The screen should show "Session ended" with a 🏁 flag and a **"Back to Home"** button
35. Tap "Back to Home" — you should be back on the home screen
36. The session should no longer appear in the "Active Sessions" list (it may take up to 5 seconds for the list to refresh)

### Manual: bottom nav behavior

37. Create a new session (tap "Start a Session" → "Random")
38. You should be on the session screen — the **Session** tab (🎮) in the bottom nav should be highlighted blue
39. Tap the **Home** tab (🏠) — you should navigate to the home screen without leaving the session
40. On the home screen, the **Home** tab should be highlighted
41. Tap the **Session** tab (🎮) — you should navigate back to your active session screen

### Manual: session screen polling pauses when tab is backgrounded

42. While on a session screen, switch to a different browser tab (or minimize the browser)
43. Wait 10+ seconds
44. Switch back to the session tab
45. The session data should refresh immediately (you can verify by having another user join/leave while the tab was backgrounded — the change should appear right when you switch back)

### Manual: home screen polling pauses when tab is backgrounded

46. Navigate to the home screen while a session exists
47. Switch to a different browser tab and wait 10+ seconds
48. Have another user create or close a session while your tab is hidden
49. Switch back to the home screen tab — the session list should update immediately

### Manual: polling stops after session ends

50. Open a session screen in one browser
51. In the other browser, have the last participant leave (closing the session)
52. In the first browser, the "Session ended" screen should appear within a few seconds
53. Open your browser's developer tools (F12 → Network tab) — no further requests to `/api/v1/sessions/<id>` should appear after the session ended screen shows

### Manual: error cases

54. Using curl or the browser console, try to create a session with an invalid ruleset:
    ```
    curl -X POST http://localhost:3000/api/v1/sessions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer <your-token>" \
      -d '{"ruleset": "invalid"}'
    ```
    Expected: 400 response with `{"error":"Invalid ruleset: 'invalid'. Valid options: random"}`

55. Try to join a closed session (use a session ID from one that was already closed):
    ```
    curl -X POST http://localhost:3000/api/v1/sessions/<closed-session-id>/join \
      -H "Authorization: Bearer <your-token>"
    ```
    Expected: 400 response with `{"error":"Cannot join a closed session"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)