### PR TITLE
Phase 3C-1: Track selection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -900,3 +900,4 @@ Random ideas that may or may not be pursued.
 - Ability to Change Username.
 - Ability to send emails.
    - Account recovery.
+- Handle concurrent `next_track` calls gracefully. Currently a double-tap can hit the `UNIQUE(session_id, race_number)` constraint and return a 500. Options: retry-on-conflict or optimistic locking. Low priority — single host makes this very unlikely.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "dotenvy",
  "jsonwebtoken",
  "migration",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "sea-orm",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4", "v5"] }
 dotenvy = "0.15"
+rand = "0.8"
 rand_core = { version = "0.6", features = ["getrandom"] }
 migration = { path = "migration" }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -127,6 +127,18 @@ async fn main() {
             "/api/v1/sessions/{id}/leave",
             post(routes::sessions::leave_session),
         )
+        .route(
+            "/api/v1/sessions/{id}/next-track",
+            post(routes::sessions::next_track),
+        )
+        .route(
+            "/api/v1/sessions/{id}/skip-turn",
+            post(routes::sessions::skip_turn),
+        )
+        .route(
+            "/api/v1/sessions/{id}/races",
+            get(routes::sessions::list_races),
+        )
         .layer(TraceLayer::new_for_http())
         .with_state(state)
         // Serve frontend static files. If no API route or static file matches,

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -78,3 +78,33 @@ pub async fn leave_session(
     sessions::leave_session(&state.db, &id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
+
+/// POST /sessions/:id/next-track — pick the next random track.
+pub async fn next_track(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), AppError> {
+    let race = sessions::next_track(&state.db, &id, &user.user_id).await?;
+    Ok((StatusCode::CREATED, Json(race)))
+}
+
+/// POST /sessions/:id/skip-turn — re-roll the current track.
+pub async fn skip_turn(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), AppError> {
+    let race = sessions::skip_turn(&state.db, &id, &user.user_id).await?;
+    Ok((StatusCode::CREATED, Json(race)))
+}
+
+/// GET /sessions/:id/races — list all races in a session.
+pub async fn list_races(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<sessions::RaceInfo>>, AppError> {
+    let races = sessions::list_races(&state.db, &id).await?;
+    Ok(Json(races))
+}

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1142,7 +1142,7 @@ mod tests {
         let r3 = next_track(&db, &session.id, &host_id).await.unwrap();
 
         // All three should be different tracks
-        let ids = vec![r1.track_id, r2.track_id, r3.track_id];
+        let ids = [r1.track_id, r2.track_id, r3.track_id];
         let unique: std::collections::HashSet<_> = ids.iter().collect();
         assert_eq!(unique.len(), 3, "All 3 track picks should be unique");
     }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -574,7 +574,7 @@ pub async fn next_track(
         session_id: Set(session_id.to_string()),
         race_number: Set(new_race_number),
         track_id: Set(chosen.id),
-        chosen_by: Set(Some(user_id.to_string())),
+        chosen_by: Set(None),
         created_at: Set(now.clone()),
     }
     .insert(&txn)
@@ -613,7 +613,7 @@ pub async fn next_track(
 pub async fn skip_turn(
     db: &DatabaseConnection,
     session_id: &str,
-    user_id: &str,
+    _user_id: &str,
 ) -> Result<SessionRaceInfo, AppError> {
     let session = sessions::Entity::find_by_id(session_id)
         .one(db)
@@ -704,7 +704,7 @@ pub async fn skip_turn(
         session_id: Set(session_id.to_string()),
         race_number: Set(keep_race_number),
         track_id: Set(chosen.id),
-        chosen_by: Set(Some(user_id.to_string())),
+        chosen_by: Set(None),
         created_at: Set(now.clone()),
     }
     .insert(&txn)

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -246,6 +246,7 @@ pub struct SessionDetail {
     pub participants: Vec<ParticipantInfo>,
     pub race_number: usize,
     pub current_race: Option<SessionRaceInfo>,
+    pub races: Vec<RaceInfo>,
 }
 
 /// Get full session detail — the polling endpoint.
@@ -327,6 +328,39 @@ pub async fn get_session_detail(
         created_at: r.created_at,
     });
 
+    // Fetch all races for history (reuses the same query shape as list_races)
+    let race_rows = RaceHistoryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+            SELECT sr.id, sr.race_number, sr.track_id,
+                   t.name AS track_name, c.name AS cup_name,
+                   COUNT(r.id) AS run_count, sr.created_at
+            FROM session_races sr
+            JOIN tracks t ON sr.track_id = t.id
+            JOIN cups c ON t.cup_id = c.id
+            LEFT JOIN runs r ON r.session_race_id = sr.id
+            WHERE sr.session_id = $1
+            GROUP BY sr.id
+            ORDER BY sr.race_number ASC
+            "#,
+        [session_id.into()],
+    ))
+    .all(db)
+    .await?;
+
+    let races: Vec<RaceInfo> = race_rows
+        .into_iter()
+        .map(|r| RaceInfo {
+            id: r.id,
+            race_number: r.race_number,
+            track_id: r.track_id,
+            track_name: r.track_name,
+            cup_name: r.cup_name,
+            run_count: r.run_count,
+            created_at: r.created_at,
+        })
+        .collect();
+
     Ok(SessionDetail {
         id: session.id,
         created_by: session.created_by,
@@ -339,6 +373,7 @@ pub async fn get_session_detail(
         participants,
         race_number,
         current_race,
+        races,
     })
 }
 
@@ -572,6 +607,8 @@ pub async fn next_track(
 
 /// Re-roll the current track. Host-only.
 /// Only valid if the most recent race has no runs submitted.
+/// Deletes the current race and picks a new one in a single transaction,
+/// excluding the skipped track from the pool so it can't come back.
 pub async fn skip_turn(
     db: &DatabaseConnection,
     session_id: &str,
@@ -612,10 +649,93 @@ pub async fn skip_turn(
         ));
     }
 
-    // Delete the current race, then pick a new one via next_track
-    current_race.delete(db).await?;
+    let skipped_track_id = current_race.track_id;
+    let keep_race_number = current_race.race_number;
 
-    next_track(db, session_id, user_id).await
+    // Build the exclusion list: all tracks used in this session (including
+    // the one being skipped, which next_track wouldn't see after deletion).
+    let used_races = session_races::Entity::find()
+        .filter(session_races::Column::SessionId.eq(session_id))
+        .all(db)
+        .await?;
+    let mut exclude_ids: Vec<i32> = used_races.iter().map(|r| r.track_id).collect();
+    // Ensure the skipped track stays excluded even though its row is about to be deleted
+    if !exclude_ids.contains(&skipped_track_id) {
+        exclude_ids.push(skipped_track_id);
+    }
+
+    // Get all tracks and filter
+    let all_tracks = tracks::Entity::find().all(db).await?;
+    let mut available: Vec<&tracks::Model> = all_tracks
+        .iter()
+        .filter(|t| !exclude_ids.contains(&t.id))
+        .collect();
+
+    // If pool is empty (all tracks used + skipped), reset but still exclude the skipped track
+    if available.is_empty() {
+        tracing::info!(
+            session_id = session_id,
+            "All tracks used during skip — resetting pool (excluding skipped track {})",
+            skipped_track_id
+        );
+        available = all_tracks
+            .iter()
+            .filter(|t| t.id != skipped_track_id)
+            .collect();
+    }
+
+    let chosen_idx = {
+        let mut rng = rand::thread_rng();
+        available
+            .choose(&mut rng)
+            .map(|t| t.id)
+            .ok_or_else(|| AppError::Internal("No tracks available for skip".to_string()))?
+    };
+    let chosen = all_tracks
+        .iter()
+        .find(|t| t.id == chosen_idx)
+        .ok_or_else(|| AppError::Internal("Track disappeared".to_string()))?;
+
+    let now = Utc::now().to_rfc3339();
+    let race_id = Uuid::new_v4().to_string();
+
+    // Delete old race + insert new one + update activity in a single transaction
+    let txn = db.begin().await?;
+
+    current_race.delete(&txn).await?;
+
+    session_races::ActiveModel {
+        id: Set(race_id.clone()),
+        session_id: Set(session_id.to_string()),
+        race_number: Set(keep_race_number),
+        track_id: Set(chosen.id),
+        chosen_by: Set(Some(user_id.to_string())),
+        created_at: Set(now.clone()),
+    }
+    .insert(&txn)
+    .await?;
+
+    let mut active_session: sessions::ActiveModel = session.into();
+    active_session.last_activity_at = Set(now.clone());
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
+
+    let cup = cups::Entity::find_by_id(chosen.cup_id)
+        .one(db)
+        .await?
+        .map(|c| c.name)
+        .unwrap_or_else(|| "Unknown Cup".to_string());
+
+    Ok(SessionRaceInfo {
+        id: race_id,
+        race_number: keep_race_number,
+        track_id: chosen.id,
+        track_name: chosen.name.clone(),
+        cup_name: cup,
+        image_path: chosen.image_path.clone(),
+        created_at: now,
+    })
 }
 
 /// List all races in a session, ordered by race_number ASC.
@@ -1103,6 +1223,37 @@ mod tests {
 
         // Race number should be 1 (replaced, not incremented)
         assert_eq!(rerolled.race_number, 1);
+
+        // Skipped track must not come back
+        assert_ne!(
+            rerolled.track_id, original.track_id,
+            "Skip must not re-roll to the same track"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skip_turn_excludes_skipped_track_even_near_pool_exhaustion() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await; // 6 tracks
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // Use 5 of 6 tracks, leaving only 1 available
+        for _ in 0..5 {
+            next_track(&db, &session.id, &host_id).await.unwrap();
+        }
+
+        // Pick the 6th (last) track
+        let last = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Skip it — pool is now fully exhausted, but the skipped track
+        // must still be excluded. The reset should offer 5 tracks.
+        let rerolled = skip_turn(&db, &session.id, &host_id).await.unwrap();
+        assert_ne!(
+            rerolled.track_id, last.track_id,
+            "Skip near pool exhaustion must not re-roll to the same track"
+        );
+        assert_eq!(rerolled.race_number, 6, "Race number should stay at 6");
     }
 
     #[tokio::test]

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1,11 +1,12 @@
 use chrono::Utc;
+use rand::seq::SliceRandom;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
-    FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    FromQueryResult, ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use uuid::Uuid;
 
-use crate::entities::{session_participants, session_races, sessions, users};
+use crate::entities::{cups, runs, session_participants, session_races, sessions, tracks, users};
 use crate::error::AppError;
 
 /// Allowed rulesets for this PR. Only "random" is supported.
@@ -183,6 +184,54 @@ struct ParticipantRow {
     left_at: Option<String>,
 }
 
+/// Info about a single race in the session (returned on create / skip / poll).
+#[derive(serde::Serialize, Clone)]
+pub struct SessionRaceInfo {
+    pub id: String,
+    pub race_number: i32,
+    pub track_id: i32,
+    pub track_name: String,
+    pub cup_name: String,
+    pub image_path: String,
+    pub created_at: String,
+}
+
+/// Race info for the race history list.
+#[derive(serde::Serialize)]
+pub struct RaceInfo {
+    pub id: String,
+    pub race_number: i32,
+    pub track_id: i32,
+    pub track_name: String,
+    pub cup_name: String,
+    pub run_count: i64,
+    pub created_at: String,
+}
+
+/// Row shape returned by the race history query.
+#[derive(Debug, FromQueryResult)]
+struct RaceHistoryRow {
+    id: String,
+    race_number: i32,
+    track_id: i32,
+    track_name: String,
+    cup_name: String,
+    run_count: i64,
+    created_at: String,
+}
+
+/// Row shape for the current race query.
+#[derive(Debug, FromQueryResult)]
+struct CurrentRaceRow {
+    id: String,
+    race_number: i32,
+    track_id: i32,
+    track_name: String,
+    cup_name: String,
+    image_path: String,
+    created_at: String,
+}
+
 /// Full session detail for polling.
 #[derive(serde::Serialize)]
 pub struct SessionDetail {
@@ -196,6 +245,7 @@ pub struct SessionDetail {
     pub last_activity_at: String,
     pub participants: Vec<ParticipantInfo>,
     pub race_number: usize,
+    pub current_race: Option<SessionRaceInfo>,
 }
 
 /// Get full session detail — the polling endpoint.
@@ -247,6 +297,36 @@ pub async fn get_session_detail(
         .await? as usize;
     let race_number = races_created.max(1);
 
+    // Fetch the most recent race with track + cup info in a single JOIN
+    let current_race_row =
+        CurrentRaceRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            db.get_database_backend(),
+            r#"
+            SELECT sr.id, sr.race_number, sr.track_id,
+                   t.name AS track_name, c.name AS cup_name,
+                   t.image_path, sr.created_at
+            FROM session_races sr
+            JOIN tracks t ON sr.track_id = t.id
+            JOIN cups c ON t.cup_id = c.id
+            WHERE sr.session_id = $1
+            ORDER BY sr.race_number DESC
+            LIMIT 1
+            "#,
+            [session_id.into()],
+        ))
+        .one(db)
+        .await?;
+
+    let current_race = current_race_row.map(|r| SessionRaceInfo {
+        id: r.id,
+        race_number: r.race_number,
+        track_id: r.track_id,
+        track_name: r.track_name,
+        cup_name: r.cup_name,
+        image_path: r.image_path,
+        created_at: r.created_at,
+    });
+
     Ok(SessionDetail {
         id: session.id,
         created_by: session.created_by,
@@ -258,6 +338,7 @@ pub async fn get_session_detail(
         last_activity_at: session.last_activity_at,
         participants,
         race_number,
+        current_race,
     })
 }
 
@@ -383,6 +464,204 @@ pub async fn leave_session(
     Ok(())
 }
 
+/// Pick the next track for a session. Host-only.
+/// Randomly selects from tracks not yet used in this session.
+/// If all tracks have been used, resets the pool.
+pub async fn next_track(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+) -> Result<SessionRaceInfo, AppError> {
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    if session.status != "active" {
+        return Err(AppError::BadRequest("Session is not active".to_string()));
+    }
+
+    if session.host_id != user_id {
+        return Err(AppError::Forbidden(
+            "Only the host can pick tracks".to_string(),
+        ));
+    }
+
+    // Get already-used track IDs
+    let used_races = session_races::Entity::find()
+        .filter(session_races::Column::SessionId.eq(session_id))
+        .all(db)
+        .await?;
+    let race_count = used_races.len() as i32;
+    let used_track_ids: Vec<i32> = used_races.iter().map(|r| r.track_id).collect();
+
+    // Get all tracks
+    let all_tracks = tracks::Entity::find().all(db).await?;
+
+    // Filter to available tracks
+    let mut available: Vec<&tracks::Model> = all_tracks
+        .iter()
+        .filter(|t| !used_track_ids.contains(&t.id))
+        .collect();
+
+    // If pool is empty, reset — all tracks become available again
+    if available.is_empty() {
+        tracing::info!(
+            session_id = session_id,
+            "All {} tracks used — resetting pool",
+            all_tracks.len()
+        );
+        available = all_tracks.iter().collect();
+    }
+
+    // Pick a random track. Scope the rng so ThreadRng (which is !Send)
+    // doesn't live across the subsequent .await points.
+    let chosen_idx = {
+        let mut rng = rand::thread_rng();
+        available
+            .choose(&mut rng)
+            .map(|t| t.id)
+            .ok_or_else(|| AppError::Internal("No tracks available".to_string()))?
+    };
+    let chosen = all_tracks
+        .iter()
+        .find(|t| t.id == chosen_idx)
+        .ok_or_else(|| AppError::Internal("Track disappeared".to_string()))?;
+
+    let now = Utc::now().to_rfc3339();
+    let race_id = Uuid::new_v4().to_string();
+    let new_race_number = race_count + 1;
+
+    let txn = db.begin().await?;
+
+    session_races::ActiveModel {
+        id: Set(race_id.clone()),
+        session_id: Set(session_id.to_string()),
+        race_number: Set(new_race_number),
+        track_id: Set(chosen.id),
+        chosen_by: Set(Some(user_id.to_string())),
+        created_at: Set(now.clone()),
+    }
+    .insert(&txn)
+    .await?;
+
+    // Update last_activity_at
+    let mut active_session: sessions::ActiveModel = session.into();
+    active_session.last_activity_at = Set(now.clone());
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
+
+    // Look up cup name for the response
+    let cup = cups::Entity::find_by_id(chosen.cup_id)
+        .one(db)
+        .await?
+        .map(|c| c.name)
+        .unwrap_or_else(|| "Unknown Cup".to_string());
+
+    Ok(SessionRaceInfo {
+        id: race_id,
+        race_number: new_race_number,
+        track_id: chosen.id,
+        track_name: chosen.name.clone(),
+        cup_name: cup,
+        image_path: chosen.image_path.clone(),
+        created_at: now,
+    })
+}
+
+/// Re-roll the current track. Host-only.
+/// Only valid if the most recent race has no runs submitted.
+pub async fn skip_turn(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+) -> Result<SessionRaceInfo, AppError> {
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    if session.status != "active" {
+        return Err(AppError::BadRequest("Session is not active".to_string()));
+    }
+
+    if session.host_id != user_id {
+        return Err(AppError::Forbidden(
+            "Only the host can skip tracks".to_string(),
+        ));
+    }
+
+    // Find the most recent race
+    let current_race = session_races::Entity::find()
+        .filter(session_races::Column::SessionId.eq(session_id))
+        .order_by_desc(session_races::Column::RaceNumber)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::BadRequest("No track to skip".to_string()))?;
+
+    // Verify no runs exist for this race
+    let run_count = runs::Entity::find()
+        .filter(runs::Column::SessionRaceId.eq(&current_race.id))
+        .count(db)
+        .await?;
+
+    if run_count > 0 {
+        return Err(AppError::BadRequest(
+            "Can't skip — runs already submitted".to_string(),
+        ));
+    }
+
+    // Delete the current race, then pick a new one via next_track
+    current_race.delete(db).await?;
+
+    next_track(db, session_id, user_id).await
+}
+
+/// List all races in a session, ordered by race_number ASC.
+pub async fn list_races(
+    db: &DatabaseConnection,
+    session_id: &str,
+) -> Result<Vec<RaceInfo>, AppError> {
+    // Verify session exists
+    sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    let rows = RaceHistoryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT sr.id, sr.race_number, sr.track_id,
+               t.name AS track_name, c.name AS cup_name,
+               COUNT(r.id) AS run_count, sr.created_at
+        FROM session_races sr
+        JOIN tracks t ON sr.track_id = t.id
+        JOIN cups c ON t.cup_id = c.id
+        LEFT JOIN runs r ON r.session_race_id = sr.id
+        WHERE sr.session_id = $1
+        GROUP BY sr.id
+        ORDER BY sr.race_number ASC
+        "#,
+        [session_id.into()],
+    ))
+    .all(db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| RaceInfo {
+            id: r.id,
+            race_number: r.race_number,
+            track_id: r.track_id,
+            track_name: r.track_name,
+            cup_name: r.cup_name,
+            run_count: r.run_count,
+            created_at: r.created_at,
+        })
+        .collect())
+}
+
 /// Close sessions that have had no activity for over an hour.
 /// Returns the number of sessions closed.
 pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppError> {
@@ -423,6 +702,43 @@ mod tests {
             .expect("pragma");
         Migrator::up(&db, None).await.expect("migrate");
         db
+    }
+
+    /// Seed a small set of cups and tracks for testing track selection.
+    /// Creates 3 cups with 2 tracks each (6 tracks total).
+    async fn seed_tracks_for_test(db: &DatabaseConnection) {
+        let cup_names = ["Test Cup A", "Test Cup B", "Test Cup C"];
+        for (i, name) in cup_names.iter().enumerate() {
+            cups::ActiveModel {
+                id: Set((i + 1) as i32),
+                name: Set(name.to_string()),
+                image_path: Set(format!("images/cups/test-cup-{}.webp", i + 1)),
+            }
+            .insert(db)
+            .await
+            .expect("insert cup");
+        }
+
+        let track_data = [
+            (1, "Track Alpha", 1, 1),
+            (2, "Track Beta", 1, 2),
+            (3, "Track Gamma", 2, 1),
+            (4, "Track Delta", 2, 2),
+            (5, "Track Epsilon", 3, 1),
+            (6, "Track Zeta", 3, 2),
+        ];
+        for (id, name, cup_id, position) in track_data {
+            tracks::ActiveModel {
+                id: Set(id),
+                name: Set(name.to_string()),
+                cup_id: Set(cup_id),
+                position: Set(position),
+                image_path: Set(format!("images/tracks/track-{id}.webp")),
+            }
+            .insert(db)
+            .await
+            .expect("insert track");
+        }
     }
 
     async fn create_user(db: &DatabaseConnection, username: &str) -> String {
@@ -671,5 +987,205 @@ mod tests {
         // Should succeed — left s1, now free to join s2
         let result = join_session(&db, &s2.id, &user_id).await;
         assert!(result.is_ok());
+    }
+
+    // ── Track selection tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_next_track_picks_random_track() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        assert_eq!(race.race_number, 1);
+        assert!((1..=6).contains(&race.track_id));
+        assert!(!race.track_name.is_empty());
+        assert!(!race.cup_name.is_empty());
+
+        // Verify session_race row was created
+        let rows = session_races::Entity::find()
+            .filter(session_races::Column::SessionId.eq(&session.id))
+            .all(&db)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].track_id, race.track_id);
+    }
+
+    #[tokio::test]
+    async fn test_next_track_excludes_already_used_tracks() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let r1 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r2 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r3 = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // All three should be different tracks
+        let ids = vec![r1.track_id, r2.track_id, r3.track_id];
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(unique.len(), 3, "All 3 track picks should be unique");
+    }
+
+    #[tokio::test]
+    async fn test_next_track_resets_pool_when_exhausted() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // Use all 6 tracks
+        for _ in 0..6 {
+            next_track(&db, &session.id, &host_id).await.unwrap();
+        }
+
+        // 7th call should succeed — pool resets
+        let r7 = next_track(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(r7.race_number, 7);
+        assert!((1..=6).contains(&r7.track_id));
+    }
+
+    #[tokio::test]
+    async fn test_next_track_only_host_can_call() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_id).await.unwrap();
+
+        let result = next_track(&db, &session.id, &user_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_next_track_fails_on_closed_session() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // Close by having host leave
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let result = next_track(&db, &session.id, &host_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_skip_turn_rerolls_current_track() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let original = next_track(&db, &session.id, &host_id).await.unwrap();
+        let rerolled = skip_turn(&db, &session.id, &host_id).await.unwrap();
+
+        // The old race should be gone and a new one should exist
+        let old_race = session_races::Entity::find_by_id(&original.id)
+            .one(&db)
+            .await
+            .unwrap();
+        assert!(old_race.is_none(), "Old race should be deleted");
+
+        // New race should exist
+        let new_race = session_races::Entity::find_by_id(&rerolled.id)
+            .one(&db)
+            .await
+            .unwrap();
+        assert!(new_race.is_some(), "New race should exist");
+
+        // Race number should be 1 (replaced, not incremented)
+        assert_eq!(rerolled.race_number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_skip_turn_fails_when_no_race_exists() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let result = skip_turn(&db, &session.id, &host_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_skip_turn_only_host_can_call() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_id).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let result = skip_turn(&db, &session.id, &user_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_current_race_appears_in_session_detail() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // Before any track pick, current_race should be None
+        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        assert!(detail.current_race.is_none());
+
+        // After picking a track, current_race should be populated
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        let current = detail.current_race.expect("current_race should be Some");
+        assert_eq!(current.track_id, race.track_id);
+        assert_eq!(current.track_name, race.track_name);
+        assert_eq!(current.cup_name, race.cup_name);
+    }
+
+    #[tokio::test]
+    async fn test_race_number_increments_correctly() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let r1 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r2 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r3 = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        assert_eq!(r1.race_number, 1);
+        assert_eq!(r2.race_number, 2);
+        assert_eq!(r3.race_number, 3);
+    }
+
+    #[tokio::test]
+    async fn test_list_races_returns_all_races_in_order() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let races = list_races(&db, &session.id).await.unwrap();
+        assert_eq!(races.len(), 3);
+        assert_eq!(races[0].race_number, 1);
+        assert_eq!(races[1].race_number, 2);
+        assert_eq!(races[2].race_number, 3);
+
+        // All should have 0 runs (no run submission in this PR)
+        for race in &races {
+            assert_eq!(race.run_count, 0);
+        }
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -605,7 +605,8 @@ pub async fn next_track(
     })
 }
 
-/// Re-roll the current track. Host-only.
+/// Re-roll the current track. Any participant can trigger this
+/// (per DESIGN.md — "any participant can pass the chooser's turn").
 /// Only valid if the most recent race has no runs submitted.
 /// Deletes the current race and picks a new one in a single transaction,
 /// excluding the skipped track from the pool so it can't come back.
@@ -621,12 +622,6 @@ pub async fn skip_turn(
 
     if session.status != "active" {
         return Err(AppError::BadRequest("Session is not active".to_string()));
-    }
-
-    if session.host_id != user_id {
-        return Err(AppError::Forbidden(
-            "Only the host can skip tracks".to_string(),
-        ));
     }
 
     // Find the most recent race
@@ -1268,17 +1263,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_skip_turn_only_host_can_call() {
+    async fn test_skip_turn_any_participant_can_call() {
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
         let user_id = create_user(&db, "user").await;
         let session = create_session(&db, &host_id, "random").await.unwrap();
         join_session(&db, &session.id, &user_id).await.unwrap();
-        next_track(&db, &session.id, &host_id).await.unwrap();
+        let original = next_track(&db, &session.id, &host_id).await.unwrap();
 
+        // Non-host participant should be able to skip
         let result = skip_turn(&db, &session.id, &user_id).await;
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        let rerolled = result.unwrap();
+        assert_ne!(rerolled.track_id, original.track_id);
     }
 
     #[tokio::test]

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client'
-import type { SessionSummary, SessionDetail } from './types'
+import type { SessionSummary, SessionDetail, SessionRaceInfo, RaceInfo } from './types'
 
 export async function getMySession(): Promise<string | null> {
   const res = await apiFetch('/api/v1/sessions/mine')
@@ -48,4 +48,28 @@ export async function leaveSession(id: string): Promise<void> {
     const err = await res.json()
     throw new Error(err.error || 'Failed to leave session')
   }
+}
+
+export async function nextTrack(sessionId: string): Promise<SessionRaceInfo> {
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/next-track`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to pick track')
+  }
+  return res.json()
+}
+
+export async function skipTurn(sessionId: string): Promise<SessionRaceInfo> {
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/skip-turn`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to skip track')
+  }
+  return res.json()
+}
+
+export async function listRaces(sessionId: string): Promise<RaceInfo[]> {
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/races`)
+  if (!res.ok) return []
+  return res.json()
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -78,6 +78,26 @@ export interface ParticipantInfo {
   left_at: string | null
 }
 
+export interface SessionRaceInfo {
+  id: string
+  race_number: number
+  track_id: number
+  track_name: string
+  cup_name: string
+  image_path: string
+  created_at: string
+}
+
+export interface RaceInfo {
+  id: string
+  race_number: number
+  track_id: number
+  track_name: string
+  cup_name: string
+  run_count: number
+  created_at: string
+}
+
 export interface SessionDetail {
   id: string
   created_by: string
@@ -89,4 +109,5 @@ export interface SessionDetail {
   last_activity_at: string
   participants: ParticipantInfo[]
   race_number: number
+  current_race: SessionRaceInfo | null
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -110,4 +110,5 @@ export interface SessionDetail {
   participants: ParticipantInfo[]
   race_number: number
   current_race: SessionRaceInfo | null
+  races: RaceInfo[]
 }

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSession } from '../hooks/useSession'
-import { joinSession, leaveSession, nextTrack, skipTurn, listRaces } from '../api/sessions'
-import type { RaceInfo } from '../api/types'
+import { joinSession, leaveSession, nextTrack, skipTurn } from '../api/sessions'
 import BottomNav from '../components/BottomNav'
 
 export default function Session() {
@@ -17,7 +16,7 @@ export default function Session() {
   const [headerExpanded, setHeaderExpanded] = useState(false)
   const [pickingTrack, setPickingTrack] = useState(false)
   const [skippingTrack, setSkippingTrack] = useState(false)
-  const [races, setRaces] = useState<RaceInfo[]>([])
+  const [trackError, setTrackError] = useState<string | null>(null)
   const [historyExpanded, setHistoryExpanded] = useState(true)
   const [trackImageError, setTrackImageError] = useState(false)
 
@@ -44,10 +43,11 @@ export default function Session() {
 
   const handleNextTrack = async () => {
     setPickingTrack(true)
+    setTrackError(null)
     try {
       await nextTrack(id!)
-    } catch {
-      // Poll will pick up any changes
+    } catch (e) {
+      setTrackError(e instanceof Error ? e.message : 'Failed to pick track')
     } finally {
       setPickingTrack(false)
     }
@@ -55,39 +55,31 @@ export default function Session() {
 
   const handleSkipTrack = async () => {
     setSkippingTrack(true)
+    setTrackError(null)
     try {
       await skipTurn(id!)
-    } catch {
-      // Poll will pick up any changes
+    } catch (e) {
+      setTrackError(e instanceof Error ? e.message : 'Failed to skip track')
     } finally {
       setSkippingTrack(false)
     }
   }
-
-  const fetchRaces = useCallback(async () => {
-    if (!id) return
-    const data = await listRaces(id)
-    setRaces(data)
-  }, [id])
-
-  // Fetch race history when session changes (piggyback on poll)
-  useEffect(() => {
-    if (session) {
-      fetchRaces()
-    }
-  }, [session, fetchRaces])
 
   // Reset image error state when the track changes
   useEffect(() => {
     setTrackImageError(false)
   }, [session?.current_race?.id])
 
-  // Auto-collapse history when > 3 races
+  // Clear track error when a successful poll shows the state changed
   useEffect(() => {
-    if (races.length > 3) {
-      setHistoryExpanded(false)
-    }
-  }, [races.length > 3]) // eslint-disable-line react-hooks/exhaustive-deps
+    if (trackError) setTrackError(null)
+  }, [session?.current_race?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-collapse history when > 3 races
+  const hasMany = (session?.races.length ?? 0) > 3
+  useEffect(() => {
+    if (hasMany) setHistoryExpanded(false)
+  }, [hasMany])
 
   if (loading) {
     return (
@@ -117,7 +109,7 @@ export default function Session() {
   const isHost = user?.id === session.host_id
   const currentRace = session.current_race
   // Past races = all except the most recent (current), shown newest-first
-  const pastRaces = [...races].reverse().filter((r) => r.id !== currentRace?.id)
+  const pastRaces = [...session.races].reverse().filter((r) => r.id !== currentRace?.id)
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -223,6 +215,7 @@ export default function Session() {
                 {skippingTrack ? 'Re-rolling...' : 'Skip Track'}
               </button>
             )}
+            {trackError && <p className="text-xs text-red-500 text-center">{trackError}</p>}
           </div>
         )}
 

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -164,7 +164,7 @@ export default function Session() {
               <img
                 src={`/${currentRace.image_path}`}
                 alt={currentRace.track_name}
-                className="w-full h-40 object-cover"
+                className="w-full h-40 object-contain bg-gray-100"
                 onError={() => setTrackImageError(true)}
               />
             )}

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -196,16 +196,20 @@ export default function Session() {
 
       {/* Zone 3 — Action Area */}
       <div className="px-4 pt-4 space-y-3">
-        {/* Host controls — Next Track and Skip Track */}
-        {isHost && isParticipant && (
+        {/* Track controls */}
+        {isParticipant && (
           <div className="space-y-2">
-            <button
-              onClick={handleNextTrack}
-              disabled={pickingTrack}
-              className="w-full py-3 text-sm font-semibold text-white bg-blue-500 rounded-xl disabled:opacity-50 active:bg-blue-600 transition-colors"
-            >
-              {pickingTrack ? 'Picking track...' : 'Next Track'}
-            </button>
+            {/* Next Track — host only */}
+            {isHost && (
+              <button
+                onClick={handleNextTrack}
+                disabled={pickingTrack}
+                className="w-full py-3 text-sm font-semibold text-white bg-blue-500 rounded-xl disabled:opacity-50 active:bg-blue-600 transition-colors"
+              >
+                {pickingTrack ? 'Picking track...' : 'Next Track'}
+              </button>
+            )}
+            {/* Skip Track — any participant */}
             {currentRace && (
               <button
                 onClick={handleSkipTrack}

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSession } from '../hooks/useSession'
-import { joinSession, leaveSession } from '../api/sessions'
+import { joinSession, leaveSession, nextTrack, skipTurn, listRaces } from '../api/sessions'
+import type { RaceInfo } from '../api/types'
 import BottomNav from '../components/BottomNav'
 
 export default function Session() {
@@ -14,6 +15,11 @@ export default function Session() {
   const [joiningSession, setJoiningSession] = useState(false)
   const [joinError, setJoinError] = useState<string | null>(null)
   const [headerExpanded, setHeaderExpanded] = useState(false)
+  const [pickingTrack, setPickingTrack] = useState(false)
+  const [skippingTrack, setSkippingTrack] = useState(false)
+  const [races, setRaces] = useState<RaceInfo[]>([])
+  const [historyExpanded, setHistoryExpanded] = useState(true)
+  const [trackImageError, setTrackImageError] = useState(false)
 
   const handleLeave = async () => {
     setLeaving(true)
@@ -35,6 +41,53 @@ export default function Session() {
       setJoiningSession(false)
     }
   }
+
+  const handleNextTrack = async () => {
+    setPickingTrack(true)
+    try {
+      await nextTrack(id!)
+    } catch {
+      // Poll will pick up any changes
+    } finally {
+      setPickingTrack(false)
+    }
+  }
+
+  const handleSkipTrack = async () => {
+    setSkippingTrack(true)
+    try {
+      await skipTurn(id!)
+    } catch {
+      // Poll will pick up any changes
+    } finally {
+      setSkippingTrack(false)
+    }
+  }
+
+  const fetchRaces = useCallback(async () => {
+    if (!id) return
+    const data = await listRaces(id)
+    setRaces(data)
+  }, [id])
+
+  // Fetch race history when session changes (piggyback on poll)
+  useEffect(() => {
+    if (session) {
+      fetchRaces()
+    }
+  }, [session, fetchRaces])
+
+  // Reset image error state when the track changes
+  useEffect(() => {
+    setTrackImageError(false)
+  }, [session?.current_race?.id])
+
+  // Auto-collapse history when > 3 races
+  useEffect(() => {
+    if (races.length > 3) {
+      setHistoryExpanded(false)
+    }
+  }, [races.length > 3]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (
@@ -62,6 +115,9 @@ export default function Session() {
   const activeParticipants = session.participants.filter((p) => !p.left_at)
   const isParticipant = activeParticipants.some((p) => p.user_id === user?.id)
   const isHost = user?.id === session.host_id
+  const currentRace = session.current_race
+  // Past races = all except the most recent (current), shown newest-first
+  const pastRaces = [...races].reverse().filter((r) => r.id !== currentRace?.id)
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -104,19 +160,72 @@ export default function Session() {
 
       {/* Zone 2 — Track Card */}
       <div className="px-4 pt-4">
-        <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
-          <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-lg flex items-center justify-center">
-            <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
+        {currentRace ? (
+          /* Active race — show track image and info */
+          <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+            {/* Track image */}
+            {trackImageError ? (
+              <div className="h-40 bg-gray-100 flex items-center justify-center">
+                <span className="text-4xl">{'\uD83C\uDFCE\uFE0F'}</span>
+              </div>
+            ) : (
+              <img
+                src={`/${currentRace.image_path}`}
+                alt={currentRace.track_name}
+                className="w-full h-40 object-cover"
+                onError={() => setTrackImageError(true)}
+              />
+            )}
+            {/* Track info */}
+            <div className="px-4 py-3">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-bold text-gray-900">{currentRace.track_name}</h2>
+                <span className="text-[10px] font-semibold text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
+                  Race {currentRace.race_number}
+                </span>
+              </div>
+              <p className="text-sm text-gray-500 mt-0.5">{currentRace.cup_name}</p>
+            </div>
           </div>
-          <p className="text-sm text-gray-500">Waiting for host to pick...</p>
-          {isHost && session.race_number === 0 && (
-            <p className="text-xs text-gray-400 mt-1">Track selection coming in a future update</p>
-          )}
-        </div>
+        ) : (
+          /* No race yet — waiting state */
+          <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
+            <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-lg flex items-center justify-center">
+              <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
+            </div>
+            <p className="text-sm text-gray-500">
+              {isHost
+                ? 'Tap Next Track to get started!'
+                : `Waiting for ${session.host_username} to pick a track...`}
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Zone 3 — Action Area */}
       <div className="px-4 pt-4 space-y-3">
+        {/* Host controls — Next Track and Skip Track */}
+        {isHost && isParticipant && (
+          <div className="space-y-2">
+            <button
+              onClick={handleNextTrack}
+              disabled={pickingTrack}
+              className="w-full py-3 text-sm font-semibold text-white bg-blue-500 rounded-xl disabled:opacity-50 active:bg-blue-600 transition-colors"
+            >
+              {pickingTrack ? 'Picking track...' : 'Next Track'}
+            </button>
+            {currentRace && (
+              <button
+                onClick={handleSkipTrack}
+                disabled={skippingTrack}
+                className="w-full py-2.5 text-sm font-medium text-gray-500 bg-white border border-gray-200 rounded-xl disabled:opacity-50 active:bg-gray-50 transition-colors"
+              >
+                {skippingTrack ? 'Re-rolling...' : 'Skip Track'}
+              </button>
+            )}
+          </div>
+        )}
+
         {/* Participant cards */}
         <div>
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1 mb-2">
@@ -136,6 +245,43 @@ export default function Session() {
             ))}
           </div>
         </div>
+
+        {/* Race History */}
+        {pastRaces.length > 0 && (
+          <div>
+            <button
+              onClick={() => setHistoryExpanded(!historyExpanded)}
+              className="w-full flex items-center justify-between px-1 mb-2"
+            >
+              <div className="flex items-center gap-2">
+                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                  Race History
+                </h3>
+                <span className="text-[10px] font-medium text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-full">
+                  {pastRaces.length}
+                </span>
+              </div>
+              <span className="text-gray-400 text-xs">{historyExpanded ? '\u25B2' : '\u25BC'}</span>
+            </button>
+            {historyExpanded && (
+              <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
+                {pastRaces.map((race) => (
+                  <div key={race.id} className="px-4 py-3 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs font-semibold text-gray-400 w-5 text-center">
+                        {race.race_number}
+                      </span>
+                      <div>
+                        <p className="text-sm font-medium text-gray-900">{race.track_name}</p>
+                        <p className="text-xs text-gray-400">{race.cup_name}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Session info */}
         <div className="bg-white rounded-xl border border-gray-200 p-4">


### PR DESCRIPTION
## Summary

- **Backend:** Added `next_track`, `skip_turn`, and `list_races` service functions with corresponding routes (`POST /sessions/:id/next-track`, `POST /sessions/:id/skip-turn`, `GET /sessions/:id/races`). The `SessionDetail` polling response now includes `current_race` and `races` (full history) — fetched via JOIN queries.
- **Track selection logic:** Host picks random tracks from the pool. Already-used tracks are excluded. When all 96 tracks are exhausted, the pool resets and tracks cycle. `skip_turn` deletes the current race (if no runs submitted) and re-rolls, excluding the skipped track so it can't come back. Delete + re-pick is atomic (single transaction).
- **Permissions:** `next_track` is host-only. `skip_turn` is any-participant (per DESIGN.md: "any participant can pass the chooser's turn"). `chosen_by` is NULL for the random ruleset since no human chose the track.
- **Frontend:** Session page track card shows the real `.webp` track image (`object-contain`, no stretching) when a race is active, with an emoji fallback for missing images. Host sees "Next Track" button; all participants see "Skip Track". Non-hosts see a waiting message with the host's name. Collapsible race history section shows past tracks. Failed actions show inline error messages.
- **12 backend unit tests** covering: random track picking, pool exclusion, pool exhaustion reset, host-only auth for next_track, any-participant skip, skip exclusion near pool exhaustion, skip/reroll mechanics, session detail integration, race number incrementing, and race listing.

## Non-obvious details

- `rand::thread_rng()` (`ThreadRng`) is `!Send`, which breaks Axum's handler trait if it lives across `.await` points. Scoped the RNG into a block that resolves before any async work.
- Race history is included in `SessionDetail` polling response — no separate polling loop needed.
- `skip_turn` builds its own exclusion list (all used tracks + the skipped track) before deleting, so the skipped track can never come back even after deletion removes it from the DB.
- `chosen_by` is `NULL` for random ruleset picks per DESIGN.md. Only set when a human deliberately picks (future round-robin). This preserves round-robin chooser rotation logic which derives state from `chosen_by`.

## Test plan

### Backend (automated — all passing)
- [x] `cargo test` — 95 tests pass (38 unit + 57 integration)

### Frontend (manual)
1. **Start the backend and frontend dev servers**
   ```bash
   cd backend && cargo run       # terminal 1
   cd frontend && bun run dev    # terminal 2
   ```
2. **Create a session and verify the waiting state**
   - Log in as user A, create a session
   - Verify the track card shows "Tap Next Track to get started!"
   - Open a second browser/incognito as user B, join the same session
   - Verify user B sees "Waiting for [hostA] to pick a track..."
3. **Pick a track (host only)**
   - As user A (host), tap "Next Track"
   - Verify a track image appears (not stretched) with track name, cup name, and "Race 1" badge
   - Verify user B's screen updates within ~3 seconds showing the same track
4. **Skip a track (any participant)**
   - As user B (non-host), verify "Skip Track" button is visible
   - Tap "Skip Track" — verify a new track appears, still labeled "Race 1"
   - Verify user B does NOT see "Next Track" button (host-only)
5. **Advance through multiple tracks**
   - As host, tap "Next Track" 2-3 more times
   - Verify race numbers increment (Race 2, Race 3, ...)
   - Verify race history section appears below with past tracks listed newest-first
   - Verify history collapses with chevron when > 3 races
6. **Error feedback**
   - (Optional) If you can trigger a failure (e.g., two rapid taps), verify an inline error message appears briefly below the buttons
7. **Track image fallback**
   - (Optional) Temporarily rename a track image file, reload — verify the 🏎️ emoji fallback appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)