### PR TITLE
Phase 3C-2: Run entry — core gameplay loop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,6 +9,10 @@ Two handoff files enable async task passing between assistants. The writer creat
 - **`.claude/cowork-handoff.md`** — Cowork → Claude Code. Check before starting work. Contains task instructions from the architecture/design assistant. Delete after completing the work.
 - **`.claude/claude-code-handoff.md`** — Claude Code → Cowork. Write this when you have questions, research requests, or design decisions for Cowork. Cowork deletes it after addressing.
 
+**Anything intended for the other assistant to act on — task specs, code review findings, bug reports, design decisions, answers to their questions — MUST be written to the appropriate handoff file.** Delivering it only in chat means the other assistant won't see it. If you find yourself composing a substantive response that the other assistant needs, stop and write it to the handoff file instead.
+
+**Do not use handoff files for your own session notes.** The handoff files are one-way channels between assistants — if the file exists, the recipient assumes there's work to do. For self-notes or session state you want to preserve across your own sessions, use `.claude/cowork-notes.md` (Cowork) or a similar assistant-specific notes file.
+
 ## Project Phase
 Phase 3 — Sessions & Run Recording (core gameplay loop).
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ target/
 # Assistant handoff files (ephemeral)
 .claude/*-handoff.md
 
+# Assistant self-notes (ephemeral session state)
+.claude/*-notes.md
+
 # Tool state (tokens, cookies)
 tools/.state/
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -450,7 +450,7 @@ Future enhancement: prioritize sessions containing players you've competed with 
 2. Everyone in the session sees the track. Each person races on their TV in Time Trial mode.
 3. After racing, each person submits their time:
    - Track is already known (from the session race) — no track selection needed.
-   - Enter time (M:SS.mmm — minutes field accepts 1-2 digits with no leading zero, manual entry for v1, camera/OCR later).
+   - Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later).
    - Drink defaults to previous, fallback to preferred. Can change or add new inline.
    - Race setup defaults to previous, fallback to preferred. Can change.
    - Option to mark the run as DQ'd (didn't finish drink before finishing race).
@@ -643,7 +643,7 @@ The main play screen. Shows:
 
 ### 4. Run Entry (within session)
 Streamlined compared to standalone entry — the track is already known from the session.
-1. Enter time (M:SS.mmm — minutes field accepts 1-2 digits with no leading zero, manual entry for v1, camera/OCR later).
+1. Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later).
 2. Drink defaults to previous, fallback to preferred. Can change or add new inline.
 3. Race setup defaults to previous, fallback to preferred. Can change.
 4. Option to mark run as DQ'd (didn't finish drink before finishing race).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -331,7 +331,7 @@ Notes:
 Validation (application-level):
 - `track_time` must be positive.
 - All three lap times must be positive and non-zero.
-- Lap times should roughly sum to `track_time` (with tolerance for game rounding).
+- Lap times must sum exactly to `track_time`. The frontend warns if they don't match; the backend rejects the submission.
 - Race setup columns pre-fill from previous run (or preferred from profile), but are all required.
 - `track_id` must match the track on the referenced `session_race_id`.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -450,7 +450,7 @@ Future enhancement: prioritize sessions containing players you've competed with 
 2. Everyone in the session sees the track. Each person races on their TV in Time Trial mode.
 3. After racing, each person submits their time:
    - Track is already known (from the session race) — no track selection needed.
-   - Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later).
+   - Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later). Auto-advance moves focus forward through all 12 fields (total → L1 → L2 → L3); backspace on an empty field moves backward. Lap times must sum exactly to total time.
    - Drink defaults to previous, fallback to preferred. Can change or add new inline.
    - Race setup defaults to previous, fallback to preferred. Can change.
    - Option to mark the run as DQ'd (didn't finish drink before finishing race).
@@ -643,7 +643,7 @@ The main play screen. Shows:
 
 ### 4. Run Entry (within session)
 Streamlined compared to standalone entry — the track is already known from the session.
-1. Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later).
+1. Enter time (M:SS.mmm — single digit minutes, no leading zero, manual entry for v1, camera/OCR later). Auto-advance moves focus forward through all 12 fields (total → L1 → L2 → L3); backspace on an empty field moves backward. Lap times must sum exactly to total time.
 2. Drink defaults to previous, fallback to preferred. Can change or add new inline.
 3. Race setup defaults to previous, fallback to preferred. Can change.
 4. Option to mark run as DQ'd (didn't finish drink before finishing race).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -450,7 +450,7 @@ Future enhancement: prioritize sessions containing players you've competed with 
 2. Everyone in the session sees the track. Each person races on their TV in Time Trial mode.
 3. After racing, each person submits their time:
    - Track is already known (from the session race) — no track selection needed.
-   - Enter time (MM:SS.mmm — manual entry for v1, camera/OCR later).
+   - Enter time (M:SS.mmm — minutes field accepts 1-2 digits with no leading zero, manual entry for v1, camera/OCR later).
    - Drink defaults to previous, fallback to preferred. Can change or add new inline.
    - Race setup defaults to previous, fallback to preferred. Can change.
    - Option to mark the run as DQ'd (didn't finish drink before finishing race).
@@ -643,7 +643,7 @@ The main play screen. Shows:
 
 ### 4. Run Entry (within session)
 Streamlined compared to standalone entry — the track is already known from the session.
-1. Enter time (MM:SS.mmm — manual entry for v1, camera/OCR later).
+1. Enter time (M:SS.mmm — minutes field accepts 1-2 digits with no leading zero, manual entry for v1, camera/OCR later).
 2. Drink defaults to previous, fallback to preferred. Can change or add new inline.
 3. Race setup defaults to previous, fallback to preferred. Can change.
 4. Option to mark run as DQ'd (didn't finish drink before finishing race).

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -11,6 +11,7 @@ pub mod m20260330_000008_create_sessions;
 pub mod m20260330_000009_create_session_participants;
 pub mod m20260330_000010_create_session_races;
 pub mod m20260330_000011_recreate_runs;
+pub mod m20260330_000012_add_runs_unique_constraint;
 
 pub struct Migrator;
 
@@ -29,6 +30,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260330_000009_create_session_participants::Migration),
             Box::new(m20260330_000010_create_session_races::Migration),
             Box::new(m20260330_000011_recreate_runs::Migration),
+            Box::new(m20260330_000012_add_runs_unique_constraint::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260330_000012_add_runs_unique_constraint.rs
+++ b/backend/migration/src/m20260330_000012_add_runs_unique_constraint.rs
@@ -1,0 +1,32 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Prevent duplicate run submissions: one run per user per race
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_runs_session_race_user_unique")
+                    .table(Alias::new("runs"))
+                    .col(Alias::new("session_race_id"))
+                    .col(Alias::new("user_id"))
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_runs_session_race_user_unique")
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -139,6 +139,16 @@ async fn main() {
             "/api/v1/sessions/{id}/races",
             get(routes::sessions::list_races),
         )
+        // Runs — /defaults before /{id} so literal matches first
+        .route(
+            "/api/v1/runs",
+            get(routes::runs::list_runs).post(routes::runs::create_run),
+        )
+        .route("/api/v1/runs/defaults", get(routes::runs::get_defaults))
+        .route(
+            "/api/v1/runs/{id}",
+            get(routes::runs::get_run).delete(routes::runs::delete_run),
+        )
         .layer(TraceLayer::new_for_http())
         .with_state(state)
         // Serve frontend static files. If no API route or static file matches,

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod drink_types;
 pub mod game_data;
+pub mod runs;
 pub mod sessions;
 pub mod users;

--- a/backend/src/routes/runs.rs
+++ b/backend/src/routes/runs.rs
@@ -1,0 +1,73 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::error::AppError;
+use crate::middleware::auth::AuthUser;
+use crate::services::runs;
+
+/// POST /runs — create a run.
+pub async fn create_run(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Json(body): Json<runs::CreateRunRequest>,
+) -> Result<(StatusCode, Json<runs::RunDetail>), AppError> {
+    let detail = runs::create_run(&state.db, &user.user_id, body).await?;
+    Ok((StatusCode::CREATED, Json(detail)))
+}
+
+#[derive(Deserialize)]
+pub struct ListRunsQuery {
+    pub session_race_id: Option<String>,
+    pub user_id: Option<String>,
+    pub track_id: Option<i32>,
+}
+
+/// GET /runs — list runs with optional filters.
+pub async fn list_runs(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Query(query): Query<ListRunsQuery>,
+) -> Result<Json<Vec<runs::RunDetail>>, AppError> {
+    let filters = runs::RunFilters {
+        session_race_id: query.session_race_id,
+        user_id: query.user_id,
+        track_id: query.track_id,
+    };
+    let results = runs::list_runs(&state.db, filters).await?;
+    Ok(Json(results))
+}
+
+/// GET /runs/defaults — get defaults for the authenticated user.
+pub async fn get_defaults(
+    user: AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<runs::RunDefaults>, AppError> {
+    let defaults = runs::get_run_defaults(&state.db, &user.user_id).await?;
+    Ok(Json(defaults))
+}
+
+/// GET /runs/:id — get a single run.
+pub async fn get_run(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<runs::RunDetail>, AppError> {
+    let detail = runs::get_run(&state.db, &id).await?;
+    Ok(Json(detail))
+}
+
+/// DELETE /runs/:id — delete a run. Owner only, active session only.
+pub async fn delete_run(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    runs::delete_run(&state.db, &id, &user.user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
+pub mod runs;
 pub mod sessions;

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -1,0 +1,919 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
+    FromQueryResult, ModelTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::entities::{
+    bodies, characters, drink_types, gliders, runs, session_participants, session_races, sessions,
+    users, wheels,
+};
+use crate::error::AppError;
+
+/// Maximum allowed track time: 10 minutes in milliseconds.
+const MAX_TRACK_TIME_MS: i32 = 600_000;
+
+#[derive(Deserialize)]
+pub struct CreateRunRequest {
+    pub session_race_id: String,
+    pub track_time: i32,
+    pub lap1_time: i32,
+    pub lap2_time: i32,
+    pub lap3_time: i32,
+    pub character_id: i32,
+    pub body_id: i32,
+    pub wheel_id: i32,
+    pub glider_id: i32,
+    pub drink_type_id: String,
+    pub disqualified: bool,
+}
+
+#[derive(Serialize)]
+pub struct RunDetail {
+    pub id: String,
+    pub user_id: String,
+    pub username: String,
+    pub session_race_id: String,
+    pub track_id: i32,
+    pub track_time: i32,
+    pub lap1_time: i32,
+    pub lap2_time: i32,
+    pub lap3_time: i32,
+    pub character_id: i32,
+    pub body_id: i32,
+    pub wheel_id: i32,
+    pub glider_id: i32,
+    pub drink_type_id: String,
+    pub drink_type_name: String,
+    pub disqualified: bool,
+    pub created_at: String,
+}
+
+/// Row shape for the run detail JOIN query.
+#[derive(Debug, FromQueryResult)]
+struct RunDetailRow {
+    id: String,
+    user_id: String,
+    username: String,
+    session_race_id: String,
+    track_id: i32,
+    track_time: i32,
+    lap1_time: i32,
+    lap2_time: i32,
+    lap3_time: i32,
+    character_id: i32,
+    body_id: i32,
+    wheel_id: i32,
+    glider_id: i32,
+    drink_type_id: String,
+    drink_type_name: String,
+    disqualified: bool,
+    created_at: String,
+}
+
+impl From<RunDetailRow> for RunDetail {
+    fn from(r: RunDetailRow) -> Self {
+        Self {
+            id: r.id,
+            user_id: r.user_id,
+            username: r.username,
+            session_race_id: r.session_race_id,
+            track_id: r.track_id,
+            track_time: r.track_time,
+            lap1_time: r.lap1_time,
+            lap2_time: r.lap2_time,
+            lap3_time: r.lap3_time,
+            character_id: r.character_id,
+            body_id: r.body_id,
+            wheel_id: r.wheel_id,
+            glider_id: r.glider_id,
+            drink_type_id: r.drink_type_id,
+            drink_type_name: r.drink_type_name,
+            disqualified: r.disqualified,
+            created_at: r.created_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct RunDefaults {
+    pub drink_type_id: Option<String>,
+    pub character_id: Option<i32>,
+    pub body_id: Option<i32>,
+    pub wheel_id: Option<i32>,
+    pub glider_id: Option<i32>,
+    pub source: String,
+}
+
+pub struct RunFilters {
+    pub session_race_id: Option<String>,
+    pub user_id: Option<String>,
+    pub track_id: Option<i32>,
+}
+
+/// Create a run for a session race. Validates all inputs before inserting.
+pub async fn create_run(
+    db: &DatabaseConnection,
+    user_id: &str,
+    body: CreateRunRequest,
+) -> Result<RunDetail, AppError> {
+    // Validate time fields
+    if body.track_time <= 0 || body.track_time > MAX_TRACK_TIME_MS {
+        return Err(AppError::BadRequest(format!(
+            "track_time must be between 1 and {MAX_TRACK_TIME_MS} ms"
+        )));
+    }
+    if body.lap1_time <= 0 || body.lap2_time <= 0 || body.lap3_time <= 0 {
+        return Err(AppError::BadRequest(
+            "All lap times must be positive".to_string(),
+        ));
+    }
+
+    // Validate session_race exists and belongs to an active session
+    let session_race = session_races::Entity::find_by_id(&body.session_race_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session race not found".to_string()))?;
+
+    let session = sessions::Entity::find_by_id(&session_race.session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+
+    if session.status != "active" {
+        return Err(AppError::BadRequest(
+            "Cannot submit run for a closed session".to_string(),
+        ));
+    }
+
+    // User must be an active participant
+    let participant = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(&session_race.session_id))
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?;
+
+    if participant.is_none() {
+        return Err(AppError::Forbidden(
+            "Must be an active participant to submit a run".to_string(),
+        ));
+    }
+
+    // Check for duplicate submission
+    let existing = runs::Entity::find()
+        .filter(
+            Condition::all()
+                .add(runs::Column::SessionRaceId.eq(&body.session_race_id))
+                .add(runs::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await?;
+
+    if existing.is_some() {
+        return Err(AppError::Conflict(
+            "Already submitted a run for this race".to_string(),
+        ));
+    }
+
+    // Validate FK references exist
+    if characters::Entity::find_by_id(body.character_id)
+        .one(db)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::BadRequest("Invalid character_id".to_string()));
+    }
+    if bodies::Entity::find_by_id(body.body_id)
+        .one(db)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::BadRequest("Invalid body_id".to_string()));
+    }
+    if wheels::Entity::find_by_id(body.wheel_id)
+        .one(db)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::BadRequest("Invalid wheel_id".to_string()));
+    }
+    if gliders::Entity::find_by_id(body.glider_id)
+        .one(db)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::BadRequest("Invalid glider_id".to_string()));
+    }
+    if drink_types::Entity::find_by_id(&body.drink_type_id)
+        .one(db)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::BadRequest("Invalid drink_type_id".to_string()));
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let run_id = Uuid::new_v4().to_string();
+
+    let txn = db.begin().await?;
+
+    runs::ActiveModel {
+        id: Set(run_id.clone()),
+        user_id: Set(user_id.to_string()),
+        session_race_id: Set(body.session_race_id.clone()),
+        track_id: Set(session_race.track_id),
+        character_id: Set(body.character_id),
+        body_id: Set(body.body_id),
+        wheel_id: Set(body.wheel_id),
+        glider_id: Set(body.glider_id),
+        track_time: Set(body.track_time),
+        lap1_time: Set(body.lap1_time),
+        lap2_time: Set(body.lap2_time),
+        lap3_time: Set(body.lap3_time),
+        drink_type_id: Set(body.drink_type_id),
+        disqualified: Set(body.disqualified),
+        photo_path: Set(None),
+        created_at: Set(now.clone()),
+        notes: Set(None),
+    }
+    .insert(&txn)
+    .await?;
+
+    // Update session last_activity_at
+    let mut active_session: sessions::ActiveModel = session.into();
+    active_session.last_activity_at = Set(now);
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
+
+    get_run(db, &run_id).await
+}
+
+/// Fetch a single run by ID with JOINed username and drink_type_name.
+pub async fn get_run(db: &DatabaseConnection, run_id: &str) -> Result<RunDetail, AppError> {
+    let row = RunDetailRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT r.id, r.user_id, u.username, r.session_race_id, r.track_id,
+               r.track_time, r.lap1_time, r.lap2_time, r.lap3_time,
+               r.character_id, r.body_id, r.wheel_id, r.glider_id,
+               r.drink_type_id, dt.name AS drink_type_name,
+               r.disqualified, r.created_at
+        FROM runs r
+        JOIN users u ON r.user_id = u.id
+        JOIN drink_types dt ON r.drink_type_id = dt.id
+        WHERE r.id = $1
+        "#,
+        [run_id.into()],
+    ))
+    .one(db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Run not found".to_string()))?;
+
+    Ok(row.into())
+}
+
+/// List runs with optional filters, ordered by track_time ASC.
+pub async fn list_runs(
+    db: &DatabaseConnection,
+    filters: RunFilters,
+) -> Result<Vec<RunDetail>, AppError> {
+    let mut conditions = Vec::new();
+    let mut params: Vec<sea_orm::Value> = Vec::new();
+    let mut param_idx = 1;
+
+    if let Some(ref sr_id) = filters.session_race_id {
+        conditions.push(format!("r.session_race_id = ${param_idx}"));
+        params.push(sr_id.clone().into());
+        param_idx += 1;
+    }
+    if let Some(ref uid) = filters.user_id {
+        conditions.push(format!("r.user_id = ${param_idx}"));
+        params.push(uid.clone().into());
+        param_idx += 1;
+    }
+    if let Some(tid) = filters.track_id {
+        conditions.push(format!("r.track_id = ${param_idx}"));
+        params.push(tid.into());
+        let _ = param_idx; // suppress unused warning
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let sql = format!(
+        r#"
+        SELECT r.id, r.user_id, u.username, r.session_race_id, r.track_id,
+               r.track_time, r.lap1_time, r.lap2_time, r.lap3_time,
+               r.character_id, r.body_id, r.wheel_id, r.glider_id,
+               r.drink_type_id, dt.name AS drink_type_name,
+               r.disqualified, r.created_at
+        FROM runs r
+        JOIN users u ON r.user_id = u.id
+        JOIN drink_types dt ON r.drink_type_id = dt.id
+        {where_clause}
+        ORDER BY r.track_time ASC
+        "#
+    );
+
+    let rows = RunDetailRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        &sql,
+        params,
+    ))
+    .all(db)
+    .await?;
+
+    Ok(rows.into_iter().map(RunDetail::from).collect())
+}
+
+/// Delete a run. Only the run's owner can delete, and the session must be active.
+pub async fn delete_run(
+    db: &DatabaseConnection,
+    run_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    let run = runs::Entity::find_by_id(run_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Run not found".to_string()))?;
+
+    if run.user_id != user_id {
+        return Err(AppError::Forbidden(
+            "Only the run's owner can delete it".to_string(),
+        ));
+    }
+
+    // Check that the session is still active
+    let session_race = session_races::Entity::find_by_id(&run.session_race_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::Internal("Session race not found for run".to_string()))?;
+
+    let session = sessions::Entity::find_by_id(&session_race.session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::Internal("Session not found for run".to_string()))?;
+
+    if session.status != "active" {
+        return Err(AppError::BadRequest(
+            "Cannot delete run from a closed session".to_string(),
+        ));
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let txn = db.begin().await?;
+
+    run.delete(&txn).await?;
+
+    // Update session last_activity_at
+    let mut active_session: sessions::ActiveModel = session.into();
+    active_session.last_activity_at = Set(now);
+    active_session.update(&txn).await?;
+
+    txn.commit().await?;
+
+    Ok(())
+}
+
+/// Get run defaults for pre-filling the run entry form.
+/// Cascade: previous run → user preferences → none.
+pub async fn get_run_defaults(
+    db: &DatabaseConnection,
+    user_id: &str,
+) -> Result<RunDefaults, AppError> {
+    // Try most recent run
+    let latest_run = runs::Entity::find()
+        .filter(runs::Column::UserId.eq(user_id))
+        .order_by_desc(runs::Column::CreatedAt)
+        .one(db)
+        .await?;
+
+    if let Some(run) = latest_run {
+        return Ok(RunDefaults {
+            drink_type_id: Some(run.drink_type_id),
+            character_id: Some(run.character_id),
+            body_id: Some(run.body_id),
+            wheel_id: Some(run.wheel_id),
+            glider_id: Some(run.glider_id),
+            source: "previous_run".to_string(),
+        });
+    }
+
+    // Fall back to user preferences
+    let user = users::Entity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+
+    if user.preferred_character_id.is_some() {
+        return Ok(RunDefaults {
+            drink_type_id: user.preferred_drink_type_id,
+            character_id: user.preferred_character_id,
+            body_id: user.preferred_body_id,
+            wheel_id: user.preferred_wheel_id,
+            glider_id: user.preferred_glider_id,
+            source: "preferences".to_string(),
+        });
+    }
+
+    Ok(RunDefaults {
+        drink_type_id: None,
+        character_id: None,
+        body_id: None,
+        wheel_id: None,
+        glider_id: None,
+        source: "none".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::{cups, tracks};
+    use crate::services::sessions;
+    use migration::{Migrator, MigratorTrait};
+    use sea_orm::Database;
+
+    async fn setup_db() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("pragma");
+        Migrator::up(&db, None).await.expect("migrate");
+        db
+    }
+
+    async fn create_user(db: &DatabaseConnection, username: &str) -> String {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
+        users::ActiveModel {
+            id: Set(id.clone()),
+            username: Set(username.to_string()),
+            email: Set(None),
+            password_hash: Set(hash.to_string()),
+            preferred_character_id: Set(None),
+            preferred_body_id: Set(None),
+            preferred_wheel_id: Set(None),
+            preferred_glider_id: Set(None),
+            preferred_drink_type_id: Set(None),
+            refresh_token_version: Set(0),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .expect("insert user");
+        id
+    }
+
+    /// Seed minimal game data required for run creation.
+    async fn seed_game_data(db: &DatabaseConnection) {
+        // Cup
+        cups::ActiveModel {
+            id: Set(1),
+            name: Set("Test Cup".to_string()),
+            image_path: Set("images/cups/test.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert cup");
+
+        // Track
+        tracks::ActiveModel {
+            id: Set(1),
+            name: Set("Test Track".to_string()),
+            cup_id: Set(1),
+            position: Set(1),
+            image_path: Set("images/tracks/test.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert track");
+
+        // Character
+        characters::ActiveModel {
+            id: Set(1),
+            name: Set("Mario".to_string()),
+            image_path: Set("images/characters/mario.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert character");
+
+        // Body
+        bodies::ActiveModel {
+            id: Set(1),
+            name: Set("Standard Kart".to_string()),
+            image_path: Set("images/bodies/standard.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert body");
+
+        // Wheels
+        wheels::ActiveModel {
+            id: Set(1),
+            name: Set("Standard".to_string()),
+            image_path: Set("images/wheels/standard.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert wheels");
+
+        // Glider
+        gliders::ActiveModel {
+            id: Set(1),
+            name: Set("Super Glider".to_string()),
+            image_path: Set("images/gliders/super.webp".to_string()),
+        }
+        .insert(db)
+        .await
+        .expect("insert glider");
+
+        // Drink type
+        let drink_id = crate::drink_type_id::drink_type_uuid("Test Beer");
+        drink_types::ActiveModel {
+            id: Set(drink_id),
+            name: Set("Test Beer".to_string()),
+            alcoholic: Set(true),
+            created_at: Set(Utc::now().to_rfc3339()),
+            created_by: Set(None),
+        }
+        .insert(db)
+        .await
+        .expect("insert drink type");
+    }
+
+    fn test_drink_id() -> String {
+        crate::drink_type_id::drink_type_uuid("Test Beer")
+    }
+
+    fn valid_run_request(session_race_id: &str) -> CreateRunRequest {
+        CreateRunRequest {
+            session_race_id: session_race_id.to_string(),
+            track_time: 120_000,
+            lap1_time: 40_000,
+            lap2_time: 39_000,
+            lap3_time: 41_000,
+            character_id: 1,
+            body_id: 1,
+            wheel_id: 1,
+            glider_id: 1,
+            drink_type_id: test_drink_id(),
+            disqualified: false,
+        }
+    }
+
+    /// Helper: create session, pick a track, return (session_id, session_race_id)
+    async fn setup_session_with_race(db: &DatabaseConnection, host_id: &str) -> (String, String) {
+        let session = sessions::create_session(db, host_id, "random")
+            .await
+            .expect("create session");
+        let race = sessions::next_track(db, &session.id, host_id)
+            .await
+            .expect("next track");
+        (session.id, race.id)
+    }
+
+    #[tokio::test]
+    async fn test_create_run_succeeds_with_valid_data() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let run = create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+
+        assert_eq!(run.user_id, host_id);
+        assert_eq!(run.track_time, 120_000);
+        assert_eq!(run.lap1_time, 40_000);
+        assert_eq!(run.username, "host");
+        assert_eq!(run.drink_type_name, "Test Beer");
+        assert!(!run.disqualified);
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_if_not_participant() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let outsider_id = create_user(&db, "outsider").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let result = create_run(&db, &outsider_id, valid_run_request(&race_id)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_if_duplicate_submission() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+        let result = create_run(&db, &host_id, valid_run_request(&race_id)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_if_session_closed() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        // Close session by having host leave
+        sessions::leave_session(&db, &session_id, &host_id)
+            .await
+            .unwrap();
+
+        let result = create_run(&db, &host_id, valid_run_request(&race_id)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_with_invalid_track_time() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        // Negative time
+        let mut req = valid_run_request(&race_id);
+        req.track_time = -1;
+        assert!(create_run(&db, &host_id, req).await.is_err());
+
+        // Over 10 minutes
+        let mut req = valid_run_request(&race_id);
+        req.track_time = 600_001;
+        assert!(create_run(&db, &host_id, req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_with_invalid_character_id() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let mut req = valid_run_request(&race_id);
+        req.character_id = 999;
+        assert!(create_run(&db, &host_id, req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_with_invalid_drink_type_id() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let mut req = valid_run_request(&race_id);
+        req.drink_type_id = "nonexistent-uuid".to_string();
+        assert!(create_run(&db, &host_id, req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_run_succeeds_for_owner() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let run = create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+        assert!(delete_run(&db, &run.id, &host_id).await.is_ok());
+
+        // Verify it's gone
+        assert!(get_run(&db, &run.id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_run_fails_for_non_owner() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+        let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
+        sessions::join_session(&db, &session_id, &user_id)
+            .await
+            .unwrap();
+
+        let run = create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+        let result = delete_run(&db, &run.id, &user_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_run_fails_if_session_closed() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+        let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
+        sessions::join_session(&db, &session_id, &user_id)
+            .await
+            .unwrap();
+
+        let run = create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+
+        // Close by having everyone leave
+        sessions::leave_session(&db, &session_id, &host_id)
+            .await
+            .ok();
+        sessions::leave_session(&db, &session_id, &user_id)
+            .await
+            .ok();
+
+        // Force-close in case leave order was wrong
+        use crate::entities::sessions as sessions_entity;
+        let s = sessions_entity::Entity::find_by_id(&session_id)
+            .one(&db)
+            .await
+            .unwrap();
+        if let Some(s) = s {
+            let mut active: sessions_entity::ActiveModel = s.into();
+            active.status = Set("closed".to_string());
+            active.update(&db).await.unwrap();
+        }
+
+        let result = delete_run(&db, &run.id, &host_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_runs_filters_by_session_race_id() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (session_id, race1_id) = setup_session_with_race(&db, &host_id).await;
+
+        create_run(&db, &host_id, valid_run_request(&race1_id))
+            .await
+            .unwrap();
+
+        // Create a second race
+        let race2 = sessions::next_track(&db, &session_id, &host_id)
+            .await
+            .unwrap();
+        // Need a second user for race2 since host already submitted for race1
+        // Actually, host can submit for race2 too (different session_race_id)
+        create_run(&db, &host_id, valid_run_request(&race2.id))
+            .await
+            .unwrap();
+
+        let filtered = list_runs(
+            &db,
+            RunFilters {
+                session_race_id: Some(race1_id),
+                user_id: None,
+                track_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_runs_ordered_by_time_ascending() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+        let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
+        sessions::join_session(&db, &session_id, &user_id)
+            .await
+            .unwrap();
+
+        // Host submits slower time
+        let mut slow = valid_run_request(&race_id);
+        slow.track_time = 150_000;
+        create_run(&db, &host_id, slow).await.unwrap();
+
+        // User submits faster time
+        let mut fast = valid_run_request(&race_id);
+        fast.track_time = 100_000;
+        create_run(&db, &user_id, fast).await.unwrap();
+
+        let runs = list_runs(
+            &db,
+            RunFilters {
+                session_race_id: Some(race_id),
+                user_id: None,
+                track_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].track_time, 100_000); // fastest first
+        assert_eq!(runs[1].track_time, 150_000);
+    }
+
+    #[tokio::test]
+    async fn test_get_run_defaults_returns_previous_run_data() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+
+        let defaults = get_run_defaults(&db, &host_id).await.unwrap();
+        assert_eq!(defaults.source, "previous_run");
+        assert_eq!(defaults.character_id, Some(1));
+        assert_eq!(defaults.drink_type_id, Some(test_drink_id()));
+    }
+
+    #[tokio::test]
+    async fn test_get_run_defaults_falls_back_to_preferences() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+
+        // Set preferences on the user
+        let user = users::Entity::find_by_id(&host_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut active: users::ActiveModel = user.into();
+        active.preferred_character_id = Set(Some(1));
+        active.preferred_body_id = Set(Some(1));
+        active.preferred_wheel_id = Set(Some(1));
+        active.preferred_glider_id = Set(Some(1));
+        active.preferred_drink_type_id = Set(Some(test_drink_id()));
+        active.update(&db).await.unwrap();
+
+        let defaults = get_run_defaults(&db, &host_id).await.unwrap();
+        assert_eq!(defaults.source, "preferences");
+        assert_eq!(defaults.character_id, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_get_run_defaults_returns_none_when_no_data() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+
+        let defaults = get_run_defaults(&db, &host_id).await.unwrap();
+        assert_eq!(defaults.source, "none");
+        assert!(defaults.character_id.is_none());
+        assert!(defaults.drink_type_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_submissions_appear_in_session_detail() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        // Before submitting
+        let detail = sessions::get_session_detail(&db, &session_id)
+            .await
+            .unwrap();
+        let current = detail.current_race.unwrap();
+        assert!(current.submissions.is_empty());
+
+        // Submit a run
+        create_run(&db, &host_id, valid_run_request(&race_id))
+            .await
+            .unwrap();
+
+        // After submitting
+        let detail = sessions::get_session_detail(&db, &session_id)
+            .await
+            .unwrap();
+        let current = detail.current_race.unwrap();
+        assert_eq!(current.submissions.len(), 1);
+        assert_eq!(current.submissions[0].username, "host");
+        assert_eq!(current.submissions[0].track_time, 120_000);
+        assert!(!current.submissions[0].disqualified);
+    }
+}

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -139,12 +139,12 @@ pub async fn create_run(
         )));
     }
 
-    // Lap sum should roughly match track_time (backend tolerance: 1s)
+    // Lap times must sum exactly to track_time
     let lap_sum = body.lap1_time + body.lap2_time + body.lap3_time;
-    let diff = (lap_sum - body.track_time).abs();
-    if diff > 1000 {
+    if lap_sum != body.track_time {
+        let diff = (lap_sum - body.track_time).abs();
         return Err(AppError::BadRequest(format!(
-            "Lap times don't match total time (off by {diff}ms, max tolerance 1000ms)"
+            "Lap times must add up to total time (off by {diff}ms)"
         )));
     }
 
@@ -692,7 +692,7 @@ mod tests {
         let host_id = create_user(&db, "host").await;
         let (_, race_id) = setup_session_with_race(&db, &host_id).await;
 
-        // Laps sum to 60000, total is 120000 — off by 60s, way beyond 1s tolerance
+        // Laps sum to 60000 but total is 120000 — must match exactly
         let mut req = valid_run_request(&race_id);
         req.lap1_time = 20_000;
         req.lap2_time = 20_000;

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -303,22 +303,21 @@ pub async fn list_runs(
 ) -> Result<Vec<RunDetail>, AppError> {
     let mut conditions = Vec::new();
     let mut params: Vec<sea_orm::Value> = Vec::new();
-    let mut param_idx = 1;
+
+    let mut add_filter = |column: &str, value: sea_orm::Value| {
+        let idx = params.len() + 1;
+        conditions.push(format!("{column} = ${idx}"));
+        params.push(value);
+    };
 
     if let Some(ref sr_id) = filters.session_race_id {
-        conditions.push(format!("r.session_race_id = ${param_idx}"));
-        params.push(sr_id.clone().into());
-        param_idx += 1;
+        add_filter("r.session_race_id", sr_id.clone().into());
     }
     if let Some(ref uid) = filters.user_id {
-        conditions.push(format!("r.user_id = ${param_idx}"));
-        params.push(uid.clone().into());
-        param_idx += 1;
+        add_filter("r.user_id", uid.clone().into());
     }
     if let Some(tid) = filters.track_id {
-        conditions.push(format!("r.track_id = ${param_idx}"));
-        params.push(tid.into());
-        let _ = param_idx; // suppress unused warning
+        add_filter("r.track_id", tid.into());
     }
 
     let where_clause = if conditions.is_empty() {

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -130,6 +130,23 @@ pub async fn create_run(
             "All lap times must be positive".to_string(),
         ));
     }
+    if body.lap1_time > MAX_TRACK_TIME_MS
+        || body.lap2_time > MAX_TRACK_TIME_MS
+        || body.lap3_time > MAX_TRACK_TIME_MS
+    {
+        return Err(AppError::BadRequest(format!(
+            "Each lap time must be at most {MAX_TRACK_TIME_MS} ms"
+        )));
+    }
+
+    // Lap sum should roughly match track_time (backend tolerance: 1s)
+    let lap_sum = body.lap1_time + body.lap2_time + body.lap3_time;
+    let diff = (lap_sum - body.track_time).abs();
+    if diff > 1000 {
+        return Err(AppError::BadRequest(format!(
+            "Lap times don't match total time (off by {diff}ms, max tolerance 1000ms)"
+        )));
+    }
 
     // Validate session_race exists and belongs to an active session
     let session_race = session_races::Entity::find_by_id(&body.session_race_id)
@@ -322,6 +339,7 @@ pub async fn list_runs(
         JOIN drink_types dt ON r.drink_type_id = dt.id
         {where_clause}
         ORDER BY r.track_time ASC
+        LIMIT 100
         "#
     );
 
@@ -415,7 +433,7 @@ pub async fn get_run_defaults(
         .await?
         .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
 
-    if user.preferred_character_id.is_some() {
+    if user.preferred_character_id.is_some() || user.preferred_drink_type_id.is_some() {
         return Ok(RunDefaults {
             drink_type_id: user.preferred_drink_type_id,
             character_id: user.preferred_character_id,
@@ -659,9 +677,39 @@ mod tests {
         req.track_time = -1;
         assert!(create_run(&db, &host_id, req).await.is_err());
 
-        // Over 10 minutes
+        // Over 10 minutes (also adjust laps to match so we test track_time cap, not lap sum)
         let mut req = valid_run_request(&race_id);
         req.track_time = 600_001;
+        req.lap1_time = 200_000;
+        req.lap2_time = 200_000;
+        req.lap3_time = 200_001;
+        assert!(create_run(&db, &host_id, req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_with_lap_sum_mismatch() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        // Laps sum to 60000, total is 120000 — off by 60s, way beyond 1s tolerance
+        let mut req = valid_run_request(&race_id);
+        req.lap1_time = 20_000;
+        req.lap2_time = 20_000;
+        req.lap3_time = 20_000;
+        assert!(create_run(&db, &host_id, req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_run_fails_with_lap_time_exceeding_max() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_, race_id) = setup_session_with_race(&db, &host_id).await;
+
+        let mut req = valid_run_request(&race_id);
+        req.lap1_time = 600_001;
         assert!(create_run(&db, &host_id, req).await.is_err());
     }
 
@@ -810,11 +858,17 @@ mod tests {
         // Host submits slower time
         let mut slow = valid_run_request(&race_id);
         slow.track_time = 150_000;
+        slow.lap1_time = 50_000;
+        slow.lap2_time = 50_000;
+        slow.lap3_time = 50_000;
         create_run(&db, &host_id, slow).await.unwrap();
 
         // User submits faster time
         let mut fast = valid_run_request(&race_id);
         fast.track_time = 100_000;
+        fast.lap1_time = 33_000;
+        fast.lap2_time = 33_000;
+        fast.lap3_time = 34_000;
         create_run(&db, &user_id, fast).await.unwrap();
 
         let runs = list_runs(

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -184,6 +184,24 @@ struct ParticipantRow {
     left_at: Option<String>,
 }
 
+/// Submission info for a single participant in a race.
+#[derive(serde::Serialize, Clone)]
+pub struct RaceSubmission {
+    pub user_id: String,
+    pub username: String,
+    pub track_time: i32,
+    pub disqualified: bool,
+}
+
+/// Row shape for the submissions query.
+#[derive(Debug, FromQueryResult)]
+struct SubmissionRow {
+    user_id: String,
+    username: String,
+    track_time: i32,
+    disqualified: bool,
+}
+
 /// Info about a single race in the session (returned on create / skip / poll).
 #[derive(serde::Serialize, Clone)]
 pub struct SessionRaceInfo {
@@ -194,6 +212,7 @@ pub struct SessionRaceInfo {
     pub cup_name: String,
     pub image_path: String,
     pub created_at: String,
+    pub submissions: Vec<RaceSubmission>,
 }
 
 /// Race info for the race history list.
@@ -318,6 +337,33 @@ pub async fn get_session_detail(
         .one(db)
         .await?;
 
+    // Fetch submissions for the current race (if any)
+    let submissions = if let Some(ref race_row) = current_race_row {
+        SubmissionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            db.get_database_backend(),
+            r#"
+            SELECT r.user_id, u.username, r.track_time, r.disqualified
+            FROM runs r
+            JOIN users u ON r.user_id = u.id
+            WHERE r.session_race_id = $1
+            ORDER BY r.track_time ASC
+            "#,
+            [race_row.id.clone().into()],
+        ))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|s| RaceSubmission {
+            user_id: s.user_id,
+            username: s.username,
+            track_time: s.track_time,
+            disqualified: s.disqualified,
+        })
+        .collect()
+    } else {
+        Vec::new()
+    };
+
     let current_race = current_race_row.map(|r| SessionRaceInfo {
         id: r.id,
         race_number: r.race_number,
@@ -326,6 +372,7 @@ pub async fn get_session_detail(
         cup_name: r.cup_name,
         image_path: r.image_path,
         created_at: r.created_at,
+        submissions,
     });
 
     // Fetch all races for history (reuses the same query shape as list_races)
@@ -602,6 +649,7 @@ pub async fn next_track(
         cup_name: cup,
         image_path: chosen.image_path.clone(),
         created_at: now,
+        submissions: Vec::new(),
     })
 }
 
@@ -730,6 +778,7 @@ pub async fn skip_turn(
         cup_name: cup,
         image_path: chosen.image_path.clone(),
         created_at: now,
+        submissions: Vec::new(),
     })
 }
 

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -3,6 +3,7 @@ use rand::seq::SliceRandom;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
     FromQueryResult, ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    sea_query::Expr,
 };
 use uuid::Uuid;
 
@@ -12,18 +13,33 @@ use crate::error::AppError;
 /// Allowed rulesets for this PR. Only "random" is supported.
 const VALID_RULESETS: &[&str] = &["random"];
 
-/// Check that the user is not already active in any session. Returns an error
-/// with the existing session ID if they are.
+/// Row shape for the active-participant-in-active-session query.
+#[derive(Debug, FromQueryResult)]
+struct ActiveParticipantRow {
+    session_id: String,
+}
+
+/// Check that the user is not already active in any *active* session.
+/// Returns an error with the existing session ID if they are.
+/// JOINs sessions to ensure closed sessions don't block the user.
 async fn check_not_in_any_session(
     db: &impl ConnectionTrait,
     user_id: &str,
 ) -> Result<(), AppError> {
-    let existing = session_participants::Entity::find()
-        .filter(
-            Condition::all()
-                .add(session_participants::Column::UserId.eq(user_id))
-                .add(session_participants::Column::LeftAt.is_null()),
-        )
+    let existing =
+        ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            db.get_database_backend(),
+            r#"
+            SELECT sp.session_id
+            FROM session_participants sp
+            JOIN sessions s ON sp.session_id = s.id
+            WHERE sp.user_id = $1
+              AND sp.left_at IS NULL
+              AND s.status = 'active'
+            LIMIT 1
+            "#,
+            [user_id.into()],
+        ))
         .one(db)
         .await?;
 
@@ -38,18 +54,26 @@ async fn check_not_in_any_session(
 }
 
 /// Returns the session ID the user is currently active in, or None.
+/// Only considers active sessions (not closed/stale ones).
 pub async fn get_active_session_id(
     db: &DatabaseConnection,
     user_id: &str,
 ) -> Result<Option<String>, AppError> {
-    let row = session_participants::Entity::find()
-        .filter(
-            Condition::all()
-                .add(session_participants::Column::UserId.eq(user_id))
-                .add(session_participants::Column::LeftAt.is_null()),
-        )
-        .one(db)
-        .await?;
+    let row = ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT sp.session_id
+        FROM session_participants sp
+        JOIN sessions s ON sp.session_id = s.id
+        WHERE sp.user_id = $1
+          AND sp.left_at IS NULL
+          AND s.status = 'active'
+        LIMIT 1
+        "#,
+        [user_id.into()],
+    ))
+    .one(db)
+    .await?;
 
     Ok(row.map(|r| r.session_id))
 }
@@ -827,6 +851,8 @@ pub async fn list_races(
 }
 
 /// Close sessions that have had no activity for over an hour.
+/// Also marks all remaining active participants as left, preventing
+/// users from being soft-locked out of creating/joining new sessions.
 /// Returns the number of sessions closed.
 pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppError> {
     let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
@@ -841,9 +867,26 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppErr
         .await?;
 
     let count = stale.len() as u64;
+    let now = Utc::now().to_rfc3339();
 
     let txn = db.begin().await?;
     for session in stale {
+        let session_id = session.id.clone();
+
+        // Mark all still-active participants as left
+        session_participants::Entity::update_many()
+            .col_expr(
+                session_participants::Column::LeftAt,
+                Expr::value(now.clone()),
+            )
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session_id))
+                    .add(session_participants::Column::LeftAt.is_null()),
+            )
+            .exec(&txn)
+            .await?;
+
         let mut active: sessions::ActiveModel = session.into();
         active.status = Set("closed".to_string());
         active.update(&txn).await?;
@@ -1385,5 +1428,38 @@ mod tests {
         for race in &races {
             assert_eq!(race.run_count, 0);
         }
+    }
+
+    #[tokio::test]
+    async fn test_stale_cleanup_marks_participants_as_left() {
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let user_id = create_user(&db, "user").await;
+
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_id).await.unwrap();
+
+        // Backdate last_activity_at past the stale threshold
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+        let s = sessions::Entity::find_by_id(&session.id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut active: sessions::ActiveModel = s.into();
+        active.last_activity_at = Set(two_hours_ago);
+        active.update(&db).await.unwrap();
+
+        close_stale_sessions(&db).await.unwrap();
+
+        // Both users must be able to create a new session after their old one times out
+        assert!(
+            create_session(&db, &host_id, "random").await.is_ok(),
+            "host should be freed from stale session"
+        );
+        assert!(
+            create_session(&db, &user_id, "random").await.is_ok(),
+            "user should be freed from stale session"
+        );
     }
 }

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -1,0 +1,62 @@
+import { apiFetch } from './client'
+import type { CreateRunRequest, RunDetail, RunDefaults } from './types'
+
+export async function createRun(body: CreateRunRequest): Promise<RunDetail> {
+  const res = await apiFetch('/api/v1/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to submit run')
+  }
+  return res.json()
+}
+
+export async function listRuns(params?: {
+  session_race_id?: string
+  user_id?: string
+  track_id?: number
+}): Promise<RunDetail[]> {
+  const query = new URLSearchParams()
+  if (params?.session_race_id) query.set('session_race_id', params.session_race_id)
+  if (params?.user_id) query.set('user_id', params.user_id)
+  if (params?.track_id) query.set('track_id', String(params.track_id))
+  const qs = query.toString()
+  const res = await apiFetch(`/api/v1/runs${qs ? `?${qs}` : ''}`)
+  if (!res.ok) return []
+  return res.json()
+}
+
+export async function getRun(id: string): Promise<RunDetail> {
+  const res = await apiFetch(`/api/v1/runs/${id}`)
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Run not found')
+  }
+  return res.json()
+}
+
+export async function deleteRun(id: string): Promise<void> {
+  const res = await apiFetch(`/api/v1/runs/${id}`, { method: 'DELETE' })
+  if (!res.ok) {
+    const err = await res.json()
+    throw new Error(err.error || 'Failed to delete run')
+  }
+}
+
+export async function getRunDefaults(): Promise<RunDefaults> {
+  const res = await apiFetch('/api/v1/runs/defaults')
+  if (!res.ok) {
+    return {
+      drink_type_id: null,
+      character_id: null,
+      body_id: null,
+      wheel_id: null,
+      glider_id: null,
+      source: 'none',
+    }
+  }
+  return res.json()
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -78,6 +78,13 @@ export interface ParticipantInfo {
   left_at: string | null
 }
 
+export interface RaceSubmission {
+  user_id: string
+  username: string
+  track_time: number
+  disqualified: boolean
+}
+
 export interface SessionRaceInfo {
   id: string
   race_number: number
@@ -86,6 +93,50 @@ export interface SessionRaceInfo {
   cup_name: string
   image_path: string
   created_at: string
+  submissions: RaceSubmission[]
+}
+
+export interface CreateRunRequest {
+  session_race_id: string
+  track_time: number
+  lap1_time: number
+  lap2_time: number
+  lap3_time: number
+  character_id: number
+  body_id: number
+  wheel_id: number
+  glider_id: number
+  drink_type_id: string
+  disqualified: boolean
+}
+
+export interface RunDetail {
+  id: string
+  user_id: string
+  username: string
+  session_race_id: string
+  track_id: number
+  track_time: number
+  lap1_time: number
+  lap2_time: number
+  lap3_time: number
+  character_id: number
+  body_id: number
+  wheel_id: number
+  glider_id: number
+  drink_type_id: string
+  drink_type_name: string
+  disqualified: boolean
+  created_at: string
+}
+
+export interface RunDefaults {
+  drink_type_id: string | null
+  character_id: number | null
+  body_id: number | null
+  wheel_id: number | null
+  glider_id: number | null
+  source: 'previous_run' | 'preferences' | 'none'
 }
 
 export interface RaceInfo {

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -1,7 +1,9 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import type { SessionRaceInfo, CreateRunRequest, RunDefaults, DrinkType } from '../api/types'
 import { createRun, getRunDefaults } from '../api/runs'
 import { parseTimeFields } from '../utils/time'
+import { useDrinkTypes } from '../hooks/useGameData'
+import { useCharacters, useBodies, useWheels, useGliders } from '../hooks/useGameData'
 import DrinkTypeSelector from './DrinkTypeSelector'
 import RaceSetupPicker from './RaceSetupPicker'
 
@@ -40,6 +42,13 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
   const [showDrinkPicker, setShowDrinkPicker] = useState(false)
   const [showSetupPicker, setShowSetupPicker] = useState(false)
 
+  // Load game data for resolving default names
+  const { items: drinkTypes } = useDrinkTypes()
+  const { items: characters } = useCharacters()
+  const { items: bodies } = useBodies()
+  const { items: wheels } = useWheels()
+  const { items: gliders } = useGliders()
+
   // Load defaults on mount
   useEffect(() => {
     getRunDefaults().then((d: RunDefaults) => {
@@ -57,6 +66,28 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
       )
     })
   }, [])
+
+  // Derive drink type object from ID + loaded data (or explicit user pick)
+  const resolvedDrinkType = useMemo(() => {
+    if (drinkType) return drinkType
+    if (drinkTypeId && drinkTypes.length > 0) {
+      return drinkTypes.find((dt) => dt.id === drinkTypeId) ?? null
+    }
+    return null
+  }, [drinkType, drinkTypeId, drinkTypes])
+
+  // Derive setup summary from IDs + loaded game data
+  const setupSummary = useMemo(() => {
+    if (!characterId || !characters.length || !bodies.length || !wheels.length || !gliders.length)
+      return ''
+    const parts = [
+      characters.find((c) => c.id === characterId)?.name,
+      bodies.find((b) => b.id === bodyId)?.name,
+      wheels.find((w) => w.id === wheelId)?.name,
+      gliders.find((g) => g.id === gliderId)?.name,
+    ].filter(Boolean)
+    return parts.length === 4 ? parts.join(' \u00B7 ') : ''
+  }, [characterId, bodyId, wheelId, gliderId, characters, bodies, wheels, gliders])
 
   const parsedTotal = parseTimeFields(totalTime.m, totalTime.ss, totalTime.mmm)
   const parsedLap1 = parseTimeFields(lap1.m, lap1.ss, lap1.mmm)
@@ -200,21 +231,23 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               onClick={() => setShowDrinkPicker(true)}
               className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-gray-50 border border-gray-200 rounded-xl text-left"
             >
-              {drinkType ? (
+              {resolvedDrinkType ? (
                 <div className="flex items-center gap-2.5">
                   <span className="text-base">
-                    {drinkType.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
+                    {resolvedDrinkType.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
                   </span>
-                  <span className="text-[14px] font-medium text-gray-800">{drinkType.name}</span>
+                  <span className="text-[14px] font-medium text-gray-800">
+                    {resolvedDrinkType.name}
+                  </span>
                 </div>
               ) : drinkTypeId ? (
-                <span className="text-[14px] text-gray-500">Drink selected</span>
+                <span className="text-[14px] text-gray-500">Loading...</span>
               ) : (
                 <span className="text-[14px] text-gray-400">Select drink</span>
               )}
               <span className="text-gray-400 text-[12px]">Change</span>
             </button>
-            {defaultsSource && !drinkType && (
+            {defaultsSource && (
               <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
             )}
           </div>
@@ -229,13 +262,15 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-gray-50 border border-gray-200 rounded-xl text-left"
             >
               {hasSetup ? (
-                <span className="text-[13px] font-medium text-gray-800">Setup selected</span>
+                <span className="text-[13px] font-medium text-gray-800">
+                  {setupSummary || 'Setup selected'}
+                </span>
               ) : (
                 <span className="text-[14px] text-gray-400">Select race setup</span>
               )}
               <span className="text-gray-400 text-[12px]">Edit</span>
             </button>
-            {defaultsSource && !hasSetup && (
+            {defaultsSource && (
               <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
             )}
           </div>

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -39,8 +39,11 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const totalMmmRef = useRef<HTMLInputElement>(null)
   const lap1MRef = useRef<HTMLInputElement>(null)
+  const lap1MmmRef = useRef<HTMLInputElement>(null)
   const lap2MRef = useRef<HTMLInputElement>(null)
+  const lap2MmmRef = useRef<HTMLInputElement>(null)
   const lap3MRef = useRef<HTMLInputElement>(null)
 
   const [showDrinkPicker, setShowDrinkPicker] = useState(false)
@@ -190,6 +193,7 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               fields={totalTime}
               setFields={setTotalTime}
               large
+              mmmRef={totalMmmRef}
               onComplete={() => lap1MRef.current?.focus()}
             />
           </div>
@@ -207,7 +211,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
                     fields={lap1}
                     setFields={setLap1}
                     mRef={lap1MRef}
+                    mmmRef={lap1MmmRef}
                     onComplete={() => lap2MRef.current?.focus()}
+                    onBackspace={() => totalMmmRef.current?.focus()}
                   />
                 </div>
               </div>
@@ -218,14 +224,21 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
                     fields={lap2}
                     setFields={setLap2}
                     mRef={lap2MRef}
+                    mmmRef={lap2MmmRef}
                     onComplete={() => lap3MRef.current?.focus()}
+                    onBackspace={() => lap1MmmRef.current?.focus()}
                   />
                 </div>
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L3</span>
                 <div className="flex-1">
-                  <TimeInputGroup fields={lap3} setFields={setLap3} mRef={lap3MRef} />
+                  <TimeInputGroup
+                    fields={lap3}
+                    setFields={setLap3}
+                    mRef={lap3MRef}
+                    onBackspace={() => lap2MmmRef.current?.focus()}
+                  />
                 </div>
               </div>
             </div>
@@ -378,12 +391,25 @@ interface TimeInputGroupProps {
   setFields: React.Dispatch<React.SetStateAction<TimeFields>>
   large?: boolean
   mRef?: React.RefObject<HTMLInputElement | null>
+  mmmRef?: React.RefObject<HTMLInputElement | null>
   onComplete?: () => void
+  onBackspace?: () => void
 }
 
-function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInputGroupProps) {
+function TimeInputGroup({
+  fields,
+  setFields,
+  large,
+  mRef,
+  mmmRef: extMmmRef,
+  onComplete,
+  onBackspace,
+}: TimeInputGroupProps) {
+  const fallbackMRef = useRef<HTMLInputElement>(null)
   const ssRef = useRef<HTMLInputElement>(null)
-  const mmmRef = useRef<HTMLInputElement>(null)
+  const fallbackMmmRef = useRef<HTMLInputElement>(null)
+  const resolvedMRef = mRef ?? fallbackMRef
+  const resolvedMmmRef = extMmmRef ?? fallbackMmmRef
 
   const inputClass = large
     ? 'h-12 text-center text-xl font-mono bg-gray-100 rounded-xl border border-gray-300 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200'
@@ -399,8 +425,19 @@ function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInpu
       setFields((prev) => ({ ...prev, [field]: val }))
       if (val.length === maxLen) {
         if (field === 'm') ssRef.current?.focus()
-        else if (field === 'ss') mmmRef.current?.focus()
+        else if (field === 'ss') resolvedMmmRef.current?.focus()
         else if (field === 'mmm') onComplete?.()
+      }
+    }
+  }
+
+  const handleKeyDown = (field: 'm' | 'ss' | 'mmm') => {
+    return (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Backspace' && e.currentTarget.value === '') {
+        e.preventDefault()
+        if (field === 'mmm') ssRef.current?.focus()
+        else if (field === 'ss') resolvedMRef.current?.focus()
+        else if (field === 'm') onBackspace?.()
       }
     }
   }
@@ -408,10 +445,11 @@ function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInpu
   return (
     <div className="flex items-center gap-1.5 justify-center">
       <input
-        ref={mRef}
+        ref={resolvedMRef}
         className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
         value={fields.m}
         onChange={handleChange('m', 1)}
+        onKeyDown={handleKeyDown('m')}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="M"
@@ -423,6 +461,7 @@ function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInpu
         className={`${inputClass} ${large ? 'w-16' : 'w-12'}`}
         value={fields.ss}
         onChange={handleChange('ss', 2)}
+        onKeyDown={handleKeyDown('ss')}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="SS"
@@ -430,10 +469,11 @@ function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInpu
       />
       <span className={sepClass}>.</span>
       <input
-        ref={mmmRef}
+        ref={resolvedMmmRef}
         className={`${inputClass} ${large ? 'w-[72px]' : 'w-14'}`}
         value={fields.mmm}
         onChange={handleChange('mmm', 3)}
+        onKeyDown={handleKeyDown('mmm')}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="mmm"

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -109,7 +109,7 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
       ? parsedLap1 + parsedLap2 + parsedLap3
       : null
   const sumDiff = lapSum !== null && parsedTotal !== null ? Math.abs(lapSum - parsedTotal) : null
-  const showSumWarning = sumDiff !== null && sumDiff > 50
+  const showSumWarning = sumDiff !== null && sumDiff > 0
 
   const handleSubmit = async () => {
     if (

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -351,13 +351,13 @@ function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
   return (
     <div className="flex items-center gap-1.5 justify-center">
       <input
-        className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
+        className={`${inputClass} ${large ? 'w-14' : 'w-12'}`}
         value={fields.m}
-        onChange={handleChange('m', 1)}
+        onChange={handleChange('m', 2)}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="M"
-        maxLength={1}
+        maxLength={2}
       />
       <span className={sepClass}>:</span>
       <input

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -1,0 +1,491 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { SessionRaceInfo, CreateRunRequest, RunDefaults, DrinkType } from '../api/types'
+import { createRun, getRunDefaults } from '../api/runs'
+import { parseTimeFields } from '../utils/time'
+import DrinkTypeSelector from './DrinkTypeSelector'
+import RaceSetupPicker from './RaceSetupPicker'
+
+interface TimeFields {
+  m: string
+  ss: string
+  mmm: string
+}
+
+const emptyTime: TimeFields = { m: '', ss: '', mmm: '' }
+
+interface RunEntrySheetProps {
+  race: SessionRaceInfo
+  onClose: () => void
+  onSubmitted: () => void
+}
+
+export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySheetProps) {
+  const [totalTime, setTotalTime] = useState<TimeFields>(emptyTime)
+  const [lap1, setLap1] = useState<TimeFields>(emptyTime)
+  const [lap2, setLap2] = useState<TimeFields>(emptyTime)
+  const [lap3, setLap3] = useState<TimeFields>(emptyTime)
+
+  const [drinkTypeId, setDrinkTypeId] = useState<string | null>(null)
+  const [drinkType, setDrinkType] = useState<DrinkType | null>(null)
+  const [characterId, setCharacterId] = useState<number | null>(null)
+  const [bodyId, setBodyId] = useState<number | null>(null)
+  const [wheelId, setWheelId] = useState<number | null>(null)
+  const [gliderId, setGliderId] = useState<number | null>(null)
+  const [defaultsSource, setDefaultsSource] = useState<string>('')
+
+  const [dq, setDq] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [showDrinkPicker, setShowDrinkPicker] = useState(false)
+  const [showSetupPicker, setShowSetupPicker] = useState(false)
+
+  // Load defaults on mount
+  useEffect(() => {
+    getRunDefaults().then((d: RunDefaults) => {
+      setDrinkTypeId(d.drink_type_id)
+      setCharacterId(d.character_id)
+      setBodyId(d.body_id)
+      setWheelId(d.wheel_id)
+      setGliderId(d.glider_id)
+      setDefaultsSource(
+        d.source === 'previous_run'
+          ? 'From your last run'
+          : d.source === 'preferences'
+            ? 'From your preferences'
+            : '',
+      )
+    })
+  }, [])
+
+  const parsedTotal = parseTimeFields(totalTime.m, totalTime.ss, totalTime.mmm)
+  const parsedLap1 = parseTimeFields(lap1.m, lap1.ss, lap1.mmm)
+  const parsedLap2 = parseTimeFields(lap2.m, lap2.ss, lap2.mmm)
+  const parsedLap3 = parseTimeFields(lap3.m, lap3.ss, lap3.mmm)
+
+  const allTimesFilled =
+    parsedTotal !== null && parsedLap1 !== null && parsedLap2 !== null && parsedLap3 !== null
+  const hasSetup = characterId !== null && bodyId !== null && wheelId !== null && gliderId !== null
+  const canSubmit = allTimesFilled && drinkTypeId !== null && hasSetup && !submitting
+
+  // Lap sum warning
+  const lapSum =
+    parsedLap1 !== null && parsedLap2 !== null && parsedLap3 !== null
+      ? parsedLap1 + parsedLap2 + parsedLap3
+      : null
+  const sumDiff = lapSum !== null && parsedTotal !== null ? Math.abs(lapSum - parsedTotal) : null
+  const showSumWarning = sumDiff !== null && sumDiff > 50
+
+  const handleSubmit = async () => {
+    if (
+      !canSubmit ||
+      parsedTotal === null ||
+      parsedLap1 === null ||
+      parsedLap2 === null ||
+      parsedLap3 === null ||
+      drinkTypeId === null ||
+      characterId === null ||
+      bodyId === null ||
+      wheelId === null ||
+      gliderId === null
+    )
+      return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const body: CreateRunRequest = {
+        session_race_id: race.id,
+        track_time: parsedTotal,
+        lap1_time: parsedLap1,
+        lap2_time: parsedLap2,
+        lap3_time: parsedLap3,
+        character_id: characterId,
+        body_id: bodyId,
+        wheel_id: wheelId,
+        glider_id: gliderId,
+        drink_type_id: drinkTypeId,
+        disqualified: dq,
+      }
+      await createRun(body)
+      onSubmitted()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to submit run')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-30 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+
+      <div
+        className="relative bg-white rounded-t-2xl shadow-2xl flex flex-col"
+        style={{ maxHeight: '92%' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-center pt-2.5 pb-1">
+          <div className="w-9 h-1 bg-gray-300 rounded-full" />
+        </div>
+
+        <div className="overflow-y-auto px-4 pb-8 flex-1">
+          {/* Track header */}
+          <div className="flex items-center gap-3 mb-5 mt-1">
+            <img
+              src={`/${race.image_path}`}
+              alt={race.track_name}
+              className="w-10 h-10 rounded-lg object-contain bg-gray-100 flex-shrink-0"
+              onError={(e) => {
+                ;(e.target as HTMLImageElement).style.display = 'none'
+              }}
+            />
+            <div>
+              <div className="font-semibold text-gray-900 text-[14px]">{race.track_name}</div>
+              <div className="text-[12px] text-gray-500">
+                {race.cup_name} &middot; Race {race.race_number}
+              </div>
+            </div>
+          </div>
+
+          {/* Total Time */}
+          <div className="mb-4">
+            <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Total Time
+            </label>
+            <TimeInputGroup fields={totalTime} setFields={setTotalTime} large />
+          </div>
+
+          {/* Lap Times */}
+          <div className="mb-5">
+            <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Lap Times
+            </label>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L1</span>
+                <div className="flex-1">
+                  <TimeInputGroup fields={lap1} setFields={setLap1} />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L2</span>
+                <div className="flex-1">
+                  <TimeInputGroup fields={lap2} setFields={setLap2} />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L3</span>
+                <div className="flex-1">
+                  <TimeInputGroup fields={lap3} setFields={setLap3} />
+                </div>
+              </div>
+            </div>
+            {showSumWarning && sumDiff !== null && (
+              <p className="text-[10px] text-amber-600 mt-1.5 text-center">
+                Lap times don&apos;t add up to total (off by {(sumDiff / 1000).toFixed(3)}s)
+              </p>
+            )}
+            {!showSumWarning && allTimesFilled && (
+              <p className="text-[10px] text-gray-400 mt-1.5 text-center">
+                Lap times should add up to total time
+              </p>
+            )}
+          </div>
+
+          {/* Drink */}
+          <div className="mb-4">
+            <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Drink
+            </label>
+            <button
+              onClick={() => setShowDrinkPicker(true)}
+              className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-gray-50 border border-gray-200 rounded-xl text-left"
+            >
+              {drinkType ? (
+                <div className="flex items-center gap-2.5">
+                  <span className="text-base">
+                    {drinkType.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
+                  </span>
+                  <span className="text-[14px] font-medium text-gray-800">{drinkType.name}</span>
+                </div>
+              ) : drinkTypeId ? (
+                <span className="text-[14px] text-gray-500">Drink selected</span>
+              ) : (
+                <span className="text-[14px] text-gray-400">Select drink</span>
+              )}
+              <span className="text-gray-400 text-[12px]">Change</span>
+            </button>
+            {defaultsSource && !drinkType && (
+              <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
+            )}
+          </div>
+
+          {/* Race Setup */}
+          <div className="mb-4">
+            <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Race Setup
+            </label>
+            <button
+              onClick={() => setShowSetupPicker(true)}
+              className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-gray-50 border border-gray-200 rounded-xl text-left"
+            >
+              {hasSetup ? (
+                <span className="text-[13px] font-medium text-gray-800">Setup selected</span>
+              ) : (
+                <span className="text-[14px] text-gray-400">Select race setup</span>
+              )}
+              <span className="text-gray-400 text-[12px]">Edit</span>
+            </button>
+            {defaultsSource && !hasSetup && (
+              <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
+            )}
+          </div>
+
+          {/* DQ */}
+          <div className="mb-6">
+            <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Didn&apos;t finish drink?
+            </label>
+            <SlideToConfirm
+              key={dq ? 'dq' : 'no-dq'}
+              confirmed={dq}
+              onConfirm={() => setDq(true)}
+              onReset={() => setDq(false)}
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-500 text-center mb-3">{error}</p>}
+
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="w-full py-4 bg-blue-600 text-white font-semibold rounded-2xl text-[15px] shadow-sm active:scale-[0.98] transition-transform disabled:opacity-50 disabled:active:scale-100"
+          >
+            {submitting ? 'Submitting...' : 'Submit Run'}
+          </button>
+        </div>
+      </div>
+
+      {showDrinkPicker && (
+        <div className="fixed inset-0 z-50 bg-white flex flex-col">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+            <button onClick={() => setShowDrinkPicker(false)} className="text-sm text-blue-500">
+              Back
+            </button>
+            <h2 className="text-sm font-semibold text-gray-900">Select Drink</h2>
+            <div className="w-10" />
+          </div>
+          <div className="flex-1 overflow-y-auto p-4">
+            <DrinkTypeSelector
+              selectedId={drinkTypeId}
+              onSelect={(dt: DrinkType) => {
+                setDrinkTypeId(dt.id)
+                setDrinkType(dt)
+                setShowDrinkPicker(false)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {showSetupPicker && (
+        <div className="fixed inset-0 z-50 bg-white flex flex-col">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+            <button onClick={() => setShowSetupPicker(false)} className="text-sm text-blue-500">
+              Back
+            </button>
+            <h2 className="text-sm font-semibold text-gray-900">Race Setup</h2>
+            <div className="w-10" />
+          </div>
+          <div className="flex-1 overflow-y-auto p-4">
+            <RaceSetupPicker
+              initialCharacterId={characterId}
+              initialBodyId={bodyId}
+              initialWheelId={wheelId}
+              initialGliderId={gliderId}
+              onComplete={(setup) => {
+                setCharacterId(setup.characterId)
+                setBodyId(setup.bodyId)
+                setWheelId(setup.wheelId)
+                setGliderId(setup.gliderId)
+                setShowSetupPicker(false)
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Time Input Group (self-contained with auto-advance) ─────────────
+
+interface TimeInputGroupProps {
+  fields: TimeFields
+  setFields: React.Dispatch<React.SetStateAction<TimeFields>>
+  large?: boolean
+}
+
+function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
+  const ssRef = useRef<HTMLInputElement>(null)
+  const mmmRef = useRef<HTMLInputElement>(null)
+
+  const inputClass = large
+    ? 'h-12 text-center text-xl font-mono bg-gray-100 rounded-xl border border-gray-300 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200'
+    : 'h-10 text-center text-[15px] font-mono bg-gray-50 rounded-lg border border-gray-200 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200'
+  const sepClass = large
+    ? 'text-xl font-mono text-gray-400 font-bold'
+    : 'text-[15px] font-mono text-gray-300 font-bold'
+
+  const handleChange = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value.replace(/\D/g, '')
+      if (val.length > maxLen) return
+      setFields((prev) => ({ ...prev, [field]: val }))
+      if (val.length === maxLen) {
+        if (field === 'm') ssRef.current?.focus()
+        else if (field === 'ss') mmmRef.current?.focus()
+      }
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 justify-center">
+      <input
+        className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
+        value={fields.m}
+        onChange={handleChange('m', 1)}
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="M"
+        maxLength={1}
+      />
+      <span className={sepClass}>:</span>
+      <input
+        ref={ssRef}
+        className={`${inputClass} ${large ? 'w-16' : 'w-12'}`}
+        value={fields.ss}
+        onChange={handleChange('ss', 2)}
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="SS"
+        maxLength={2}
+      />
+      <span className={sepClass}>.</span>
+      <input
+        ref={mmmRef}
+        className={`${inputClass} ${large ? 'w-[72px]' : 'w-14'}`}
+        value={fields.mmm}
+        onChange={handleChange('mmm', 3)}
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="mmm"
+        maxLength={3}
+      />
+    </div>
+  )
+}
+
+// ── Slide to Confirm DQ ─────────────────────────────────────────────
+
+interface SlideToConfirmProps {
+  confirmed: boolean
+  onConfirm: () => void
+  onReset: () => void
+}
+
+function SlideToConfirm({ confirmed, onConfirm, onReset }: SlideToConfirmProps) {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const [offsetX, setOffsetX] = useState(0)
+  const [trackWidth, setTrackWidth] = useState(280)
+  const thumbW = 44
+
+  // Measure track width after mount and on resize
+  useEffect(() => {
+    const measure = () => {
+      if (trackRef.current) setTrackWidth(trackRef.current.offsetWidth)
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [])
+
+  const handleMove = useCallback(
+    (clientX: number) => {
+      if (!dragging || confirmed || !trackRef.current) return
+      const rect = trackRef.current.getBoundingClientRect()
+      const x = Math.min(Math.max(0, clientX - rect.left - thumbW / 2), trackWidth - thumbW)
+      setOffsetX(x)
+    },
+    [dragging, confirmed, trackWidth],
+  )
+
+  const handleEnd = useCallback(() => {
+    if (!dragging) return
+    setDragging(false)
+    const threshold = trackWidth - thumbW - 4
+    if (offsetX >= threshold) {
+      setOffsetX(trackWidth - thumbW)
+      onConfirm()
+    } else {
+      setOffsetX(0)
+    }
+  }, [dragging, offsetX, onConfirm, trackWidth])
+
+  if (confirmed) {
+    return (
+      <button
+        onClick={onReset}
+        className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-red-50 border border-red-200 rounded-xl text-left"
+      >
+        <div>
+          <div className="text-[14px] font-semibold text-red-700">Disqualified</div>
+          <div className="text-[11px] text-red-400 mt-0.5">
+            Excluded from leaderboards &middot; Tap to undo
+          </div>
+        </div>
+        <span className="text-red-400 text-[18px]">{'\u2715'}</span>
+      </button>
+    )
+  }
+
+  const progress = Math.min(offsetX / (trackWidth - thumbW || 1), 1)
+
+  return (
+    <div
+      ref={trackRef}
+      className="relative w-full h-12 rounded-xl bg-gray-100 border border-gray-200 overflow-hidden select-none touch-none"
+      onMouseMove={(e) => handleMove(e.clientX)}
+      onMouseUp={handleEnd}
+      onMouseLeave={handleEnd}
+      onTouchMove={(e) => handleMove(e.touches[0].clientX)}
+      onTouchEnd={handleEnd}
+    >
+      <div
+        className="absolute inset-0 flex items-center justify-center pointer-events-none"
+        style={{ opacity: 1 - progress * 1.5 }}
+      >
+        <span className="text-[13px] font-medium text-gray-400 tracking-wide">
+          Slide to DQ &rarr;
+        </span>
+      </div>
+      <div
+        className="absolute top-1 h-10 rounded-lg bg-red-500 shadow-md flex items-center justify-center cursor-grab active:cursor-grabbing"
+        style={{
+          width: thumbW,
+          left: offsetX + 4,
+          transition: dragging ? 'none' : 'left 0.25s ease',
+        }}
+        onMouseDown={(e) => {
+          e.preventDefault()
+          if (!confirmed) setDragging(true)
+        }}
+        onTouchStart={() => {
+          if (!confirmed) setDragging(true)
+        }}
+      >
+        <span className="text-white text-[16px] font-bold">&raquo;</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -39,6 +39,10 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const lap1MRef = useRef<HTMLInputElement>(null)
+  const lap2MRef = useRef<HTMLInputElement>(null)
+  const lap3MRef = useRef<HTMLInputElement>(null)
+
   const [showDrinkPicker, setShowDrinkPicker] = useState(false)
   const [showSetupPicker, setShowSetupPicker] = useState(false)
 
@@ -182,7 +186,12 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
             <label className="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-2">
               Total Time
             </label>
-            <TimeInputGroup fields={totalTime} setFields={setTotalTime} large />
+            <TimeInputGroup
+              fields={totalTime}
+              setFields={setTotalTime}
+              large
+              onComplete={() => lap1MRef.current?.focus()}
+            />
           </div>
 
           {/* Lap Times */}
@@ -194,19 +203,29 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L1</span>
                 <div className="flex-1">
-                  <TimeInputGroup fields={lap1} setFields={setLap1} />
+                  <TimeInputGroup
+                    fields={lap1}
+                    setFields={setLap1}
+                    mRef={lap1MRef}
+                    onComplete={() => lap2MRef.current?.focus()}
+                  />
                 </div>
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L2</span>
                 <div className="flex-1">
-                  <TimeInputGroup fields={lap2} setFields={setLap2} />
+                  <TimeInputGroup
+                    fields={lap2}
+                    setFields={setLap2}
+                    mRef={lap2MRef}
+                    onComplete={() => lap3MRef.current?.focus()}
+                  />
                 </div>
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L3</span>
                 <div className="flex-1">
-                  <TimeInputGroup fields={lap3} setFields={setLap3} />
+                  <TimeInputGroup fields={lap3} setFields={setLap3} mRef={lap3MRef} />
                 </div>
               </div>
             </div>
@@ -358,9 +377,11 @@ interface TimeInputGroupProps {
   fields: TimeFields
   setFields: React.Dispatch<React.SetStateAction<TimeFields>>
   large?: boolean
+  mRef?: React.RefObject<HTMLInputElement | null>
+  onComplete?: () => void
 }
 
-function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
+function TimeInputGroup({ fields, setFields, large, mRef, onComplete }: TimeInputGroupProps) {
   const ssRef = useRef<HTMLInputElement>(null)
   const mmmRef = useRef<HTMLInputElement>(null)
 
@@ -379,6 +400,7 @@ function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
       if (val.length === maxLen) {
         if (field === 'm') ssRef.current?.focus()
         else if (field === 'ss') mmmRef.current?.focus()
+        else if (field === 'mmm') onComplete?.()
       }
     }
   }
@@ -386,6 +408,7 @@ function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
   return (
     <div className="flex items-center gap-1.5 justify-center">
       <input
+        ref={mRef}
         className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
         value={fields.m}
         onChange={handleChange('m', 1)}

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -421,7 +421,13 @@ function TimeInputGroup({
   const handleChange = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
       const val = e.target.value.replace(/\D/g, '')
-      if (val.length > maxLen) return
+      if (val.length > maxLen) {
+        // Field is full — advance focus without changing the value
+        if (field === 'm') ssRef.current?.focus()
+        else if (field === 'ss') resolvedMmmRef.current?.focus()
+        else if (field === 'mmm') onComplete?.()
+        return
+      }
       setFields((prev) => ({ ...prev, [field]: val }))
       if (val.length === maxLen) {
         if (field === 'm') ssRef.current?.focus()

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -421,13 +421,7 @@ function TimeInputGroup({
   const handleChange = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
       const val = e.target.value.replace(/\D/g, '')
-      if (val.length > maxLen) {
-        // Field is full — advance focus without changing the value
-        if (field === 'm') ssRef.current?.focus()
-        else if (field === 'ss') resolvedMmmRef.current?.focus()
-        else if (field === 'mmm') onComplete?.()
-        return
-      }
+      if (val.length > maxLen) return
       setFields((prev) => ({ ...prev, [field]: val }))
       if (val.length === maxLen) {
         if (field === 'm') ssRef.current?.focus()
@@ -437,13 +431,22 @@ function TimeInputGroup({
     }
   }
 
-  const handleKeyDown = (field: 'm' | 'ss' | 'mmm') => {
+  const advanceFrom = (field: 'm' | 'ss' | 'mmm') => {
+    if (field === 'm') ssRef.current?.focus()
+    else if (field === 'ss') resolvedMmmRef.current?.focus()
+    else if (field === 'mmm') onComplete?.()
+  }
+
+  const handleKeyDown = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
     return (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Backspace' && e.currentTarget.value === '') {
         e.preventDefault()
         if (field === 'mmm') ssRef.current?.focus()
         else if (field === 'ss') resolvedMRef.current?.focus()
         else if (field === 'm') onBackspace?.()
+      } else if (/^[0-9]$/.test(e.key) && e.currentTarget.value.length >= maxLen) {
+        // Field is full and user typed a digit — advance focus
+        advanceFrom(field)
       }
     }
   }
@@ -455,7 +458,7 @@ function TimeInputGroup({
         className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
         value={fields.m}
         onChange={handleChange('m', 1)}
-        onKeyDown={handleKeyDown('m')}
+        onKeyDown={handleKeyDown('m', 1)}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="M"
@@ -467,7 +470,7 @@ function TimeInputGroup({
         className={`${inputClass} ${large ? 'w-16' : 'w-12'}`}
         value={fields.ss}
         onChange={handleChange('ss', 2)}
-        onKeyDown={handleKeyDown('ss')}
+        onKeyDown={handleKeyDown('ss', 2)}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="SS"
@@ -479,7 +482,7 @@ function TimeInputGroup({
         className={`${inputClass} ${large ? 'w-[72px]' : 'w-14'}`}
         value={fields.mmm}
         onChange={handleChange('mmm', 3)}
-        onKeyDown={handleKeyDown('mmm')}
+        onKeyDown={handleKeyDown('mmm', 3)}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="mmm"

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -386,13 +386,13 @@ function TimeInputGroup({ fields, setFields, large }: TimeInputGroupProps) {
   return (
     <div className="flex items-center gap-1.5 justify-center">
       <input
-        className={`${inputClass} ${large ? 'w-14' : 'w-12'}`}
+        className={`${inputClass} ${large ? 'w-14' : 'w-10'}`}
         value={fields.m}
-        onChange={handleChange('m', 2)}
+        onChange={handleChange('m', 1)}
         inputMode="numeric"
         pattern="[0-9]*"
         placeholder="M"
-        maxLength={2}
+        maxLength={1}
       />
       <span className={sepClass}>:</span>
       <input

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSession } from '../hooks/useSession'
 import { joinSession, leaveSession, nextTrack, skipTurn } from '../api/sessions'
+import { formatTime } from '../utils/time'
+import RunEntrySheet from '../components/RunEntrySheet'
 import BottomNav from '../components/BottomNav'
 
 export default function Session() {
@@ -19,6 +21,7 @@ export default function Session() {
   const [trackError, setTrackError] = useState<string | null>(null)
   const [historyExpanded, setHistoryExpanded] = useState(true)
   const [trackImageError, setTrackImageError] = useState(false)
+  const [showRunEntry, setShowRunEntry] = useState(false)
 
   const handleLeave = async () => {
     setLeaving(true)
@@ -108,8 +111,12 @@ export default function Session() {
   const isParticipant = activeParticipants.some((p) => p.user_id === user?.id)
   const isHost = user?.id === session.host_id
   const currentRace = session.current_race
-  // Past races = all except the most recent (current), shown newest-first
   const pastRaces = [...session.races].reverse().filter((r) => r.id !== currentRace?.id)
+
+  // Submission status
+  const submissions = currentRace?.submissions ?? []
+  const mySubmission = submissions.find((s) => s.user_id === user?.id)
+  const hasSubmitted = !!mySubmission
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -133,7 +140,6 @@ export default function Session() {
           </div>
         </button>
 
-        {/* Expanded participant list */}
         {headerExpanded && (
           <div className="px-4 pb-3 border-t border-gray-100 pt-2 space-y-1.5">
             {activeParticipants.map((p) => (
@@ -153,9 +159,7 @@ export default function Session() {
       {/* Zone 2 — Track Card */}
       <div className="px-4 pt-4">
         {currentRace ? (
-          /* Active race — show track image and info */
           <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-            {/* Track image */}
             {trackImageError ? (
               <div className="h-40 bg-gray-100 flex items-center justify-center">
                 <span className="text-4xl">{'\uD83C\uDFCE\uFE0F'}</span>
@@ -168,7 +172,6 @@ export default function Session() {
                 onError={() => setTrackImageError(true)}
               />
             )}
-            {/* Track info */}
             <div className="px-4 py-3">
               <div className="flex items-center justify-between">
                 <h2 className="text-lg font-bold text-gray-900">{currentRace.track_name}</h2>
@@ -180,7 +183,6 @@ export default function Session() {
             </div>
           </div>
         ) : (
-          /* No race yet — waiting state */
           <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
             <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-lg flex items-center justify-center">
               <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
@@ -199,7 +201,6 @@ export default function Session() {
         {/* Track controls */}
         {isParticipant && (
           <div className="space-y-2">
-            {/* Next Track — host only */}
             {isHost && (
               <button
                 onClick={handleNextTrack}
@@ -209,7 +210,6 @@ export default function Session() {
                 {pickingTrack ? 'Picking track...' : 'Next Track'}
               </button>
             )}
-            {/* Skip Track — any participant */}
             {currentRace && (
               <button
                 onClick={handleSkipTrack}
@@ -223,23 +223,79 @@ export default function Session() {
           </div>
         )}
 
-        {/* Participant cards */}
+        {/* Submit Time / Your Time */}
+        {isParticipant && currentRace && (
+          <>
+            {hasSubmitted ? (
+              <div
+                className={`rounded-xl border p-4 text-center ${
+                  mySubmission.disqualified
+                    ? 'bg-red-50 border-red-200'
+                    : 'bg-green-50 border-green-200'
+                }`}
+              >
+                <p
+                  className={`text-xs font-semibold uppercase tracking-wider mb-1 ${
+                    mySubmission.disqualified ? 'text-red-500' : 'text-green-600'
+                  }`}
+                >
+                  {mySubmission.disqualified ? 'Your Time (DQ)' : 'Your Time'}
+                </p>
+                <p
+                  className={`text-2xl font-mono font-bold ${
+                    mySubmission.disqualified ? 'text-red-600 line-through' : 'text-green-700'
+                  }`}
+                >
+                  {formatTime(mySubmission.track_time)}
+                </p>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowRunEntry(true)}
+                className="w-full py-3 text-sm font-semibold text-white bg-blue-500 rounded-xl active:bg-blue-600 transition-colors"
+              >
+                Submit Time
+              </button>
+            )}
+          </>
+        )}
+
+        {/* Participant cards — submission-aware */}
         <div>
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1 mb-2">
             Players
           </h3>
           <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
-            {activeParticipants.map((p) => (
-              <div key={p.user_id} className="px-4 py-3 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  {p.user_id === session.host_id && (
-                    <span className="text-xs">{'\uD83C\uDFE0'}</span>
+            {activeParticipants.map((p) => {
+              const sub = submissions.find((s) => s.user_id === p.user_id)
+              return (
+                <div key={p.user_id} className="px-4 py-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {p.user_id === session.host_id && (
+                      <span className="text-xs">{'\uD83C\uDFE0'}</span>
+                    )}
+                    <span className="text-sm font-medium text-gray-900">{p.username}</span>
+                  </div>
+                  {currentRace ? (
+                    sub ? (
+                      sub.disqualified ? (
+                        <span className="text-xs font-medium text-red-500">
+                          DQ {formatTime(sub.track_time)}
+                        </span>
+                      ) : (
+                        <span className="text-xs font-medium text-green-600">
+                          {'\u2705'} {formatTime(sub.track_time)}
+                        </span>
+                      )
+                    ) : (
+                      <span className="text-xs text-gray-400">{'\u23F3'} Racing...</span>
+                    )
+                  ) : (
+                    <span className="text-xs text-gray-400">{'\u23F3'} waiting</span>
                   )}
-                  <span className="text-sm font-medium text-gray-900">{p.username}</span>
                 </div>
-                <span className="text-xs text-gray-400">{'\u23F3'} waiting</span>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
 
@@ -289,7 +345,6 @@ export default function Session() {
         </div>
 
         {isParticipant ? (
-          /* Leave button — only shown to participants */
           <button
             onClick={handleLeave}
             disabled={leaving}
@@ -298,7 +353,6 @@ export default function Session() {
             {leaving ? 'Leaving...' : 'Leave Session'}
           </button>
         ) : (
-          /* Join button — shown to non-participants */
           <div className="space-y-2">
             <button
               onClick={handleJoin}
@@ -313,6 +367,15 @@ export default function Session() {
       </div>
 
       <BottomNav />
+
+      {/* Run entry bottom sheet */}
+      {showRunEntry && currentRace && (
+        <RunEntrySheet
+          race={currentRace}
+          onClose={() => setShowRunEntry(false)}
+          onSubmitted={() => setShowRunEntry(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,17 @@
+/** Format milliseconds as M:SS.mmm (no leading zero on minutes). */
+export function formatTime(ms: number): string {
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  const millis = ms % 1000
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`
+}
+
+/** Parse M, SS, mmm fields into total milliseconds. Returns null if invalid. */
+export function parseTimeFields(m: string, ss: string, mmm: string): number | null {
+  const mins = parseInt(m, 10)
+  const secs = parseInt(ss, 10)
+  const ms = parseInt(mmm, 10)
+  if (isNaN(mins) || isNaN(secs) || isNaN(ms)) return null
+  if (secs > 59 || ms > 999 || mins < 0 || secs < 0 || ms < 0) return null
+  return mins * 60000 + secs * 1000 + ms
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,5 +1,6 @@
 /** Format milliseconds as M:SS.mmm (no leading zero on minutes). */
 export function formatTime(ms: number): string {
+  if (ms < 0) return '\u2014'
   const minutes = Math.floor(ms / 60000)
   const seconds = Math.floor((ms % 60000) / 1000)
   const millis = ms % 1000


### PR DESCRIPTION
## Summary

This PR makes the game **playable**. Players can now submit race times, see each other's results in real-time, and the core gameplay loop is complete.

- **Backend: Run CRUD** — New `services/runs.rs` with 5 service functions (`create_run`, `get_run`, `list_runs`, `delete_run`, `get_run_defaults`) and `routes/runs.rs` with 5 endpoints. Full validation: session must be active, user must be participant, no duplicate submissions (enforced by UNIQUE constraint), FK validation for all game data IDs, time range checks, lap times must sum exactly to total time.
- **Backend: Defaults cascade** — `GET /runs/defaults` returns pre-fill data: previous run > user preferences (including drink-only) > empty. Includes a `source` field so the UI shows where defaults came from.
- **Backend: Submission polling** — `SessionRaceInfo` now includes a `submissions` array populated via JOIN. Clients see who has submitted in real-time.
- **Backend: Stale session fix** — `close_stale_sessions` now sets `left_at` on all active participants before closing, preventing users from being soft-locked. `check_not_in_any_session` and `get_active_session_id` now JOIN sessions to filter by `status='active'` as defense-in-depth.
- **Frontend: RunEntrySheet** — Bottom sheet with: M:SS.mmm time inputs (single-digit minutes), full bidirectional navigation (auto-advance forward through all 12 fields: total → L1 → L2 → L3; backspace on empty field moves backward), exact lap sum validation, DrinkTypeSelector/RaceSetupPicker as overlay wrappers, slide-to-confirm DQ toggle, defaults resolve to full names via `useMemo`, submit with error handling.
- **Frontend: Session page** — Submission-aware player cards (green check + time, red DQ, hourglass "Racing..."). "Submit Time" button / "Your Time" display.
- **Migration** — `UNIQUE(session_race_id, user_id)` on runs table to prevent duplicate submissions at the DB level.
- **19 new backend tests** covering run CRUD, validation (time ranges, exact lap sum, lap cap, duplicate, FK), authorization, filtering, ordering, defaults cascade, submissions in polling, and stale session participant cleanup.

## Non-obvious details

- `/api/v1/runs/defaults` registered before `/api/v1/runs/{id}` so the literal path matches first.
- `SlideToConfirm` DQ widget uses `key` prop to force remount on toggle (avoids `setState-in-useEffect`).
- Drink type and setup names resolved via `useMemo` from game data hooks — no separate state or effects.
- Stale cleanup bug was pre-existing (from PR 3B), not introduced in this PR, but fixed here since it blocks correct gameplay.
- `list_runs` has a `LIMIT 100` default and uses a closure for parameter indexing to prevent future misalignment.
- `formatTime` returns em-dash for negative input.
- Lap sum validation: no tolerance — laps must sum exactly to total. Both frontend (warning) and backend (400 rejection) enforce this.
- Time input navigation is fully bidirectional: typing the last digit auto-advances forward; backspace on empty field moves backward. Chain covers all 12 fields across 4 rows.
- `TimeInputGroup` uses resolved refs (external prop with internal fallback) so both forward focus (via `mRef`) and backward focus (via `mmmRef`) work whether or not the parent provides the ref.

## Test plan

### Backend (automated — all passing)
- [x] `cargo test` — 114 tests pass (57 unit + 57 integration)

### Frontend (manual)

1. **Start servers**
   ```bash
   cd backend && cargo run       # terminal 1
   cd frontend && bun run dev    # terminal 2
   ```

2. **Submit a run (happy path)**
   - Create session as user A, pick a track
   - Tap "Submit Time" — verify bottom sheet slides up with track image, name, cup, and race number
   - Type `2` in total time M field — verify cursor auto-advances to SS
   - Type `14` in SS — verify cursor auto-advances to mmm
   - Type `523` in mmm — verify cursor auto-advances to L1's M field
   - Complete L1 — verify auto-advance to L2's M field; then L2 → L3
   - Tap drink pill → verify DrinkTypeSelector overlay opens, pick a drink, verify pill shows emoji + name
   - Tap setup pill → verify RaceSetupPicker overlay opens, complete setup, verify pill shows summary
   - Tap "Submit Run" — verify sheet closes, "Your Time" card appears in green

3. **Backspace navigation**
   - After entering all times, place cursor in L3 mmm field and clear it
   - Press backspace on the now-empty L3 mmm — verify focus moves to L3 SS
   - Clear L3 SS, press backspace — verify focus moves to L3 M
   - Clear L3 M, press backspace — verify focus moves to L2 mmm
   - Continue pressing backspace through empty fields — verify the full backward chain works: L2 → L1 → total

4. **Lap sum validation (exact match required)**
   - Enter total = `2:00.000`, lap times summing to `1:59.999` — verify warning appears
   - Attempt to submit — verify backend rejects with 400
   - Fix laps to sum exactly — verify warning disappears and submit succeeds

5. **Real-time updates**
   - Open second browser/incognito as user B, join same session
   - User A submits — verify user B sees user A's time within ~3 seconds (✅ + time)
   - User B submits — verify both see both times
   - Verify ⏳ "Racing..." for participants who haven't submitted

6. **DQ toggle**
   - Slide DQ slider right — verify "Disqualified" red state; tap to undo — verify reset
   - Submit with DQ — verify red "Your Time (DQ)" with strikethrough

7. **Duplicate prevention**
   - After submitting, verify "Submit Time" button replaced by "Your Time" display

8. **Defaults cascade**
   - After first run: pick next track, open run entry — verify drink and setup pre-filled with actual names
   - Verify "From your last run" label visible below both sections
   - Change a selection — verify label stays visible

9. **Backend validation (via curl)**
   - Submit with laps not summing to total — verify 400: "Lap times must add up to total time"
   - Submit with a lap time > 600000ms — verify 400: "Each lap time must be at most 600000 ms"

10. **Stale session recovery** (optional)
    - Let a session time out or manually run cleanup — verify both users can create new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)