### PR TITLE
Audit PR B: Add low-level primitives

### DIFF
--- a/backend/src/domain/enums.rs
+++ b/backend/src/domain/enums.rs
@@ -1,0 +1,146 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+
+/// Lifecycle state of a session.
+///
+/// Stored in the DB as the strings returned by `as_str`. An unknown value read
+/// from the DB is treated as `Internal` (corruption or schema drift), not user
+/// input, so it bubbles up as a 500.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    Active,
+    Closed,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+impl fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SessionStatus {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "closed" => Ok(Self::Closed),
+            other => Err(AppError::Internal(format!(
+                "Unknown session status: {other}"
+            ))),
+        }
+    }
+}
+
+/// Session scheduling ruleset. Only `Random` is supported in Phase 3; future
+/// variants (e.g. `RoundRobin`) belong here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Ruleset {
+    Random,
+}
+
+impl Ruleset {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Random => "random",
+        }
+    }
+}
+
+impl fmt::Display for Ruleset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Ruleset {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "random" => Ok(Self::Random),
+            other => Err(AppError::BadRequest(format!("Invalid ruleset: '{other}'"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_status_parses_known_values() {
+        assert_eq!(
+            SessionStatus::from_str("active").unwrap(),
+            SessionStatus::Active
+        );
+        assert_eq!(
+            SessionStatus::from_str("closed").unwrap(),
+            SessionStatus::Closed
+        );
+    }
+
+    #[test]
+    fn session_status_unknown_is_internal_error() {
+        let err = SessionStatus::from_str("nonsense").unwrap_err();
+        match err {
+            AppError::Internal(msg) => assert!(msg.contains("nonsense")),
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_status_round_trip() {
+        for status in [SessionStatus::Active, SessionStatus::Closed] {
+            let s = status.as_str();
+            assert_eq!(SessionStatus::from_str(s).unwrap(), status);
+            assert_eq!(status.to_string(), s);
+        }
+    }
+
+    #[test]
+    fn session_status_serde_lowercase() {
+        let json = serde_json::to_string(&SessionStatus::Active).unwrap();
+        assert_eq!(json, "\"active\"");
+        let parsed: SessionStatus = serde_json::from_str("\"closed\"").unwrap();
+        assert_eq!(parsed, SessionStatus::Closed);
+    }
+
+    #[test]
+    fn ruleset_parses_known_values() {
+        assert_eq!(Ruleset::from_str("random").unwrap(), Ruleset::Random);
+    }
+
+    #[test]
+    fn ruleset_unknown_is_bad_request() {
+        // Unknown ruleset is user input (from API), so it's a 400, not a 500 —
+        // deliberately different from SessionStatus, which is read from the DB.
+        let err = Ruleset::from_str("spiral").unwrap_err();
+        match err {
+            AppError::BadRequest(msg) => assert!(msg.contains("spiral")),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ruleset_round_trip() {
+        let s = Ruleset::Random.as_str();
+        assert_eq!(Ruleset::from_str(s).unwrap(), Ruleset::Random);
+        assert_eq!(Ruleset::Random.to_string(), s);
+    }
+}

--- a/backend/src/domain/ids.rs
+++ b/backend/src/domain/ids.rs
@@ -1,0 +1,127 @@
+use serde::{Deserialize, Serialize};
+
+/// Generate a string-backed newtype for an ID.
+///
+/// The newtype is transparent for serde (so it serializes as a bare string),
+/// implements `Display`, `AsRef<str>`, `Deref<Target = str>`, and conversion
+/// from `String` / `&str`. `Deref` lets call sites treat the newtype as a
+/// `&str` for read-only operations (e.g. passing into SeaORM filters that
+/// expect `&str`).
+macro_rules! string_id_newtype {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+
+            fn deref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_string())
+            }
+        }
+    };
+}
+
+string_id_newtype!(UserId);
+string_id_newtype!(SessionId);
+string_id_newtype!(RunId);
+string_id_newtype!(SessionRaceId);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_id_round_trip() {
+        let id = UserId::new("abc");
+        assert_eq!(id.as_str(), "abc");
+        assert_eq!(id.to_string(), "abc");
+        assert_eq!(id.clone().into_string(), "abc".to_string());
+    }
+
+    #[test]
+    fn session_id_deref_to_str() {
+        let id = SessionId::new("xyz-123");
+        // Deref<Target = str> lets us use &str methods directly.
+        assert_eq!(id.len(), 7);
+        assert!(id.starts_with("xyz"));
+        // AsRef<str> for API ergonomics.
+        let as_ref: &str = id.as_ref();
+        assert_eq!(as_ref, "xyz-123");
+    }
+
+    #[test]
+    fn from_string_and_str() {
+        let a: RunId = "r1".into();
+        let b: RunId = String::from("r1").into();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn serde_is_transparent() {
+        let id = UserId::new("u-9");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"u-9\"");
+        let parsed: UserId = serde_json::from_str("\"u-9\"").unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn different_newtypes_are_not_interchangeable() {
+        // Compile-time property: UserId and SessionId do not unify. Documented
+        // here so future refactors don't unknowingly reach for `From<UserId>
+        // for SessionId` or similar. If you need to convert between them,
+        // it should be deliberate via `.as_str()` or `.into_string()`.
+        let user = UserId::new("u");
+        let session: SessionId = SessionId::new(user.as_str());
+        assert_eq!(session.as_str(), "u");
+    }
+
+    #[test]
+    fn hash_and_eq_work() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(SessionRaceId::new("sr-1"));
+        assert!(set.contains(&SessionRaceId::new("sr-1")));
+        assert!(!set.contains(&SessionRaceId::new("sr-2")));
+    }
+}

--- a/backend/src/domain/mod.rs
+++ b/backend/src/domain/mod.rs
@@ -1,0 +1,3 @@
+pub mod enums;
+pub mod ids;
+pub mod race_setup;

--- a/backend/src/domain/race_setup.rs
+++ b/backend/src/domain/race_setup.rs
@@ -1,0 +1,110 @@
+use crate::error::AppError;
+
+/// A fully-specified race setup update (all four IDs required together).
+///
+/// The API accepts `preferred_*_id` fields individually for partial updates,
+/// but a race setup must always be all-four-or-nothing: picking a character
+/// without wheels (etc.) is meaningless. This type encodes that invariant at
+/// compile time so call sites can't read only some of the fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RaceSetupUpdate {
+    pub character_id: i32,
+    pub body_id: i32,
+    pub wheel_id: i32,
+    pub glider_id: i32,
+}
+
+impl RaceSetupUpdate {
+    /// Parse a race-setup update from four optional fields.
+    ///
+    /// - All four `None` → `Ok(None)` (caller is not updating race setup).
+    /// - All four `Some` → `Ok(Some(RaceSetupUpdate))`.
+    /// - Any mix        → `Err(BadRequest)`.
+    pub fn try_from_optional(
+        character_id: Option<i32>,
+        body_id: Option<i32>,
+        wheel_id: Option<i32>,
+        glider_id: Option<i32>,
+    ) -> Result<Option<Self>, AppError> {
+        match (character_id, body_id, wheel_id, glider_id) {
+            (None, None, None, None) => Ok(None),
+            (Some(character_id), Some(body_id), Some(wheel_id), Some(glider_id)) => {
+                Ok(Some(Self {
+                    character_id,
+                    body_id,
+                    wheel_id,
+                    glider_id,
+                }))
+            }
+            _ => Err(AppError::BadRequest(
+                "Race setup must be provided all together (character, body, wheel, glider) or not at all".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_none_returns_ok_none() {
+        let result = RaceSetupUpdate::try_from_optional(None, None, None, None).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn all_some_returns_ok_some() {
+        let result = RaceSetupUpdate::try_from_optional(Some(1), Some(2), Some(3), Some(4))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            result,
+            RaceSetupUpdate {
+                character_id: 1,
+                body_id: 2,
+                wheel_id: 3,
+                glider_id: 4,
+            }
+        );
+    }
+
+    fn assert_bad_request(result: Result<Option<RaceSetupUpdate>, AppError>) {
+        match result {
+            Err(AppError::BadRequest(msg)) => {
+                assert!(msg.contains("all together"), "msg was: {msg}");
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_some_is_bad_request() {
+        assert_bad_request(RaceSetupUpdate::try_from_optional(
+            Some(1),
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn three_some_one_none_is_bad_request() {
+        assert_bad_request(RaceSetupUpdate::try_from_optional(
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+        ));
+    }
+
+    #[test]
+    fn interior_none_is_bad_request() {
+        assert_bad_request(RaceSetupUpdate::try_from_optional(
+            Some(1),
+            None,
+            Some(3),
+            Some(4),
+        ));
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod domain;
 pub mod drink_type_id;
 #[allow(unused_imports)]
 pub mod entities;
@@ -6,6 +7,9 @@ pub mod error;
 pub mod middleware;
 pub mod routes;
 pub mod services;
+
+#[cfg(test)]
+pub mod test_helpers;
 
 use std::sync::Arc;
 

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -140,35 +140,13 @@ pub async fn pick_random_track<C: ConnectionTrait>(
 mod tests {
     use super::*;
     use sea_orm::{ActiveModelTrait, Set};
-    use uuid::Uuid;
 
     use crate::entities::{characters, cups, tracks};
-    use crate::test_helpers::{create_user, seed_tracks_for_test, setup_db};
+    use crate::test_helpers::{
+        create_user, insert_participant, insert_session, seed_tracks_for_test, setup_db,
+    };
 
     // --- load_active_session ---
-
-    async fn insert_session(
-        db: &sea_orm::DatabaseConnection,
-        host_id: &str,
-        status: &str,
-    ) -> String {
-        let id = Uuid::new_v4().to_string();
-        let now = Utc::now().naive_utc();
-        sessions::ActiveModel {
-            id: Set(id.clone()),
-            created_by: Set(host_id.to_string()),
-            host_id: Set(host_id.to_string()),
-            ruleset: Set("random".to_string()),
-            least_played_drink_category: Set(None),
-            status: Set(status.to_string()),
-            created_at: Set(now),
-            last_activity_at: Set(now),
-        }
-        .insert(db)
-        .await
-        .expect("insert session");
-        id
-    }
 
     #[tokio::test]
     async fn load_active_session_returns_active() {
@@ -201,25 +179,6 @@ mod tests {
     }
 
     // --- require_active_participant ---
-
-    async fn insert_participant(
-        db: &sea_orm::DatabaseConnection,
-        session_id: &str,
-        user_id: &str,
-        left_at: Option<chrono::NaiveDateTime>,
-    ) {
-        let now = Utc::now().naive_utc();
-        session_participants::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
-            session_id: Set(session_id.to_string()),
-            user_id: Set(user_id.to_string()),
-            joined_at: Set(now),
-            left_at: Set(left_at),
-        }
-        .insert(db)
-        .await
-        .expect("insert participant");
-    }
 
     #[tokio::test]
     async fn require_active_participant_returns_row_when_active() {

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -88,13 +88,19 @@ where
 }
 
 /// Pick a random track, excluding IDs in `exclude`. If every track is in the
-/// exclusion set (pool exhausted), reset by picking from the full set and
-/// log an info-level message.
+/// exclusion set (pool exhausted), reset the pool — but keep any IDs in
+/// `always_exclude` filtered out even after the reset.
+///
+/// Two-tier exclusion supports both callers:
+/// - `next_track`: `exclude = &used_ids, always_exclude = &[]` — full reset.
+/// - `skip_turn`:  `exclude = &used_ids, always_exclude = &[skipped_id]` —
+///   the skipped track stays excluded even through a reset.
 ///
 /// Returns `Internal` only if the `tracks` table is empty (seed error).
 pub async fn pick_random_track<C: ConnectionTrait>(
     db: &C,
     exclude: &[i32],
+    always_exclude: &[i32],
 ) -> Result<tracks::Model, AppError> {
     let all_tracks = tracks::Entity::find().all(db).await?;
     if all_tracks.is_empty() {
@@ -103,15 +109,19 @@ pub async fn pick_random_track<C: ConnectionTrait>(
 
     let available: Vec<&tracks::Model> = all_tracks
         .iter()
-        .filter(|t| !exclude.contains(&t.id))
+        .filter(|t| !exclude.contains(&t.id) && !always_exclude.contains(&t.id))
         .collect();
 
     let pool: Vec<&tracks::Model> = if available.is_empty() {
         tracing::info!(
             excluded = exclude.len(),
-            "Track pool exhausted — resetting exclusion",
+            always_excluded = always_exclude.len(),
+            "Track pool exhausted — resetting (always_exclude still applied)",
         );
-        all_tracks.iter().collect()
+        all_tracks
+            .iter()
+            .filter(|t| !always_exclude.contains(&t.id))
+            .collect()
     } else {
         available
     };
@@ -325,7 +335,7 @@ mod tests {
         seed_tracks_for_test(&db).await;
 
         // Exclude tracks 1,2,3 — only 4,5,6 are available.
-        let chosen = pick_random_track(&db, &[1, 2, 3]).await.unwrap();
+        let chosen = pick_random_track(&db, &[1, 2, 3], &[]).await.unwrap();
         assert!([4, 5, 6].contains(&chosen.id));
     }
 
@@ -335,15 +345,35 @@ mod tests {
         seed_tracks_for_test(&db).await;
 
         // Exclude everything — should still return one of the seeded tracks.
-        let chosen = pick_random_track(&db, &[1, 2, 3, 4, 5, 6]).await.unwrap();
+        let chosen = pick_random_track(&db, &[1, 2, 3, 4, 5, 6], &[])
+            .await
+            .unwrap();
         assert!([1, 2, 3, 4, 5, 6].contains(&chosen.id));
+    }
+
+    #[tokio::test]
+    async fn pick_random_track_always_exclude_survives_reset() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await; // 6 tracks: IDs 1-6
+
+        // Exhaust the pool (exclude all 6) but always_exclude track 3.
+        // On reset, track 3 stays excluded — result must not be 3.
+        for _ in 0..20 {
+            let chosen = pick_random_track(&db, &[1, 2, 3, 4, 5, 6], &[3])
+                .await
+                .unwrap();
+            assert_ne!(
+                chosen.id, 3,
+                "always_exclude track must stay excluded through pool reset"
+            );
+        }
     }
 
     #[tokio::test]
     async fn pick_random_track_empty_table_is_internal() {
         let db = setup_db().await;
         // No tracks seeded.
-        let err = pick_random_track(&db, &[]).await.unwrap_err();
+        let err = pick_random_track(&db, &[], &[]).await.unwrap_err();
         assert!(matches!(err, AppError::Internal(_)));
     }
 
@@ -370,7 +400,7 @@ mod tests {
         .await
         .unwrap();
 
-        let chosen = pick_random_track(&db, &[]).await.unwrap();
+        let chosen = pick_random_track(&db, &[], &[]).await.unwrap();
         assert_eq!(chosen.id, 42);
     }
 }

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -1,0 +1,376 @@
+//! Small, reusable service-layer helpers.
+//!
+//! These are building blocks for the larger service functions. PR B lands
+//! them with tests; PR C migrates the existing `sessions` / `runs` service
+//! functions to use them.
+
+use chrono::Utc;
+use rand::seq::SliceRandom;
+use sea_orm::{
+    ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait, QueryFilter,
+    sea_query::Expr,
+};
+
+use crate::domain::enums::SessionStatus;
+use crate::entities::{session_participants, sessions, tracks};
+use crate::error::AppError;
+
+/// Load a session by ID and require that it is in the `Active` state.
+///
+/// - `NotFound` if no row with that ID exists.
+/// - `Conflict` if the session exists but is closed.
+pub async fn load_active_session<C: ConnectionTrait>(
+    db: &C,
+    session_id: &str,
+) -> Result<sessions::Model, AppError> {
+    let session = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Session not found".into()))?;
+    if session.status != SessionStatus::Active.as_str() {
+        return Err(AppError::Conflict("Session is not active".into()));
+    }
+    Ok(session)
+}
+
+/// Require that `user_id` is an active (not-yet-left) participant in the
+/// session. Returns the participant row on success.
+///
+/// `Forbidden` if the user has no active participant row for this session.
+pub async fn require_active_participant<C: ConnectionTrait>(
+    db: &C,
+    session_id: &str,
+    user_id: &str,
+) -> Result<session_participants::Model, AppError> {
+    session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::UserId.eq(user_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("Not a participant in this session".into()))
+}
+
+/// Bump the session's `last_activity_at` column to now. Single `UPDATE`,
+/// no prior read required.
+pub async fn touch_session<C: ConnectionTrait>(db: &C, session_id: &str) -> Result<(), AppError> {
+    let now = Utc::now().naive_utc();
+    sessions::Entity::update_many()
+        .col_expr(sessions::Column::LastActivityAt, Expr::value(now))
+        .filter(sessions::Column::Id.eq(session_id))
+        .exec(db)
+        .await?;
+    Ok(())
+}
+
+/// Assert that a row with the given primary key exists in entity `E`.
+/// Returns `BadRequest` with a formatted message on miss (e.g., "Invalid
+/// character_id").
+///
+/// The generic bounds mirror `EntityTrait::find_by_id` — the primary key's
+/// `ValueType` is what the caller must pass in.
+pub async fn require_exists<E, C>(
+    db: &C,
+    id: <<E as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType,
+    entity_label: &str,
+) -> Result<(), AppError>
+where
+    E: EntityTrait,
+    C: ConnectionTrait,
+{
+    if E::find_by_id(id).one(db).await?.is_none() {
+        return Err(AppError::BadRequest(format!("Invalid {entity_label}_id")));
+    }
+    Ok(())
+}
+
+/// Pick a random track, excluding IDs in `exclude`. If every track is in the
+/// exclusion set (pool exhausted), reset by picking from the full set and
+/// log an info-level message.
+///
+/// Returns `Internal` only if the `tracks` table is empty (seed error).
+pub async fn pick_random_track<C: ConnectionTrait>(
+    db: &C,
+    exclude: &[i32],
+) -> Result<tracks::Model, AppError> {
+    let all_tracks = tracks::Entity::find().all(db).await?;
+    if all_tracks.is_empty() {
+        return Err(AppError::Internal("No tracks configured".into()));
+    }
+
+    let available: Vec<&tracks::Model> = all_tracks
+        .iter()
+        .filter(|t| !exclude.contains(&t.id))
+        .collect();
+
+    let pool: Vec<&tracks::Model> = if available.is_empty() {
+        tracing::info!(
+            excluded = exclude.len(),
+            "Track pool exhausted — resetting exclusion",
+        );
+        all_tracks.iter().collect()
+    } else {
+        available
+    };
+
+    // `rand::thread_rng()` is !Send; keep it confined to this sync scope so
+    // the returned `Model` can cross `.await` boundaries in callers.
+    let chosen = {
+        let mut rng = rand::thread_rng();
+        pool.choose(&mut rng).copied().cloned()
+    };
+
+    chosen.ok_or_else(|| AppError::Internal("pick_random_track: empty pool after reset".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{ActiveModelTrait, Set};
+    use uuid::Uuid;
+
+    use crate::entities::{characters, cups, tracks};
+    use crate::test_helpers::{create_user, seed_tracks_for_test, setup_db};
+
+    // --- load_active_session ---
+
+    async fn insert_session(
+        db: &sea_orm::DatabaseConnection,
+        host_id: &str,
+        status: &str,
+    ) -> String {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().naive_utc();
+        sessions::ActiveModel {
+            id: Set(id.clone()),
+            created_by: Set(host_id.to_string()),
+            host_id: Set(host_id.to_string()),
+            ruleset: Set("random".to_string()),
+            least_played_drink_category: Set(None),
+            status: Set(status.to_string()),
+            created_at: Set(now),
+            last_activity_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .expect("insert session");
+        id
+    }
+
+    #[tokio::test]
+    async fn load_active_session_returns_active() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+
+        let model = load_active_session(&db, &session_id).await.unwrap();
+        assert_eq!(model.id, session_id);
+        assert_eq!(model.status, "active");
+    }
+
+    #[tokio::test]
+    async fn load_active_session_missing_is_not_found() {
+        let db = setup_db().await;
+        let err = load_active_session(&db, "does-not-exist")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn load_active_session_closed_is_conflict() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "closed").await;
+
+        let err = load_active_session(&db, &session_id).await.unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    // --- require_active_participant ---
+
+    async fn insert_participant(
+        db: &sea_orm::DatabaseConnection,
+        session_id: &str,
+        user_id: &str,
+        left_at: Option<chrono::NaiveDateTime>,
+    ) {
+        let now = Utc::now().naive_utc();
+        session_participants::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            session_id: Set(session_id.to_string()),
+            user_id: Set(user_id.to_string()),
+            joined_at: Set(now),
+            left_at: Set(left_at),
+        }
+        .insert(db)
+        .await
+        .expect("insert participant");
+    }
+
+    #[tokio::test]
+    async fn require_active_participant_returns_row_when_active() {
+        let db = setup_db().await;
+        let user = create_user(&db, "u1").await;
+        let session_id = insert_session(&db, &user, "active").await;
+        insert_participant(&db, &session_id, &user, None).await;
+
+        let row = require_active_participant(&db, &session_id, &user)
+            .await
+            .unwrap();
+        assert_eq!(row.user_id, user);
+        assert!(row.left_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn require_active_participant_no_row_is_forbidden() {
+        let db = setup_db().await;
+        let user = create_user(&db, "u1").await;
+        let session_id = insert_session(&db, &user, "active").await;
+
+        let err = require_active_participant(&db, &session_id, &user)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn require_active_participant_left_is_forbidden() {
+        let db = setup_db().await;
+        let user = create_user(&db, "u1").await;
+        let session_id = insert_session(&db, &user, "active").await;
+        insert_participant(&db, &session_id, &user, Some(Utc::now().naive_utc())).await;
+
+        let err = require_active_participant(&db, &session_id, &user)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    // --- touch_session ---
+
+    #[tokio::test]
+    async fn touch_session_updates_last_activity_at() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+
+        let before = sessions::Entity::find_by_id(&session_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .last_activity_at;
+
+        // Sleep a millisecond so the new timestamp is strictly later. SQLite's
+        // DateTime has microsecond precision; 1ms of real wall-clock time is
+        // comfortably over the resolution boundary.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+
+        touch_session(&db, &session_id).await.unwrap();
+
+        let after = sessions::Entity::find_by_id(&session_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .last_activity_at;
+
+        assert!(
+            after > before,
+            "expected last_activity_at to advance: before={before}, after={after}"
+        );
+    }
+
+    // --- require_exists ---
+
+    #[tokio::test]
+    async fn require_exists_ok_when_row_present() {
+        let db = setup_db().await;
+        // Seed one cup; characters/etc. are empty.
+        cups::ActiveModel {
+            id: Set(7),
+            name: Set("Seeded".to_string()),
+            image_path: Set("x".to_string()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        require_exists::<cups::Entity, _>(&db, 7, "cup")
+            .await
+            .expect("cup 7 exists");
+    }
+
+    #[tokio::test]
+    async fn require_exists_bad_request_when_missing() {
+        let db = setup_db().await;
+        let err = require_exists::<characters::Entity, _>(&db, 999, "character")
+            .await
+            .unwrap_err();
+        match err {
+            AppError::BadRequest(msg) => assert_eq!(msg, "Invalid character_id"),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    // --- pick_random_track ---
+
+    #[tokio::test]
+    async fn pick_random_track_returns_from_available() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+
+        // Exclude tracks 1,2,3 — only 4,5,6 are available.
+        let chosen = pick_random_track(&db, &[1, 2, 3]).await.unwrap();
+        assert!([4, 5, 6].contains(&chosen.id));
+    }
+
+    #[tokio::test]
+    async fn pick_random_track_resets_when_pool_exhausted() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+
+        // Exclude everything — should still return one of the seeded tracks.
+        let chosen = pick_random_track(&db, &[1, 2, 3, 4, 5, 6]).await.unwrap();
+        assert!([1, 2, 3, 4, 5, 6].contains(&chosen.id));
+    }
+
+    #[tokio::test]
+    async fn pick_random_track_empty_table_is_internal() {
+        let db = setup_db().await;
+        // No tracks seeded.
+        let err = pick_random_track(&db, &[]).await.unwrap_err();
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn pick_random_track_uses_all_tracks_when_exclude_empty() {
+        let db = setup_db().await;
+        // Seed exactly one track so the choice is deterministic.
+        cups::ActiveModel {
+            id: Set(1),
+            name: Set("Only Cup".to_string()),
+            image_path: Set("x".to_string()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+        tracks::ActiveModel {
+            id: Set(42),
+            name: Set("Only Track".to_string()),
+            cup_id: Set(1),
+            position: Set(1),
+            image_path: Set("x".to_string()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        let chosen = pick_random_track(&db, &[]).await.unwrap();
+        assert_eq!(chosen.id, 42);
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,3 +1,5 @@
 pub mod auth;
+pub mod helpers;
 pub mod runs;
+pub mod session_context;
 pub mod sessions;

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -1,0 +1,188 @@
+//! Loaded-and-validated session bundle.
+//!
+//! Aggregates the helpers from `services::helpers` so service functions that
+//! start by loading an active session, checking host/participant, and touching
+//! activity can read top-to-bottom without repeating the ceremony.
+
+use sea_orm::ConnectionTrait;
+
+use crate::entities::{session_participants, sessions};
+use crate::error::AppError;
+use crate::services::helpers;
+
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    pub session: sessions::Model,
+}
+
+impl SessionContext {
+    /// Load the session by ID and require it to be in the `Active` state.
+    pub async fn load_active<C: ConnectionTrait>(
+        db: &C,
+        session_id: &str,
+    ) -> Result<Self, AppError> {
+        let session = helpers::load_active_session(db, session_id).await?;
+        Ok(Self { session })
+    }
+
+    /// Require that `user_id` is the host of this session.
+    pub fn require_host(&self, user_id: &str) -> Result<(), AppError> {
+        if self.session.host_id != user_id {
+            return Err(AppError::Forbidden("Only the host can do that".into()));
+        }
+        Ok(())
+    }
+
+    /// Require that `user_id` is an active participant and return their row.
+    pub async fn require_participant<C: ConnectionTrait>(
+        &self,
+        db: &C,
+        user_id: &str,
+    ) -> Result<session_participants::Model, AppError> {
+        helpers::require_active_participant(db, &self.session.id, user_id).await
+    }
+
+    /// Bump `last_activity_at` to now. Delegates to `helpers::touch_session`.
+    pub async fn touch<C: ConnectionTrait>(&self, db: &C) -> Result<(), AppError> {
+        helpers::touch_session(db, &self.session.id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+    use uuid::Uuid;
+
+    use crate::test_helpers::{create_user, setup_db};
+
+    async fn insert_session(
+        db: &sea_orm::DatabaseConnection,
+        host_id: &str,
+        status: &str,
+    ) -> String {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().naive_utc();
+        sessions::ActiveModel {
+            id: Set(id.clone()),
+            created_by: Set(host_id.to_string()),
+            host_id: Set(host_id.to_string()),
+            ruleset: Set("random".to_string()),
+            least_played_drink_category: Set(None),
+            status: Set(status.to_string()),
+            created_at: Set(now),
+            last_activity_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .expect("insert session");
+        id
+    }
+
+    async fn insert_participant(db: &sea_orm::DatabaseConnection, session_id: &str, user_id: &str) {
+        let now = Utc::now().naive_utc();
+        session_participants::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            session_id: Set(session_id.to_string()),
+            user_id: Set(user_id.to_string()),
+            joined_at: Set(now),
+            left_at: Set(None),
+        }
+        .insert(db)
+        .await
+        .expect("insert participant");
+    }
+
+    #[tokio::test]
+    async fn load_active_populates_session() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+
+        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+        assert_eq!(ctx.session.id, session_id);
+        assert_eq!(ctx.session.host_id, host);
+    }
+
+    #[tokio::test]
+    async fn load_active_missing_propagates_not_found() {
+        let db = setup_db().await;
+        let err = SessionContext::load_active(&db, "missing")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn load_active_closed_propagates_conflict() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "closed").await;
+
+        let err = SessionContext::load_active(&db, &session_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn require_host_matches() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+
+        ctx.require_host(&host).expect("host matches");
+    }
+
+    #[tokio::test]
+    async fn require_host_mismatch_is_forbidden() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let other = create_user(&db, "other").await;
+        let session_id = insert_session(&db, &host, "active").await;
+        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+
+        let err = ctx.require_host(&other).unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn require_participant_happy_and_forbidden_paths() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+        insert_participant(&db, &session_id, &host).await;
+        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+
+        // Happy path: host is a participant.
+        let row = ctx.require_participant(&db, &host).await.unwrap();
+        assert_eq!(row.user_id, host);
+
+        // Forbidden path: another user isn't.
+        let outsider = create_user(&db, "outsider").await;
+        let err = ctx.require_participant(&db, &outsider).await.unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn touch_bumps_last_activity_at() {
+        let db = setup_db().await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+
+        let before = ctx.session.last_activity_at;
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        ctx.touch(&db).await.unwrap();
+
+        let after = sessions::Entity::find_by_id(&session_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .last_activity_at;
+        assert!(after > before, "before={before}, after={after}");
+    }
+}

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -56,48 +56,9 @@ impl SessionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
-    use uuid::Uuid;
+    use sea_orm::EntityTrait;
 
-    use crate::test_helpers::{create_user, setup_db};
-
-    async fn insert_session(
-        db: &sea_orm::DatabaseConnection,
-        host_id: &str,
-        status: &str,
-    ) -> String {
-        let id = Uuid::new_v4().to_string();
-        let now = Utc::now().naive_utc();
-        sessions::ActiveModel {
-            id: Set(id.clone()),
-            created_by: Set(host_id.to_string()),
-            host_id: Set(host_id.to_string()),
-            ruleset: Set("random".to_string()),
-            least_played_drink_category: Set(None),
-            status: Set(status.to_string()),
-            created_at: Set(now),
-            last_activity_at: Set(now),
-        }
-        .insert(db)
-        .await
-        .expect("insert session");
-        id
-    }
-
-    async fn insert_participant(db: &sea_orm::DatabaseConnection, session_id: &str, user_id: &str) {
-        let now = Utc::now().naive_utc();
-        session_participants::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
-            session_id: Set(session_id.to_string()),
-            user_id: Set(user_id.to_string()),
-            joined_at: Set(now),
-            left_at: Set(None),
-        }
-        .insert(db)
-        .await
-        .expect("insert participant");
-    }
+    use crate::test_helpers::{create_user, insert_participant, insert_session, setup_db};
 
     #[tokio::test]
     async fn load_active_populates_session() {
@@ -158,7 +119,7 @@ mod tests {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let session_id = insert_session(&db, &host, "active").await;
-        insert_participant(&db, &session_id, &host).await;
+        insert_participant(&db, &session_id, &host, None).await;
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         // Happy path: host is a participant.

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -42,9 +42,14 @@ impl SessionContext {
         helpers::require_active_participant(db, &self.session.id, user_id).await
     }
 
-    /// Bump `last_activity_at` to now. Delegates to `helpers::touch_session`.
-    pub async fn touch<C: ConnectionTrait>(&self, db: &C) -> Result<(), AppError> {
-        helpers::touch_session(db, &self.session.id).await
+    /// Bump `last_activity_at` to now in both the DB and this struct.
+    /// Delegates the UPDATE to `helpers::touch_session`, then refreshes
+    /// the in-memory field so callers that read it post-touch see the
+    /// updated value.
+    pub async fn touch<C: ConnectionTrait>(&mut self, db: &C) -> Result<(), AppError> {
+        helpers::touch_session(db, &self.session.id).await?;
+        self.session.last_activity_at = chrono::Utc::now().naive_utc();
+        Ok(())
     }
 }
 
@@ -167,22 +172,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn touch_bumps_last_activity_at() {
+    async fn touch_bumps_last_activity_at_in_db_and_struct() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let session_id = insert_session(&db, &host, "active").await;
-        let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
+        let mut ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         let before = ctx.session.last_activity_at;
         tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         ctx.touch(&db).await.unwrap();
 
-        let after = sessions::Entity::find_by_id(&session_id)
+        // In-memory field is updated.
+        assert!(
+            ctx.session.last_activity_at > before,
+            "struct field should advance: before={before}, after={}",
+            ctx.session.last_activity_at
+        );
+
+        // DB is also updated.
+        let db_value = sessions::Entity::find_by_id(&session_id)
             .one(&db)
             .await
             .unwrap()
             .unwrap()
             .last_activity_at;
-        assert!(after > before, "before={before}, after={after}");
+        assert!(
+            db_value > before,
+            "DB should advance: before={before}, after={db_value}"
+        );
     }
 }

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -1,0 +1,169 @@
+//! Shared test setup for service-layer unit tests.
+//!
+//! PR B introduces this module side-by-side with the existing duplicated
+//! helpers in `services/sessions.rs` and `services/runs.rs`. PR C removes
+//! the duplicates and migrates call sites here.
+//!
+//! Future: if tests move to an integration-test layout (`backend/tests/` with
+//! a shared `common/mod.rs`), relocate these helpers there instead.
+
+#![cfg(test)]
+#![allow(dead_code)] // Nothing consumes these until PR C.
+
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, DatabaseConnection, Set};
+use uuid::Uuid;
+
+use crate::drink_type_id::drink_type_uuid;
+use crate::entities::{bodies, characters, cups, drink_types, gliders, tracks, users, wheels};
+
+/// Spin up an in-memory SQLite database with foreign keys enabled and all
+/// migrations applied. Each call returns a fresh, isolated DB.
+pub async fn setup_db() -> DatabaseConnection {
+    use migration::{Migrator, MigratorTrait};
+
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("connect to sqlite::memory:");
+    db.execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .expect("enable foreign keys");
+    Migrator::up(&db, None).await.expect("run migrations");
+    db
+}
+
+/// Insert a user with the given username and a fixed placeholder password
+/// hash. Returns the generated user ID.
+pub async fn create_user(db: &DatabaseConnection, username: &str) -> String {
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now().naive_utc();
+    // Placeholder hash — tests don't verify passwords, but the column is NOT NULL.
+    let placeholder_hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
+    users::ActiveModel {
+        id: Set(id.clone()),
+        username: Set(username.to_string()),
+        email: Set(None),
+        password_hash: Set(placeholder_hash.to_string()),
+        preferred_character_id: Set(None),
+        preferred_body_id: Set(None),
+        preferred_wheel_id: Set(None),
+        preferred_glider_id: Set(None),
+        preferred_drink_type_id: Set(None),
+        refresh_token_version: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(db)
+    .await
+    .expect("insert user");
+    id
+}
+
+/// Seed 3 cups × 2 tracks each (6 tracks total) for tests that exercise
+/// random-track selection. Matches the shape used by existing session tests.
+pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
+    let cup_names = ["Test Cup A", "Test Cup B", "Test Cup C"];
+    for (i, name) in cup_names.iter().enumerate() {
+        cups::ActiveModel {
+            id: Set((i + 1) as i32),
+            name: Set((*name).to_string()),
+            image_path: Set(format!("images/cups/test-cup-{}.webp", i + 1)),
+        }
+        .insert(db)
+        .await
+        .expect("insert cup");
+    }
+
+    let track_data = [
+        (1, "Track Alpha", 1, 1),
+        (2, "Track Beta", 1, 2),
+        (3, "Track Gamma", 2, 1),
+        (4, "Track Delta", 2, 2),
+        (5, "Track Epsilon", 3, 1),
+        (6, "Track Zeta", 3, 2),
+    ];
+    for (id, name, cup_id, position) in track_data {
+        tracks::ActiveModel {
+            id: Set(id),
+            name: Set(name.to_string()),
+            cup_id: Set(cup_id),
+            position: Set(position),
+            image_path: Set(format!("images/tracks/track-{id}.webp")),
+        }
+        .insert(db)
+        .await
+        .expect("insert track");
+    }
+}
+
+/// Seed the minimum game data required for run-creation tests: one each of
+/// cup, track, character, body, wheels, glider, and a single drink type.
+pub async fn seed_game_data(db: &DatabaseConnection) {
+    cups::ActiveModel {
+        id: Set(1),
+        name: Set("Test Cup".to_string()),
+        image_path: Set("images/cups/test.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert cup");
+
+    tracks::ActiveModel {
+        id: Set(1),
+        name: Set("Test Track".to_string()),
+        cup_id: Set(1),
+        position: Set(1),
+        image_path: Set("images/tracks/test.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert track");
+
+    characters::ActiveModel {
+        id: Set(1),
+        name: Set("Mario".to_string()),
+        image_path: Set("images/characters/mario.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert character");
+
+    bodies::ActiveModel {
+        id: Set(1),
+        name: Set("Standard Kart".to_string()),
+        image_path: Set("images/bodies/standard.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert body");
+
+    wheels::ActiveModel {
+        id: Set(1),
+        name: Set("Standard".to_string()),
+        image_path: Set("images/wheels/standard.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert wheels");
+
+    gliders::ActiveModel {
+        id: Set(1),
+        name: Set("Super Glider".to_string()),
+        image_path: Set("images/gliders/super.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert glider");
+
+    let drink_id = drink_type_uuid("Test Beer");
+    drink_types::ActiveModel {
+        id: Set(drink_id),
+        name: Set("Test Beer".to_string()),
+        alcoholic: Set(true),
+        created_at: Set(Utc::now().naive_utc()),
+        created_by: Set(None),
+    }
+    .insert(db)
+    .await
+    .expect("insert drink type");
+}

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -15,7 +15,10 @@ use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, DatabaseConnection, S
 use uuid::Uuid;
 
 use crate::drink_type_id::drink_type_uuid;
-use crate::entities::{bodies, characters, cups, drink_types, gliders, tracks, users, wheels};
+use crate::entities::{
+    bodies, characters, cups, drink_types, gliders, session_participants, sessions, tracks, users,
+    wheels,
+};
 
 /// Spin up an in-memory SQLite database with foreign keys enabled and all
 /// migrations applied. Each call returns a fresh, isolated DB.
@@ -94,6 +97,48 @@ pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
         .await
         .expect("insert track");
     }
+}
+
+/// Insert a session with the given host and status. Returns the generated
+/// session ID.
+pub async fn insert_session(db: &DatabaseConnection, host_id: &str, status: &str) -> String {
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now().naive_utc();
+    sessions::ActiveModel {
+        id: Set(id.clone()),
+        created_by: Set(host_id.to_string()),
+        host_id: Set(host_id.to_string()),
+        ruleset: Set("random".to_string()),
+        least_played_drink_category: Set(None),
+        status: Set(status.to_string()),
+        created_at: Set(now),
+        last_activity_at: Set(now),
+    }
+    .insert(db)
+    .await
+    .expect("insert session");
+    id
+}
+
+/// Insert a participant into a session. Pass `None` for `left_at` to create
+/// an active (currently-in-session) participant.
+pub async fn insert_participant(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+    left_at: Option<chrono::NaiveDateTime>,
+) {
+    let now = Utc::now().naive_utc();
+    session_participants::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        session_id: Set(session_id.to_string()),
+        user_id: Set(user_id.to_string()),
+        joined_at: Set(now),
+        left_at: Set(left_at),
+    }
+    .insert(db)
+    .await
+    .expect("insert participant");
 }
 
 /// Seed the minimum game data required for run-creation tests: one each of


### PR DESCRIPTION
## Summary

Pure-addition PR (no existing call sites changed) that lays the foundation for PR C's service refactors. Part of the [Rust backend audit](reviews/design/2026-04-15-rust-audit.md).

### New modules

| Module | Purpose | Audit section |
|--------|---------|---------------|
| `domain/enums.rs` | `SessionStatus` and `Ruleset` enums — replace magic strings `"active"`, `"closed"`, `"random"` | §1.2 |
| `domain/ids.rs` | `UserId`, `SessionId`, `RunId`, `SessionRaceId` newtypes with `Deref<Target=str>` | §4.2 |
| `domain/race_setup.rs` | `RaceSetupUpdate::try_from_optional` — all-four-or-nothing race setup validator | §1.6 |
| `services/helpers.rs` | `load_active_session`, `require_active_participant`, `touch_session`, `require_exists`, `pick_random_track` | §2.1–2.5 |
| `services/session_context.rs` | `SessionContext` facade aggregating helpers | §4.1 |
| `test_helpers.rs` | Shared `setup_db`, `create_user`, `seed_tracks_for_test`, `seed_game_data` (side-by-side with existing duplicates — PR C deletes them) | §2.6 |

### Design decisions

**`Ruleset::FromStr` returns `BadRequest`, not `Internal`.** Rulesets come from user input via the API, not from the DB. This matches the existing `create_session` behavior and the error-variant convention from audit §1.5 ("BadRequest = malformed input or invalid value from client"). `SessionStatus::FromStr` returns `Internal` because an unknown status read from the DB is corruption.

**`load_active_session` returns `Conflict` (409) for closed sessions.** This is the audit-approved reclassification (§1.5): "Session closed" is a state conflict, not malformed input. Existing callers use `BadRequest` (400) — that change happens in PR C when call sites migrate, and it is intentional.

**`pick_random_track` has two-tier exclusion.** `exclude` IDs are dropped on pool reset; `always_exclude` IDs persist. This preserves the `skip_turn` invariant where the skipped track must stay excluded even through a pool exhaustion reset.

**`SessionContext::touch` takes `&mut self`.** Updates both the DB and the in-memory `session.last_activity_at` field, preventing a stale-field footgun for callers that read the timestamp after touching.

### Coverage

All new production modules exceed 80% line coverage:
- `domain/enums.rs` — 97%
- `domain/ids.rs` — 100%
- `domain/race_setup.rs` — 98%
- `services/helpers.rs` — 99%
- `services/session_context.rs` — 100%
- `test_helpers.rs` — 58% (expected: no consumers until PR C migrates call sites)

### Verification

- [x] `cargo build` passes
- [x] `cargo test` — 96 unit + 57 integration, all green (39 new tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Diff is pure additions — no existing function bodies changed

## Test plan

To verify locally after checkout:

```bash
cd backend

# 1. Confirm all tests pass (153 total: 96 unit + 57 integration)
cargo test
# Expected: "test result: ok. 96 passed" (unit) + 27 + 20 + 10 (integration)

# 2. Confirm clippy and fmt are clean
cargo clippy --all-targets -- -D warnings
cargo fmt --check

# 3. Confirm this PR is pure additions — no existing service/route code changed
git diff main -- src/services/sessions.rs src/services/runs.rs src/routes/
# Expected: empty output (no changes to existing files in those directories)

# 4. Confirm the new domain types compile and serialize correctly
cargo test --lib domain::
# Expected: 18 passed — enums round-trip, serde transparent, race_setup validation

# 5. Confirm helpers work against a real (in-memory) SQLite DB
cargo test --lib services::helpers
# Expected: 14 passed — covers all 5 helpers including always_exclude behavior

# 6. Confirm SessionContext facade delegates correctly
cargo test --lib services::session_context
# Expected: 7 passed — load/host/participant/touch with both happy + error paths

# 7. Spot-check that pick_random_track always_exclude survives pool reset
cargo test --lib pick_random_track_always_exclude
# Expected: runs 20 iterations, never picks the always-excluded track

# 8. (Optional) Check coverage on new modules
just coverage-summary
# Look for: domain/enums ≥96%, domain/ids 100%, domain/race_setup ≥98%,
# services/helpers ≥98%, services/session_context 100%
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)