### PR TITLE
Reclassify session-closed errors from 400 to 409

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -62,6 +62,7 @@ Provide a concise summary in chat covering:
   - **Critical** (blocks merge): Security vulnerabilities, data loss risks, broken functionality
   - **Important** (should fix before merge): Logic errors, missing validation, convention violations
   - **Suggestions** (nice to have): Style improvements, performance optimizations, readability
+- **DESIGN.md accuracy**: State explicitly whether DESIGN.md needed updates, whether they were made, and whether they match the code. (See the "DESIGN.md Accuracy" section below.)
 - **What's good**: Call out things done well. Positive reinforcement matters.
 
 ### Tier 2: PR Comments (when issues found)
@@ -96,6 +97,24 @@ reviews/pr-<number>-review.md
 This file should include the full analysis with code snippets, links to relevant documentation, and detailed fix suggestions. Link to it from the chat summary.
 
 ## What to Look For
+
+### DESIGN.md Accuracy
+
+DESIGN.md is the single source of truth for the project's architecture and conventions. Part of every review is verifying that it still accurately reflects what the code does after the PR lands.
+
+For every PR, check whether the changes touch anything described in DESIGN.md:
+
+- **Data model changes** (new tables, columns, relationships, index choices, UUID vs INTEGER decisions)
+- **API surface changes** (new/changed endpoints, request/response shapes, auth requirements)
+- **Architecture changes** (new services, new layers, changes to how components talk to each other)
+- **Convention changes** (naming, error handling patterns, testing approach)
+- **Design decisions** (anything that would answer "why did we do it this way?" for a future reader)
+
+If the PR changes any of these, DESIGN.md should be updated in the same PR. Flag missing updates as an **Important** finding — merging code that drifts from the design doc silently erodes its value.
+
+If DESIGN.md *was* updated, verify the updates actually match what the code does. A stale or inaccurate update is worse than no update. Quote specific passages and compare them to the diff.
+
+If the PR doesn't touch anything DESIGN.md covers, say so explicitly in the review ("DESIGN.md accuracy: no changes required") so it's clear the check was performed.
 
 ### Code Quality
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -26,7 +26,7 @@ pub enum AppError {
     Forbidden(String),
     /// 404 — resource not found
     NotFound(String),
-    /// 409 — duplicate username, etc.
+    /// 409 — state conflict (e.g. closed session) or uniqueness violation (e.g. duplicate username)
     Conflict(String),
     /// 500 — unexpected internal failures (DB, crypto, etc.)
     /// The String is a log-only message; the user sees "Internal server error".

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -160,7 +160,7 @@ pub async fn create_run(
         .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
 
     if session.status != "active" {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Conflict(
             "Cannot submit run for a closed session".to_string(),
         ));
     }
@@ -382,7 +382,7 @@ pub async fn delete_run(
         .ok_or_else(|| AppError::Internal("Session not found for run".to_string()))?;
 
     if session.status != "active" {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Conflict(
             "Cannot delete run from a closed session".to_string(),
         ));
     }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -461,7 +461,7 @@ pub async fn join_session(
         .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
 
     if session.status != "active" {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Conflict(
             "Cannot join a closed session".to_string(),
         ));
     }
@@ -584,7 +584,7 @@ pub async fn next_track(
         .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
 
     if session.status != "active" {
-        return Err(AppError::BadRequest("Session is not active".to_string()));
+        return Err(AppError::Conflict("Session is not active".to_string()));
     }
 
     if session.host_id != user_id {
@@ -693,7 +693,7 @@ pub async fn skip_turn(
         .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
 
     if session.status != "active" {
-        return Err(AppError::BadRequest("Session is not active".to_string()));
+        return Err(AppError::Conflict("Session is not active".to_string()));
     }
 
     // Find the most recent race

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -228,7 +228,7 @@ async fn test_get_session_returns_participants_and_race_number() {
 }
 
 #[tokio::test]
-async fn test_join_closed_session_returns_400() {
+async fn test_join_closed_session_returns_409() {
     let (server, _db) = setup_test_app().await;
     let (token_host, _) = register_and_get_token(&server, "host").await;
     let (token_user2, _) = register_and_get_token(&server, "user2").await;
@@ -252,7 +252,7 @@ async fn test_join_closed_session_returns_400() {
         .post(&format!("/api/v1/sessions/{session_id}/join"))
         .add_header(AUTH_HEADER, auth_value(&token_user2))
         .await;
-    res.assert_status(axum::http::StatusCode::BAD_REQUEST);
+    res.assert_status(axum::http::StatusCode::CONFLICT);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Apply audit §1.5 error-variant convention: "session is not active" / "cannot X a closed session" errors are state conflicts (409), not malformed input (400)
- Add DESIGN.md accuracy check to the code-review skill

### Changed call sites

| File | Function | Old | New |
|------|----------|-----|-----|
| `services/sessions.rs` | `join_session` | BadRequest | Conflict |
| `services/sessions.rs` | `next_track` | BadRequest | Conflict |
| `services/sessions.rs` | `skip_turn` | BadRequest | Conflict |
| `services/runs.rs` | `create_run` | BadRequest | Conflict |
| `services/runs.rs` | `delete_run` | BadRequest | Conflict |

This aligns existing callers with `services/helpers.rs::load_active_session` (PR B), which already returns `Conflict` for closed sessions per the audit-approved convention.

## Test plan

```bash
cd backend

# 1. All tests pass (the integration test was updated to expect 409)
cargo test

# 2. Verify the specific integration test name and status code changed
cargo test --test session_integration test_join_closed_session_returns_409
# Expected: 1 passed

# 3. Confirm no 400 remains for "not active" / "closed session" checks
grep -n 'BadRequest.*closed\|BadRequest.*not active' src/services/sessions.rs src/services/runs.rs
# Expected: no output
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)