### PR TITLE
Pending races: schema, race-creation hook, query, get_session_detail integration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -338,7 +338,7 @@ Notes:
 - `skipped_at IS NULL` AND no corresponding `runs` row = pending state.
 - `skipped_at IS NOT NULL` = user explicitly forfeited this race.
 - A `runs` row for `(session_race_id, user_id)` = user submitted; pending state cleared by row presence in `runs`.
-- Rows are never deleted. After grace expires or after a session closes, rows remain in the DB for history; they just become inaccessible via normal API paths (filtered out by grace check or `session.status = 'active'` filter).
+- Rows are never deleted. After grace expires or after a session closes, rows remain in the DB for history; they just become inaccessible via normal API paths. Both filters are required — the grace check **and** the `session.status = 'active'` check — because a session can close (via `close_stale_sessions` or the host-leaves-last cascade) while users are still inside their 5-minute grace window. See the Pending Race Tracking derivation below.
 
 ### Runs
 
@@ -437,13 +437,14 @@ This approach supports an unbounded number of rivals — no tracking table neede
 
 Within a session, a participant may have "pending" races — session races they were present for but haven't yet submitted a time. The UI caps pending races at 3 (oldest expire first), but the schema places no limit, allowing this cap to be adjusted later.
 
-**Derivation.** A `session_race_participations` row represents pending state for user `U` and race `SR` iff all of the following hold:
+**Derivation.** A `session_race_participations` row represents pending state for user `U` and race `SR` iff **all** of the following hold:
 
 1. The row exists (i.e. `U` was present when `SR` was created).
 2. `skipped_at IS NULL` on the row.
 3. No `runs` row exists for `(SR.id, U.id)`.
 4. `U` is currently within grace — `session_participants.left_at IS NULL` OR `NOW() - left_at <= 5min`.
 5. `SR.created_at >= session_participants.joined_at` for `U` (excludes pre-gap pending after a long-gap rejoin reset `joined_at`).
+6. `sessions.status = 'active'` for `SR.session_id`. Closed sessions accept no further submissions or skips, so any pending entries on them would be phantom (no API path to resolve them). This is a separate filter from the grace check, not a substitute for it: a session can close while users are still inside their grace window (via `close_stale_sessions`, or as part of the host-leaves-last cascade in `leave_session`).
 
 Pending races are returned ordered by `session_races.race_number ASC`. The API returns all; the UI applies the 3-cap.
 
@@ -451,7 +452,7 @@ Pending races are returned ordered by `session_races.race_number ASC`. The API r
 
 **Session advancement.** If the session advances while a participant hasn't submitted, they see their pending list (oldest first) when they go to submit, and must resolve them in order before submitting for the current race. This ensures no one person holds up the group, consistent with "never feel rushed."
 
-**Forfeiture vs. deletion.** Forfeited pending records (those filtered out by grace expiration or `joined_at` reset) are **not deleted** from `session_race_participations`. They remain as historical state and become inaccessible via the derivation above. This preserves the audit trail of "what was pending at any moment" for debugging and future analytics.
+**Forfeiture vs. deletion.** Forfeited pending records (those filtered out by grace expiration, `joined_at` reset, or session close) are **not deleted** from `session_race_participations`. They remain as historical state and become inaccessible via the derivation above. This preserves the audit trail of "what was pending at any moment" for debugging and future analytics.
 
 ### Session Rulesets
 

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -269,6 +269,12 @@ impl MigrationTrait for Migration {
         .await?;
 
         // ---- Session participants ----
+        //
+        // One row per (session, user). Leave/rejoin mutates this row rather
+        // than appending a new one — `joined_at` is the start of the current
+        // presence segment, `left_at` is null while present. Per-race presence
+        // is captured by `session_race_participations` (below) at race-creation
+        // time, not derived from this table.
 
         conn.execute_unprepared(
             "CREATE TABLE IF NOT EXISTS session_participants (
@@ -276,7 +282,8 @@ impl MigrationTrait for Migration {
                     session_id TEXT NOT NULL REFERENCES sessions(id),
                     user_id TEXT NOT NULL REFERENCES users(id),
                     joined_at datetime_text NOT NULL,
-                    left_at datetime_text
+                    left_at datetime_text,
+                    UNIQUE(session_id, user_id)
                 )",
         )
         .await?;
@@ -308,6 +315,35 @@ impl MigrationTrait for Migration {
                     created_at datetime_text NOT NULL,
                     UNIQUE(session_id, race_number)
                 )",
+        )
+        .await?;
+
+        // ---- Session race participations ----
+        //
+        // One row per (race, user) for every user present at race-creation
+        // time. The row is the proof of "this user was present when this race
+        // was created" — pending-state derivation reads from here, not from a
+        // walk of `session_participants` history. `skipped_at` flips when the
+        // user explicitly forfeits the race.
+        //
+        // ON DELETE CASCADE on session_race_id matters for `skip_turn`, which
+        // deletes-and-replaces the current race; cascading drops the old
+        // participations atomically.
+
+        conn.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS session_race_participations (
+                    session_race_id TEXT NOT NULL REFERENCES session_races(id) ON DELETE CASCADE,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    created_at datetime_text NOT NULL,
+                    skipped_at datetime_text,
+                    PRIMARY KEY (session_race_id, user_id)
+                )",
+        )
+        .await?;
+
+        conn.execute_unprepared(
+            "CREATE INDEX idx_session_race_participations_user
+                 ON session_race_participations(user_id)",
         )
         .await?;
 
@@ -375,6 +411,8 @@ impl MigrationTrait for Migration {
         conn.execute_unprepared("DROP TABLE IF EXISTS run_flags")
             .await?;
         conn.execute_unprepared("DROP TABLE IF EXISTS runs").await?;
+        conn.execute_unprepared("DROP TABLE IF EXISTS session_race_participations")
+            .await?;
         conn.execute_unprepared("DROP TABLE IF EXISTS session_races")
             .await?;
         conn.execute_unprepared("DROP TABLE IF EXISTS session_participants")

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -326,14 +326,20 @@ impl MigrationTrait for Migration {
         // walk of `session_participants` history. `skipped_at` flips when the
         // user explicitly forfeits the race.
         //
-        // ON DELETE CASCADE on session_race_id matters for `skip_turn`, which
-        // deletes-and-replaces the current race; cascading drops the old
-        // participations atomically.
+        // ON DELETE CASCADE on session_race_id is required: `skip_turn`
+        // deletes-and-replaces the current race, and the old participations
+        // need to evaporate atomically with the race delete.
+        //
+        // user_id intentionally does NOT cascade — DESIGN.md guarantees these
+        // rows are never deleted (they're the audit trail of "who was present
+        // when"). If a user-deletion path is ever added, it must explicitly
+        // decide what to do with these rows rather than letting them silently
+        // vanish.
 
         conn.execute_unprepared(
             "CREATE TABLE IF NOT EXISTS session_race_participations (
                     session_race_id TEXT NOT NULL REFERENCES session_races(id) ON DELETE CASCADE,
-                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    user_id TEXT NOT NULL REFERENCES users(id),
                     created_at datetime_text NOT NULL,
                     skipped_at datetime_text,
                     PRIMARY KEY (session_race_id, user_id)

--- a/backend/src/entities/mod.rs
+++ b/backend/src/entities/mod.rs
@@ -10,6 +10,7 @@ pub mod gliders;
 pub mod run_flags;
 pub mod runs;
 pub mod session_participants;
+pub mod session_race_participations;
 pub mod session_races;
 pub mod sessions;
 pub mod tracks;

--- a/backend/src/entities/prelude.rs
+++ b/backend/src/entities/prelude.rs
@@ -8,6 +8,7 @@ pub use super::gliders::Entity as Gliders;
 pub use super::run_flags::Entity as RunFlags;
 pub use super::runs::Entity as Runs;
 pub use super::session_participants::Entity as SessionParticipants;
+pub use super::session_race_participations::Entity as SessionRaceParticipations;
 pub use super::session_races::Entity as SessionRaces;
 pub use super::sessions::Entity as Sessions;
 pub use super::tracks::Entity as Tracks;

--- a/backend/src/entities/session_race_participations.rs
+++ b/backend/src/entities/session_race_participations.rs
@@ -1,0 +1,52 @@
+//! Hand-written entity for `session_race_participations`.
+//!
+//! Composite primary key `(session_race_id, user_id)` — one row per (race, user)
+//! captured at race-creation time. Existence proves presence; `skipped_at`
+//! flips when the user explicitly forfeits the race.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "session_race_participations")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
+    pub session_race_id: String,
+    #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
+    pub user_id: String,
+    pub created_at: DateTime,
+    pub skipped_at: Option<DateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::session_races::Entity",
+        from = "Column::SessionRaceId",
+        to = "super::session_races::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    SessionRaces,
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::UserId",
+        to = "super::users::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Users,
+}
+
+impl Related<super::session_races::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SessionRaces.def()
+    }
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Users.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/entities/session_race_participations.rs
+++ b/backend/src/entities/session_race_participations.rs
@@ -32,7 +32,7 @@ pub enum Relation {
         from = "Column::UserId",
         to = "super::users::Column::Id",
         on_update = "NoAction",
-        on_delete = "Cascade"
+        on_delete = "NoAction"
     )]
     Users,
 }

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -51,11 +51,11 @@ pub async fn list_sessions(
 
 /// GET /sessions/:id — full session state for polling.
 pub async fn get_session(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<sessions::SessionDetail>, AppError> {
-    let detail = sessions::get_session_detail(&state.db, &id).await?;
+    let detail = sessions::get_session_detail(&state.db, &id, Some(&user.user_id)).await?;
     Ok(Json(detail))
 }
 

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -6,8 +6,8 @@
 use chrono::Utc;
 use rand::seq::SliceRandom;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait,
-    QueryFilter, Set, sea_query::Expr,
+    ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait, QueryFilter, Set,
+    sea_query::Expr,
 };
 
 use crate::domain::enums::SessionStatus;
@@ -80,16 +80,26 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
         .all(txn)
         .await?;
 
-    for participant in present {
-        session_race_participations::ActiveModel {
+    if present.is_empty() {
+        // `insert_many` with an empty iterator panics in some SeaORM
+        // versions; bail before the call. Nothing to snapshot is a valid
+        // state — e.g. all participants left between race creation and the
+        // helper call (shouldn't happen in normal flow, but defended here).
+        return Ok(());
+    }
+
+    let rows = present
+        .into_iter()
+        .map(|p| session_race_participations::ActiveModel {
             session_race_id: Set(session_race_id.to_string()),
-            user_id: Set(participant.user_id),
+            user_id: Set(p.user_id),
             created_at: Set(now),
             skipped_at: Set(None),
-        }
-        .insert(txn)
+        });
+
+    session_race_participations::Entity::insert_many(rows)
+        .exec(txn)
         .await?;
-    }
 
     Ok(())
 }
@@ -181,9 +191,12 @@ mod tests {
     use super::*;
     use sea_orm::{ActiveModelTrait, Set};
 
-    use crate::entities::{characters, cups, tracks};
+    use sea_orm::PaginatorTrait;
+
+    use crate::entities::{characters, cups, session_race_participations, tracks};
     use crate::test_helpers::{
-        create_user, insert_participant, insert_session, seed_tracks_for_test, setup_db,
+        create_user, insert_participant, insert_session, insert_session_race, seed_tracks_for_test,
+        setup_db,
     };
 
     // --- load_active_session ---
@@ -401,5 +414,74 @@ mod tests {
 
         let chosen = pick_random_track(&db, &[], &[]).await.unwrap();
         assert_eq!(chosen.id, 42);
+    }
+
+    // --- insert_race_participations ---
+
+    #[tokio::test]
+    async fn insert_race_participations_snapshots_only_present_users() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host = create_user(&db, "host").await;
+        let active = create_user(&db, "active").await;
+        let left = create_user(&db, "left").await;
+
+        let session_id = insert_session(&db, &host, "active").await;
+        insert_participant(&db, &session_id, &host, None).await;
+        insert_participant(&db, &session_id, &active, None).await;
+        insert_participant(&db, &session_id, &left, Some(Utc::now().naive_utc())).await;
+
+        let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
+
+        insert_race_participations(&db, &session_id, &race_id)
+            .await
+            .expect("snapshot succeeds");
+
+        let rows = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::SessionRaceId.eq(&race_id))
+            .all(&db)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "only the two left_at IS NULL users are snapshotted"
+        );
+        let users: std::collections::HashSet<&str> =
+            rows.iter().map(|r| r.user_id.as_str()).collect();
+        assert!(users.contains(host.as_str()));
+        assert!(users.contains(active.as_str()));
+        assert!(
+            !users.contains(left.as_str()),
+            "user with left_at set must not be snapshotted"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_race_participations_no_present_users_is_noop() {
+        // Edge case: a race exists but no participant is currently present
+        // (e.g. all left between race creation and the helper call). Helper
+        // should succeed and insert zero rows — no INSERT statement at all,
+        // since `insert_many` with an empty iterator panics in some
+        // SeaORM versions.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host, "active").await;
+        // host has already left
+        insert_participant(&db, &session_id, &host, Some(Utc::now().naive_utc())).await;
+
+        let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
+
+        insert_race_participations(&db, &session_id, &race_id)
+            .await
+            .expect("empty snapshot must not error");
+
+        let count = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::SessionRaceId.eq(&race_id))
+            .count(&db)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "no rows inserted when no users present");
     }
 }

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -6,12 +6,12 @@
 use chrono::Utc;
 use rand::seq::SliceRandom;
 use sea_orm::{
-    ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait, QueryFilter,
-    sea_query::Expr,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait,
+    QueryFilter, Set, sea_query::Expr,
 };
 
 use crate::domain::enums::SessionStatus;
-use crate::entities::{session_participants, sessions, tracks};
+use crate::entities::{session_participants, session_race_participations, sessions, tracks};
 use crate::error::AppError;
 
 /// Load a session by ID and require that it is in the `Active` state.
@@ -51,6 +51,47 @@ pub async fn require_active_participant<C: ConnectionTrait>(
         .one(db)
         .await?
         .ok_or_else(|| AppError::Forbidden("Not a participant in this session".into()))
+}
+
+/// Snapshot per-race presence at race-creation time.
+///
+/// Inserts one `session_race_participations` row for every user currently
+/// present in the session (`session_participants.left_at IS NULL`). The
+/// existence of each row is the proof that the user was present when the
+/// race was created — pending-state derivation reads from here, not from
+/// a participation history walk.
+///
+/// **Caller contract:** must run inside the same transaction as the
+/// `session_races` INSERT. If any participation insert fails the whole
+/// transaction rolls back, leaving no orphan race or partial snapshot.
+pub async fn insert_race_participations<C: ConnectionTrait>(
+    txn: &C,
+    session_id: &str,
+    session_race_id: &str,
+) -> Result<(), AppError> {
+    let now = Utc::now().naive_utc();
+
+    let present = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::LeftAt.is_null()),
+        )
+        .all(txn)
+        .await?;
+
+    for participant in present {
+        session_race_participations::ActiveModel {
+            session_race_id: Set(session_race_id.to_string()),
+            user_id: Set(participant.user_id),
+            created_at: Set(now),
+            skipped_at: Set(None),
+        }
+        .insert(txn)
+        .await?;
+    }
+
+    Ok(())
 }
 
 /// Bump the session's `last_activity_at` column to now. Single `UPDATE`,

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -863,7 +863,7 @@ mod tests {
         let (session_id, race_id) = setup_session_with_race(&db, &host_id).await;
 
         // Before submitting
-        let detail = sessions::get_session_detail(&db, &session_id)
+        let detail = sessions::get_session_detail(&db, &session_id, Some(&host_id))
             .await
             .unwrap();
         let current = detail.current_race.unwrap();
@@ -875,7 +875,7 @@ mod tests {
             .unwrap();
 
         // After submitting
-        let detail = sessions::get_session_detail(&db, &session_id)
+        let detail = sessions::get_session_detail(&db, &session_id, Some(&host_id))
             .await
             .unwrap();
         let current = detail.current_race.unwrap();

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -635,12 +635,17 @@ pub async fn join_session(
         }
         Some(row) => {
             let Some(left_at) = row.left_at else {
-                // Already present in this session. The partial unique index on
-                // user_id WHERE left_at IS NULL would catch a stray duplicate
-                // INSERT, but `check_not_in_any_session` should have already
-                // surfaced this as a 409 — reaching here implies a different
-                // active session, which is a user-level conflict.
-                return Err(AppError::Conflict("Already in this session".to_string()));
+                // Defensive: should be unreachable in normal flow. `existing`
+                // is filtered to (session_id, user_id), so a row with
+                // `left_at IS NULL` here means the user is already active in
+                // *this* session — and `check_not_in_any_session` above would
+                // have surfaced that as a 409 before we got here. Landing in
+                // this branch implies a race between the two queries (very
+                // unlikely without external manipulation) or direct DB
+                // tampering. Return Conflict either way for safety.
+                return Err(AppError::Conflict(
+                    "Already an active participant in this session".to_string(),
+                ));
             };
 
             let mut active: session_participants::ActiveModel = row.into();

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -117,7 +117,7 @@ pub async fn create_session(
 
     txn.commit().await?;
 
-    get_session_detail(db, &session_id).await
+    get_session_detail(db, &session_id, Some(user_id)).await
 }
 
 /// Summary info for listing active sessions.
@@ -283,6 +283,11 @@ pub struct SessionDetail {
     pub race_number: usize,
     pub current_race: Option<SessionRaceInfo>,
     pub races: Vec<RaceInfo>,
+    /// Pending races for the requesting user, oldest first. Empty if the
+    /// user is not in this session, has no pending races, or is past the
+    /// 5-minute grace window after leaving. The API returns all matching
+    /// rows; the UI applies the "max 3 pending" cap.
+    pub your_pending: Vec<SessionRaceInfo>,
 }
 
 // ── get_session_detail sub-queries ────────────────────────────────────
@@ -427,10 +432,105 @@ async fn load_race_history(
         .collect())
 }
 
+/// Row shape for the pending-races query.
+#[derive(Debug, FromQueryResult)]
+struct PendingRaceRow {
+    id: String,
+    race_number: i32,
+    track_id: i32,
+    track_name: String,
+    cup_name: String,
+    image_path: String,
+    created_at: NaiveDateTime,
+}
+
+/// Return the requesting user's pending races within a session, oldest first.
+///
+/// A race is **pending** for user `U` iff all of the following hold (per
+/// DESIGN.md "Pending Race Tracking"):
+///
+/// 1. A `session_race_participations` row exists for `(SR.id, U.id)` —
+///    proves `U` was present when `SR` was created.
+/// 2. `skipped_at IS NULL` on that row — `U` hasn't explicitly forfeited.
+/// 3. No `runs` row exists for `(SR.id, U.id)` — `U` hasn't submitted.
+/// 4. `U` is currently within grace — `session_participants.left_at IS NULL`
+///    OR `NOW() - left_at <= REJOIN_GRACE_MINUTES`.
+/// 5. `SR.created_at >= session_participants.joined_at` — excludes pre-gap
+///    pending after a long-gap rejoin reset `joined_at`.
+///
+/// Returns empty if the user is not a participant, all races are submitted/
+/// skipped, or the user is past the grace window.
+///
+/// **Lazy check note:** The grace-period predicate is computed at query time
+/// from `NOW()` and stored timestamps. No background task touches
+/// `session_race_participations` rows — they remain in the DB for history
+/// regardless of accessibility.
+///
+/// **`submissions` is intentionally empty.** Pending races report only the
+/// race shell here; per-race submissions belong to the current/history views,
+/// not the pending list. This avoids an N+1 query and keeps the polling path
+/// fast.
+pub async fn get_pending_races(
+    db: &impl ConnectionTrait,
+    session_id: &str,
+    user_id: &str,
+) -> Result<Vec<SessionRaceInfo>, AppError> {
+    let now = Utc::now().naive_utc();
+    let grace_cutoff = now - chrono::Duration::minutes(REJOIN_GRACE_MINUTES);
+
+    let rows = PendingRaceRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT sr.id, sr.race_number, sr.track_id,
+               t.name AS track_name, c.name AS cup_name,
+               t.image_path, sr.created_at
+        FROM session_race_participations srp
+        JOIN session_races sr ON srp.session_race_id = sr.id
+        JOIN tracks t ON sr.track_id = t.id
+        JOIN cups c ON t.cup_id = c.id
+        JOIN session_participants sp
+          ON sp.session_id = sr.session_id AND sp.user_id = srp.user_id
+        WHERE sr.session_id = $1
+          AND srp.user_id = $2
+          AND srp.skipped_at IS NULL
+          AND sr.created_at >= sp.joined_at
+          AND (sp.left_at IS NULL OR sp.left_at >= $3)
+          AND NOT EXISTS (
+              SELECT 1 FROM runs r
+              WHERE r.session_race_id = sr.id AND r.user_id = srp.user_id
+          )
+        ORDER BY sr.race_number ASC
+        "#,
+        [session_id.into(), user_id.into(), grace_cutoff.into()],
+    ))
+    .all(db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| SessionRaceInfo {
+            id: r.id,
+            race_number: r.race_number,
+            track_id: r.track_id,
+            track_name: r.track_name,
+            cup_name: r.cup_name,
+            image_path: r.image_path,
+            created_at: r.created_at.and_utc(),
+            submissions: Vec::new(),
+        })
+        .collect())
+}
+
 /// Get full session detail — the polling endpoint.
+///
+/// `requesting_user_id` is the authenticated caller — used to compute the
+/// per-user `your_pending` list. Anonymous callers aren't supported by the
+/// route layer, so this is always `Some` in production; tests pass `None`
+/// when they don't care about pending state.
 pub async fn get_session_detail(
     db: &DatabaseConnection,
     session_id: &str,
+    requesting_user_id: Option<&str>,
 ) -> Result<SessionDetail, AppError> {
     let session = sessions::Entity::find_by_id(session_id)
         .one(db)
@@ -441,6 +541,10 @@ pub async fn get_session_detail(
     let participants = load_participants(db, session_id).await?;
     let current_race = load_current_race_with_submissions(db, session_id).await?;
     let races = load_race_history(db, session_id).await?;
+    let your_pending = match requesting_user_id {
+        Some(uid) => get_pending_races(db, session_id, uid).await?,
+        None => Vec::new(),
+    };
 
     // Derive race_number from history instead of a separate COUNT query —
     // saves one DB round trip on every poll. Safe because race numbers are
@@ -462,10 +566,28 @@ pub async fn get_session_detail(
         race_number,
         current_race,
         races,
+        your_pending,
     })
 }
 
-/// Join a session. Creates a new participant row.
+/// Grace window for "rejoin without losing pre-leave pending races." Within
+/// this window of `left_at`, rejoining preserves `joined_at` (and therefore
+/// preserves access to pre-leave pending races, per the §3 grace semantics).
+/// After this window, `joined_at` is reset to NOW(), forfeiting any pre-gap
+/// pending records.
+pub const REJOIN_GRACE_MINUTES: i64 = 5;
+
+/// Join (or rejoin) a session. **Single mutable row per (session, user)** —
+/// first join INSERTs, rejoin mutates the existing row.
+///
+/// Rejoin behavior:
+/// - **Within grace** (`NOW() - left_at <= 5 min`): clear `left_at`, leave
+///   `joined_at` untouched. The user is treated as continuously present, so
+///   any pending races created before the leave remain accessible.
+/// - **Outside grace** (`NOW() - left_at > 5 min`): clear `left_at` AND reset
+///   `joined_at = NOW()`. Pre-gap pending records remain in the DB for
+///   history but are filtered out by the pending-races query
+///   (`session_races.created_at >= session_participants.joined_at`).
 pub async fn join_session(
     db: &DatabaseConnection,
     session_id: &str,
@@ -479,18 +601,53 @@ pub async fn join_session(
         })?;
     check_not_in_any_session(db, user_id).await?;
 
+    let existing = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await?;
+
     let now = Utc::now().naive_utc();
     let txn = db.begin().await?;
 
-    session_participants::ActiveModel {
-        id: Set(Uuid::new_v4().to_string()),
-        session_id: Set(session_id.to_string()),
-        user_id: Set(user_id.to_string()),
-        joined_at: Set(now),
-        left_at: Set(None),
+    match existing {
+        None => {
+            session_participants::ActiveModel {
+                id: Set(Uuid::new_v4().to_string()),
+                session_id: Set(session_id.to_string()),
+                user_id: Set(user_id.to_string()),
+                joined_at: Set(now),
+                left_at: Set(None),
+            }
+            .insert(&txn)
+            .await?;
+        }
+        Some(row) => {
+            let Some(left_at) = row.left_at else {
+                // Already present in this session. The partial unique index on
+                // user_id WHERE left_at IS NULL would catch a stray duplicate
+                // INSERT, but `check_not_in_any_session` should have already
+                // surfaced this as a 409 — reaching here implies a different
+                // active session, which is a user-level conflict.
+                return Err(AppError::Conflict("Already in this session".to_string()));
+            };
+
+            let mut active: session_participants::ActiveModel = row.into();
+            active.left_at = Set(None);
+
+            let gap = now.signed_duration_since(left_at);
+            if gap > chrono::Duration::minutes(REJOIN_GRACE_MINUTES) {
+                // Outside grace — reset joined_at so pre-gap pending records
+                // are filtered out of the user's pending list.
+                active.joined_at = Set(now);
+            }
+
+            active.update(&txn).await?;
+        }
     }
-    .insert(&txn)
-    .await?;
 
     helpers::touch_session(&txn, session_id).await?;
 
@@ -520,6 +677,13 @@ enum HostDisposition {
 /// the same transaction before calling this function. The non-host branch
 /// counts active participants via `left_at IS NULL`, and relies on the
 /// leaver's row being excluded by the prior update.
+///
+/// **Note on `joined_at` semantics:** `joined_at` is the start of the
+/// participant's *current* presence segment, which gets reset on a long-gap
+/// rejoin (see `join_session`). So "earliest-joined" effectively means
+/// "most-tenured in the current segment." That's the right host successor —
+/// someone who just rejoined after a long break shouldn't outrank a steadily
+/// present participant.
 async fn transfer_host_or_close(
     txn: &impl ConnectionTrait,
     session_id: &str,
@@ -646,6 +810,7 @@ pub async fn next_track(
     .insert(&txn)
     .await?;
 
+    helpers::insert_race_participations(&txn, session_id, &race_id).await?;
     helpers::touch_session(&txn, session_id).await?;
 
     txn.commit().await?;
@@ -717,7 +882,10 @@ pub async fn skip_turn(
     let now = Utc::now().naive_utc();
     let race_id = Uuid::new_v4().to_string();
 
-    // Delete old race + insert new one + update activity in a single transaction
+    // Delete old race + insert new one + snapshot present users in a single
+    // transaction. The old race's `session_race_participations` rows cascade
+    // away with the delete; the new race gets a fresh snapshot of who's
+    // currently present.
     let txn = db.begin().await?;
 
     current_race.delete(&txn).await?;
@@ -733,6 +901,7 @@ pub async fn skip_turn(
     .insert(&txn)
     .await?;
 
+    helpers::insert_race_participations(&txn, session_id, &race_id).await?;
     helpers::touch_session(&txn, session_id).await?;
 
     txn.commit().await?;
@@ -845,8 +1014,10 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppErr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::entities::session_race_participations;
     use crate::test_helpers::{
-        create_user, insert_participant, insert_session, seed_tracks_for_test, setup_db,
+        backdate_participant, create_user, insert_participant, insert_race_participation,
+        insert_session, insert_session_race, seed_tracks_for_test, setup_db,
     };
 
     // ── load_host_username ───────────────────────────────────────────
@@ -1093,7 +1264,9 @@ mod tests {
         let session = create_session(&db, &host_id, "random").await.unwrap();
         join_session(&db, &session.id, &user2_id).await.unwrap();
 
-        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        let detail = get_session_detail(&db, &session.id, Some(&host_id))
+            .await
+            .unwrap();
         assert_eq!(detail.participants.len(), 2);
         assert_eq!(detail.host_username, "host");
         assert_eq!(detail.race_number, 1);
@@ -1339,12 +1512,16 @@ mod tests {
         let session = create_session(&db, &host_id, "random").await.unwrap();
 
         // Before any track pick, current_race should be None
-        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        let detail = get_session_detail(&db, &session.id, Some(&host_id))
+            .await
+            .unwrap();
         assert!(detail.current_race.is_none());
 
         // After picking a track, current_race should be populated
         let race = next_track(&db, &session.id, &host_id).await.unwrap();
-        let detail = get_session_detail(&db, &session.id).await.unwrap();
+        let detail = get_session_detail(&db, &session.id, Some(&host_id))
+            .await
+            .unwrap();
         let current = detail.current_race.expect("current_race should be Some");
         assert_eq!(current.track_id, race.track_id);
         assert_eq!(current.track_name, race.track_name);
@@ -1421,5 +1598,479 @@ mod tests {
             create_session(&db, &user_id, "random").await.is_ok(),
             "user should be freed from stale session"
         );
+    }
+
+    // ── Race-creation participation hook (PR 3D-1) ──────────────────────
+
+    #[tokio::test]
+    async fn test_create_session_race_inserts_participations_for_currently_present_users() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let parts = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::SessionRaceId.eq(&race.id))
+            .all(&db)
+            .await
+            .unwrap();
+        assert_eq!(parts.len(), 2, "one row per currently-present user");
+        let user_ids: std::collections::HashSet<&str> =
+            parts.iter().map(|p| p.user_id.as_str()).collect();
+        assert!(user_ids.contains(host_id.as_str()));
+        assert!(user_ids.contains(user2_id.as_str()));
+        for p in &parts {
+            assert!(
+                p.skipped_at.is_none(),
+                "fresh participation rows are not skipped"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_session_race_does_not_insert_participations_for_left_users() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let leaver_id = create_user(&db, "leaver").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &leaver_id).await.unwrap();
+        leave_session(&db, &session.id, &leaver_id).await.unwrap();
+
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let parts = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::SessionRaceId.eq(&race.id))
+            .all(&db)
+            .await
+            .unwrap();
+        assert_eq!(
+            parts.len(),
+            1,
+            "only the still-present host should be snapshotted"
+        );
+        assert_eq!(parts[0].user_id, host_id);
+    }
+
+    #[tokio::test]
+    async fn test_create_session_race_atomic_with_race_insert() {
+        // If a participation insert fails inside the same transaction as the
+        // session_races insert, the entire transaction must roll back —
+        // the race row must not be visible afterwards. We force the failure
+        // by trying to INSERT a participation row with a non-existent
+        // user_id (FK violation) inside the same txn.
+        use sea_orm::TransactionTrait;
+
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, "active").await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+
+        let txn = db.begin().await.unwrap();
+        let race_id = Uuid::new_v4().to_string();
+        let now = Utc::now().naive_utc();
+
+        session_races::ActiveModel {
+            id: Set(race_id.clone()),
+            session_id: Set(session_id.clone()),
+            race_number: Set(1),
+            track_id: Set(1),
+            chosen_by: Set(None),
+            created_at: Set(now),
+        }
+        .insert(&txn)
+        .await
+        .expect("race insert succeeds");
+
+        // FK violation: user_id "ghost" doesn't exist in users.
+        let bad = session_race_participations::ActiveModel {
+            session_race_id: Set(race_id.clone()),
+            user_id: Set("ghost".to_string()),
+            created_at: Set(now),
+            skipped_at: Set(None),
+        }
+        .insert(&txn)
+        .await;
+        assert!(bad.is_err(), "FK violation must surface as Err");
+
+        txn.rollback().await.unwrap();
+
+        let race = session_races::Entity::find_by_id(&race_id)
+            .one(&db)
+            .await
+            .unwrap();
+        assert!(
+            race.is_none(),
+            "session_races row must be rolled back when a participation insert fails"
+        );
+    }
+
+    // ── Pending race query (PR 3D-1) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_pending_includes_unresolved_present_races() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, race.id);
+        assert_eq!(pending[0].race_number, race.race_number);
+        assert_eq!(pending[0].track_id, race.track_id);
+    }
+
+    #[tokio::test]
+    async fn test_pending_excludes_submitted_races() {
+        // Insert a runs row directly to avoid pulling all of run-creation's
+        // validation surface into a query test.
+        use crate::drink_type_id::drink_type_uuid;
+        use crate::entities::{drink_types, runs};
+        use crate::test_helpers::seed_game_data;
+
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, "active").await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
+        insert_race_participation(&db, &race_id, &host_id, None).await;
+
+        // Verify pending before the run
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1);
+
+        // Insert a run row for this (race, user)
+        let drink_id = drink_type_uuid("Test Beer");
+        let _drink = drink_types::Entity::find_by_id(&drink_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .expect("seed_game_data inserts Test Beer");
+        runs::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(host_id.clone()),
+            session_race_id: Set(race_id.clone()),
+            track_id: Set(1),
+            character_id: Set(1),
+            body_id: Set(1),
+            wheel_id: Set(1),
+            glider_id: Set(1),
+            track_time: Set(120_000),
+            lap1_time: Set(40_000),
+            lap2_time: Set(40_000),
+            lap3_time: Set(40_000),
+            drink_type_id: Set(drink_id),
+            disqualified: Set(false),
+            photo_path: Set(None),
+            created_at: Set(Utc::now().naive_utc()),
+            notes: Set(None),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "submitted races drop from pending");
+    }
+
+    #[tokio::test]
+    async fn test_pending_excludes_skipped_races() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, "active").await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
+
+        // skipped_at IS NOT NULL → not pending
+        insert_race_participation(&db, &race_id, &host_id, Some(Utc::now().naive_utc())).await;
+
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "skipped races drop from pending");
+    }
+
+    #[tokio::test]
+    async fn test_pending_excludes_races_user_was_absent_for() {
+        // User B leaves before the race is created — so next_track only
+        // snapshots A. After B rejoins, B has no participation row for that
+        // race and therefore no pending entry for it.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+
+        let pending_b = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert!(
+            pending_b.is_empty(),
+            "user absent at race creation has no pending row"
+        );
+
+        let pending_a = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(
+            pending_a.len(),
+            1,
+            "host who was present has a pending entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pending_returned_ordered_by_race_number_asc() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let r1 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r2 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r3 = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        let race_numbers: Vec<i32> = pending.iter().map(|r| r.race_number).collect();
+        assert_eq!(race_numbers, vec![1, 2, 3]);
+        assert_eq!(pending[0].id, r1.id);
+        assert_eq!(pending[1].id, r2.id);
+        assert_eq!(pending[2].id, r3.id);
+    }
+
+    #[tokio::test]
+    async fn test_pending_returns_all_records_ui_caps() {
+        // Schema/API has no cap; the 3-cap is a UI concern. Verify the
+        // backend returns more than 3 when more than 3 are pending.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        for _ in 0..5 {
+            next_track(&db, &session.id, &host_id).await.unwrap();
+        }
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 5, "API returns all; UI applies the cap");
+    }
+
+    // ── Grace period (PR 3D-1) ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_pending_accessible_when_currently_in_session() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1, "left_at IS NULL → pending accessible");
+    }
+
+    #[tokio::test]
+    async fn test_pending_accessible_when_within_grace() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        // Backdate left_at to 3 minutes ago — well inside the 5-minute window.
+        let three_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(3);
+        backdate_participant(&db, &session.id, &host_id, None, Some(three_min_ago)).await;
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1, "within grace, pending stays accessible");
+    }
+
+    #[tokio::test]
+    async fn test_pending_inaccessible_when_grace_expired() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        // Backdate left_at to 6 minutes ago — past the 5-minute window.
+        let six_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(6);
+        backdate_participant(&db, &session.id, &host_id, None, Some(six_min_ago)).await;
+
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "grace expired → no accessible pending");
+
+        // The row still exists in the DB (lazy check, no cleanup).
+        let count = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::UserId.eq(&host_id))
+            .count(&db)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "participation row remains for history");
+    }
+
+    #[tokio::test]
+    async fn test_rejoin_within_grace_preserves_pending() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Capture B's joined_at, then leave + backdate left_at to 3 min ago.
+        let original_joined = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&user_b)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .joined_at;
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+        let three_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(3);
+        backdate_participant(&db, &session.id, &user_b, None, Some(three_min_ago)).await;
+
+        join_session(&db, &session.id, &user_b).await.unwrap();
+
+        let row = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&user_b)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.left_at.is_none(), "left_at cleared on rejoin");
+        assert_eq!(
+            row.joined_at, original_joined,
+            "within-grace rejoin must NOT advance joined_at"
+        );
+
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "pre-leave pending preserved on within-grace rejoin"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rejoin_after_grace_resets_joined_at_and_forfeits_pending() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        let original_joined = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&user_b)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .joined_at;
+
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+        // Backdate left_at to 20 min ago — well past the 5-minute window.
+        let twenty_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(20);
+        backdate_participant(&db, &session.id, &user_b, None, Some(twenty_min_ago)).await;
+
+        join_session(&db, &session.id, &user_b).await.unwrap();
+
+        let row = session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(&session.id))
+                    .add(session_participants::Column::UserId.eq(&user_b)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.left_at.is_none(), "left_at cleared on rejoin");
+        assert!(
+            row.joined_at > original_joined,
+            "outside-grace rejoin must advance joined_at: was {}, now {}",
+            original_joined,
+            row.joined_at,
+        );
+
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert!(
+            pending.is_empty(),
+            "pre-gap pending is forfeited (filtered by created_at >= joined_at)"
+        );
+
+        // The participation row itself stays for history.
+        let count = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::UserId.eq(&user_b))
+            .count(&db)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "forfeited participation row remains in DB");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_short_flaps_within_grace_preserve_pending() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Flap 1: leave, backdate left_at to 2 min ago, rejoin.
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+        let two_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(2);
+        backdate_participant(&db, &session.id, &user_b, None, Some(two_min_ago)).await;
+        join_session(&db, &session.id, &user_b).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(pending.len(), 1, "after first short flap, pending intact");
+
+        // Flap 2: leave again, backdate left_at to 1 min ago, rejoin.
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+        let one_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(1);
+        backdate_participant(&db, &session.id, &user_b, None, Some(one_min_ago)).await;
+        join_session(&db, &session.id, &user_b).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(pending.len(), 1, "multiple short flaps preserve pending");
+    }
+
+    /// Documents intent: no background timer or sweeper task touches
+    /// `session_race_participations`. Pending accessibility is a pure read-time
+    /// derivation from `(session_race_participations, session_participants,
+    /// runs)` — see `get_pending_races`. Forfeited rows remain in the DB
+    /// indefinitely as historical state. If a future PR adds a sweeper, this
+    /// assertion (and the design rationale in DESIGN.md "Pending Race
+    /// Tracking") needs to be revisited.
+    #[tokio::test]
+    async fn test_lazy_check_assertion() {
+        // No-op test by design — this comment IS the assertion.
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -457,9 +457,15 @@ struct PendingRaceRow {
 ///    OR `NOW() - left_at <= REJOIN_GRACE_MINUTES`.
 /// 5. `SR.created_at >= session_participants.joined_at` — excludes pre-gap
 ///    pending after a long-gap rejoin reset `joined_at`.
+/// 6. `sessions.status = 'active'` — closed sessions accept no further
+///    submissions, so any "pending" entries on them are phantom (the user
+///    has no API path to resolve them). Required in addition to the grace
+///    clause: a session can close while users are still inside their
+///    5-minute grace window (e.g. via `close_stale_sessions`, or as part of
+///    the host-leaves-last cascade).
 ///
 /// Returns empty if the user is not a participant, all races are submitted/
-/// skipped, or the user is past the grace window.
+/// skipped, the session is closed, or the user is past the grace window.
 ///
 /// **Lazy check note:** The grace-period predicate is computed at query time
 /// from `NOW()` and stored timestamps. No background task touches
@@ -486,12 +492,14 @@ pub async fn get_pending_races(
                t.image_path, sr.created_at
         FROM session_race_participations srp
         JOIN session_races sr ON srp.session_race_id = sr.id
+        JOIN sessions s ON s.id = sr.session_id
         JOIN tracks t ON sr.track_id = t.id
         JOIN cups c ON t.cup_id = c.id
         JOIN session_participants sp
           ON sp.session_id = sr.session_id AND sp.user_id = srp.user_id
         WHERE sr.session_id = $1
           AND srp.user_id = $2
+          AND s.status = 'active'
           AND srp.skipped_at IS NULL
           AND sr.created_at >= sp.joined_at
           AND (sp.left_at IS NULL OR sp.left_at >= $3)
@@ -1879,40 +1887,56 @@ mod tests {
 
     #[tokio::test]
     async fn test_pending_accessible_when_within_grace() {
+        // Two participants so the session stays active after user_b leaves
+        // (host transfer keeps it open). This isolates the grace check from
+        // the session-status filter — we want to assert grace alone keeps
+        // pending accessible.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
         let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
         next_track(&db, &session.id, &host_id).await.unwrap();
-        leave_session(&db, &session.id, &host_id).await.unwrap();
+        leave_session(&db, &session.id, &user_b).await.unwrap();
 
-        // Backdate left_at to 3 minutes ago — well inside the 5-minute window.
+        // Backdate user_b's left_at to 3 minutes ago — well inside the
+        // 5-minute window. Session is still active (host remained).
         let three_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(3);
-        backdate_participant(&db, &session.id, &host_id, None, Some(three_min_ago)).await;
+        backdate_participant(&db, &session.id, &user_b, None, Some(three_min_ago)).await;
 
-        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
-        assert_eq!(pending.len(), 1, "within grace, pending stays accessible");
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "within grace + active session → pending accessible"
+        );
     }
 
     #[tokio::test]
     async fn test_pending_inaccessible_when_grace_expired() {
+        // Two participants so the session stays active — this isolates the
+        // grace check from the status filter, proving exclusion is from
+        // grace expiration alone.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
         let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
         next_track(&db, &session.id, &host_id).await.unwrap();
-        leave_session(&db, &session.id, &host_id).await.unwrap();
+        leave_session(&db, &session.id, &user_b).await.unwrap();
 
-        // Backdate left_at to 6 minutes ago — past the 5-minute window.
+        // Backdate user_b's left_at to 6 minutes ago — past the 5-minute window.
         let six_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(6);
-        backdate_participant(&db, &session.id, &host_id, None, Some(six_min_ago)).await;
+        backdate_participant(&db, &session.id, &user_b, None, Some(six_min_ago)).await;
 
-        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
         assert!(pending.is_empty(), "grace expired → no accessible pending");
 
         // The row still exists in the DB (lazy check, no cleanup).
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(&host_id))
+            .filter(session_race_participations::Column::UserId.eq(&user_b))
             .count(&db)
             .await
             .unwrap();
@@ -2072,5 +2096,55 @@ mod tests {
     #[tokio::test]
     async fn test_lazy_check_assertion() {
         // No-op test by design — this comment IS the assertion.
+    }
+
+    #[tokio::test]
+    async fn test_pending_excludes_closed_session_even_within_grace() {
+        // Regression: `close_stale_sessions` (and the host-leaves-last
+        // cascade in leave_session) sets `left_at = NOW()` for still-active
+        // participants and flips `status` to closed in the same transaction.
+        // Within the next 5 minutes, those users are inside the grace window
+        // — but the session can no longer accept submissions or skips, so
+        // the pending entries are phantom. `get_pending_races` must filter
+        // them out via `sessions.status = 'active'`.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Sanity: pending exists while session is active.
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1);
+
+        // Backdate last_activity_at past the stale threshold so
+        // close_stale_sessions catches it; this mirrors the production path
+        // (sets left_at = NOW() and status = 'closed' atomically).
+        let two_hours_ago = Utc::now().naive_utc() - chrono::Duration::hours(2);
+        let s = sessions::Entity::find_by_id(&session.id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut active: sessions::ActiveModel = s.into();
+        active.last_activity_at = Set(two_hours_ago);
+        active.update(&db).await.unwrap();
+        close_stale_sessions(&db).await.unwrap();
+
+        // Host's left_at is now ~now (well within the 5-min grace), but the
+        // session is closed — pending must be empty.
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert!(
+            pending.is_empty(),
+            "closed session must not return pending even within grace window"
+        );
+
+        // The participation row itself stays in the DB for history.
+        let count = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::UserId.eq(&host_id))
+            .count(&db)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "participation row remains for history");
     }
 }

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 
 use crate::drink_type_id::drink_type_uuid;
 use crate::entities::{
-    bodies, characters, cups, drink_types, gliders, session_participants, sessions, tracks, users,
-    wheels,
+    bodies, characters, cups, drink_types, gliders, session_participants,
+    session_race_participations, session_races, sessions, tracks, users, wheels,
 };
 
 /// Spin up an in-memory SQLite database with foreign keys enabled and all
@@ -138,6 +138,80 @@ pub async fn insert_participant(
     .insert(db)
     .await
     .expect("insert participant");
+}
+
+/// Insert a `session_races` row directly. Returns the new race ID. Useful
+/// for pending-races tests that need to construct races at specific
+/// timestamps without going through `next_track`.
+pub async fn insert_session_race(
+    db: &DatabaseConnection,
+    session_id: &str,
+    race_number: i32,
+    track_id: i32,
+    created_at: chrono::NaiveDateTime,
+) -> String {
+    let id = Uuid::new_v4().to_string();
+    session_races::ActiveModel {
+        id: Set(id.clone()),
+        session_id: Set(session_id.to_string()),
+        race_number: Set(race_number),
+        track_id: Set(track_id),
+        chosen_by: Set(None),
+        created_at: Set(created_at),
+    }
+    .insert(db)
+    .await
+    .expect("insert session race");
+    id
+}
+
+/// Insert a `session_race_participations` row directly. Use this in tests
+/// that need fine-grained control over per-race presence and skip status.
+pub async fn insert_race_participation(
+    db: &DatabaseConnection,
+    session_race_id: &str,
+    user_id: &str,
+    skipped_at: Option<chrono::NaiveDateTime>,
+) {
+    session_race_participations::ActiveModel {
+        session_race_id: Set(session_race_id.to_string()),
+        user_id: Set(user_id.to_string()),
+        created_at: Set(Utc::now().naive_utc()),
+        skipped_at: Set(skipped_at),
+    }
+    .insert(db)
+    .await
+    .expect("insert race participation");
+}
+
+/// Backdate a participant's `left_at` and optionally `joined_at`. Tests use
+/// this to simulate "user left N minutes ago" without sleeping.
+pub async fn backdate_participant(
+    db: &DatabaseConnection,
+    session_id: &str,
+    user_id: &str,
+    joined_at: Option<chrono::NaiveDateTime>,
+    left_at: Option<chrono::NaiveDateTime>,
+) {
+    use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter};
+
+    let row = session_participants::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_participants::Column::SessionId.eq(session_id))
+                .add(session_participants::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await
+        .expect("query participant")
+        .expect("participant exists");
+
+    let mut active: session_participants::ActiveModel = row.into();
+    if let Some(j) = joined_at {
+        active.joined_at = Set(j);
+    }
+    active.left_at = Set(left_at);
+    active.update(db).await.expect("backdate participant");
 }
 
 /// Seed the minimum game data required for run-creation tests: one each of


### PR DESCRIPTION
## Summary

Read-side foundation for the Pending Races & Grace Period feature, per [`reviews/design/2026-04-19-pending-races-and-grace-period.md`](reviews/design/2026-04-19-pending-races-and-grace-period.md) (fully signed off). Enforcement (skip endpoint, ordered-submit check, HTTP integration tests) is intentionally **deferred to PR 3D-2**.

After this PR the system can:
- Track per-race presence at race-creation time.
- Track which races a user has pending (correctly excluding submitted, skipped, absent-at-creation, and grace-expired).
- Surface a user's pending list as `your_pending` on the session detail polling response.

After this PR the system **cannot yet**:
- Skip a pending race via API (no endpoint).
- Block out-of-order run submission (`create_run` still accepts any order).

That gap is intentional — 3D-1 is read-side only.

## Schema (consolidated migration edited in place)

- `session_participants` gains `UNIQUE(session_id, user_id)` — single mutable row per (session, user) replaces the old multi-row history design. The partial unique index `(user_id) WHERE left_at IS NULL` stays; it still enforces "active in only one session at a time."
- New `session_race_participations` table: composite PK `(session_race_id, user_id)`, `ON DELETE CASCADE` on the **race-side** FK (`skip_turn`'s delete-and-replace relies on it), plain `REFERENCES` on the user-side FK (rows are never deleted by design — preserves the audit trail), index on `user_id`.

## Service changes

- **`helpers::insert_race_participations`** snapshots currently-present users into `session_race_participations` inside the same transaction as the race insert. Wired into `next_track` and `skip_turn`. Single `insert_many` per call.
- **`join_session`** rewritten for single-row mutate-on-rejoin. Within the 5-min grace window, rejoin only clears `left_at`; outside the window, `joined_at` resets to `NOW()` — which forfeits pre-gap pending records via the `get_pending_races` derivation.
- **`get_pending_races`** implements the 6-clause derivation from DESIGN.md (presence row + not skipped + no run + within grace + post-`joined_at` + session is active). Uses `find_by_statement` per the §5.1 ORM convention for multi-table JOINs. The `sessions.status = 'active'` clause was added in commit `a975225` after PR review caught a phantom-pending bug for sessions that close while a user is still inside their grace window.
- **`get_session_detail`** now takes `Option<&str> requesting_user_id` and includes `your_pending: Vec<SessionRaceInfo>` in the response. Route handler passes the auth user.

`SessionRaceInfo.submissions` is intentionally empty for pending races to avoid an N+1 on the polling path; the design review didn't require submissions on pending entries. Easy to add later if needed.

## Tests

**19 new tests, 204 total** (was 185 on main). All pass.

- 3 race-creation hook tests in `services::sessions::tests::test_create_session_race_*` — presence snapshot correctness, atomicity (FK violation rolls back the race insert).
- 6 pending-query tests in `services::sessions::tests::test_pending_*` — happy path, exclusions for submitted/skipped/absent-at-creation, ordering, no schema cap.
- 7 grace-period tests in `services::sessions::tests::test_pending_*` and `test_*_grace_*` — in-session, within grace, expired, within-grace rejoin (preserves `joined_at`), after-grace rejoin (resets `joined_at`, forfeits pending), multiple flaps, lazy-check intent assertion.
- 1 closed-session regression test (`test_pending_excludes_closed_session_even_within_grace`) added in `a975225` — exercises the `close_stale_sessions` path.
- 2 helper unit tests in `services::helpers::tests::insert_race_participations_*` added in `2be5b18` — direct coverage for the snapshot helper, including the empty-snapshot edge case.

`backdate_participant`, `insert_session_race`, and `insert_race_participation` test helpers added for fine-grained timestamp manipulation without sleeping.

## Reviewer note

**Reset the dev DB before booting** to pick up the schema change (per the prelaunch convention):
```
rm data/db/beerio-kart.db
```
The consolidated migration rebuilds the schema on next startup; SeaORM seeds run automatically.

## What this PR does NOT do

- `POST /sessions/:id/races/:race_id/skip` endpoint — PR 3D-2.
- Ordered-submit enforcement in `create_run` — PR 3D-2.
- HTTP-layer integration tests for the new behavior — PR 3D-2.
- Frontend consumption of `your_pending` — separate UI design.

## Test plan

### 1. Test suite (fast path — covers all logic)

```bash
git fetch origin phase-3/3d-1-pending-foundation
git checkout phase-3/3d-1-pending-foundation
rm -f data/db/beerio-kart.db
cd backend && cargo test
```

**Expected:** `test result: ok. 204 passed; 0 failed` total across all targets — broken down as 138 lib + 27 api_integration + 21 auth_integration + 8 auth_middleware + 10 session_integration.

To run only the tests added/modified in this PR:

```bash
cd backend && cargo test --lib -- \
    services::sessions::tests::test_create_session_race \
    services::sessions::tests::test_pending \
    services::sessions::tests::test_rejoin_within_grace \
    services::sessions::tests::test_rejoin_after_grace \
    services::sessions::tests::test_multiple_short_flaps \
    services::sessions::tests::test_lazy_check \
    services::helpers::tests::insert_race_participations
```

**Expected:** 19 tests, all pass.

### 2. End-to-end smoke test (HTTP + direct DB inspection)

Requires `jq` and `sqlite3`. Run from the repo root with the backend booted in another terminal:

```bash
# Terminal 1 — backend (will block; leave running)
cd backend && rm -f ../data/db/beerio-kart.db && JWT_SECRET=smoke-test-secret COOKIE_SECURE=false cargo run
# Wait for "Seeding complete" before continuing.
```

```bash
# Terminal 2 — set up env vars and run the smoke test
API=http://localhost:3000/api/v1
DB=data/db/beerio-kart.db

# Sanity check: backend is up. `curl -s` swallows connection errors silently,
# which would otherwise leave $A empty and produce confusing `null` outputs
# downstream. Run this first to fail fast if the server isn't listening yet.
curl -fsS "$API/hello" -o /dev/null && echo "backend up" || \
    { echo "backend not reachable on $API — start it in terminal 1 first" >&2; }

# Register two users; capture access tokens and user IDs.
A=$(curl -s -X POST "$API/auth/register" \
    -H 'Content-Type: application/json' \
    -d '{"username":"alice","password":"smoketest123"}')
TOKEN_A=$(echo "$A" | jq -r .access_token)
USER_A=$(echo  "$A" | jq -r .user.id)

B=$(curl -s -X POST "$API/auth/register" \
    -H 'Content-Type: application/json' \
    -d '{"username":"bob","password":"smoketest123"}')
TOKEN_B=$(echo "$B" | jq -r .access_token)
USER_B=$(echo  "$B" | jq -r .user.id)

echo "alice=$USER_A bob=$USER_B"
```

**Expected:** two non-empty UUIDs printed. If either is `null`, the register call failed — re-check the backend log.

```bash
# Step A: alice creates a session, bob joins.
SESSION=$(curl -s -X POST "$API/sessions" \
    -H "Authorization: Bearer $TOKEN_A" \
    -H 'Content-Type: application/json' \
    -d '{"ruleset":"random"}' | jq -r .id)

curl -s -X POST "$API/sessions/$SESSION/join" \
    -H "Authorization: Bearer $TOKEN_B" -o /dev/null -w "%{http_code}\n"
# Expected: 204
```

```bash
# Step B: alice picks the next track. This is the call that should
# create one session_race_participations row per currently-present user.
RACE=$(curl -s -X POST "$API/sessions/$SESSION/next-track" \
    -H "Authorization: Bearer $TOKEN_A" | jq -r .id)
echo "race=$RACE"
```

**Verify in the DB** — should show **2 rows** (one for alice, one for bob), both with `skipped_at = NULL`:

```bash
sqlite3 -header -column "$DB" \
    "SELECT user_id, created_at, skipped_at
     FROM session_race_participations
     WHERE session_race_id = '$RACE';"
```

**Expected output (2 rows, ordering may differ):**
```
user_id                               created_at                  skipped_at
------------------------------------  --------------------------  ----------
<alice's UUID>                        2026-05-02T...                          
<bob's UUID>                          2026-05-02T...                          
```

```bash
# Step C: alice's pending list contains the race.
curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN_A" | jq '(.your_pending | length), .your_pending[0].id'
# Expected: 1 then "$RACE"
```

```bash
# Step D: alice leaves the session. Session stays active because bob is
# still in it — host transfer keeps it open.
curl -s -X POST "$API/sessions/$SESSION/leave" \
    -H "Authorization: Bearer $TOKEN_A" -o /dev/null -w "%{http_code}\n"
# Expected: 204
```

```bash
# Step E: while still within 5 minutes, alice's pending is preserved.
curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN_A" | jq '.your_pending | length'
# Expected: 1
```

```bash
# Step F: backdate alice's left_at to 6 minutes ago to simulate the
# grace window expiring without waiting. Then re-query.
sqlite3 "$DB" \
    "UPDATE session_participants
       SET left_at = datetime('now', '-6 minutes')
     WHERE session_id = '$SESSION' AND user_id = '$USER_A';"

curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN_A" | jq '.your_pending | length'
# Expected: 0  (grace expired → no accessible pending)
```

```bash
# Step G: confirm the participation row still exists in the DB
# (lazy check — no cleanup task touches it).
sqlite3 -header "$DB" \
    "SELECT COUNT(*) AS rows_remaining
     FROM session_race_participations
     WHERE user_id = '$USER_A';"
# Expected: rows_remaining = 1
```

### 3. Closed-session regression check (added in `a975225`)

This exercises the bug from the first review run — pending should NOT be returned for a session that's closed, even when the user is well within their grace window.

```bash
# Continuing from the smoke test above.
# Backdate bob's left_at to within grace, then have bob leave so the
# session closes via the host-leaves-last cascade.
sqlite3 "$DB" \
    "UPDATE session_participants
       SET left_at = datetime('now', '-2 minutes')
     WHERE session_id = '$SESSION' AND user_id = '$USER_B';"

# Force-close the session directly (mirrors the close_stale_sessions effect).
sqlite3 "$DB" \
    "UPDATE sessions SET status = 'closed' WHERE id = '$SESSION';"

# Bob is within grace AND has a presence row for the race — but the session
# is closed, so pending must be empty.
curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN_B" | jq '.your_pending | length'
# Expected: 0  (closed session → no accessible pending, even within grace)
```

If all expected outputs match, the read-side foundation is working end-to-end including the closed-session edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
