### PR TITLE
Pending races: skip endpoint and ordered-submit guard

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -266,7 +266,7 @@ Notes:
 - `host_id` starts as `created_by`. If the host leaves, host role transfers to the earliest-joined remaining participant.
 - `least_played_drink_category` stores values as `"alcoholic"` or `"non_alcoholic"` (snake_case, per database convention). The frontend maps these to display text with hyphens ("non-alcoholic").
 - Ruleset-specific config uses explicit nullable columns rather than a JSON blob. With four well-defined rulesets, explicit columns are safer (database can enforce CHECK constraints) and queryable. New config options require a migration, but that's the right tradeoff for known rulesets.
-- Session auto-closes after 1 hour of no activity. No further run submissions accepted after close. A lightweight Tokio background task checks for and closes stale sessions periodically (e.g., every 5 minutes) so they don't linger in the active sessions list. Actions that update `last_activity_at`: run submission, track selection (next-track, choose-track), join, leave, skip-turn.
+- Session auto-closes after 1 hour of no activity. No further run submissions accepted after close. A lightweight Tokio background task checks for and closes stale sessions periodically (e.g., every 5 minutes) so they don't linger in the active sessions list. Actions that update `last_activity_at`: run submission, track selection (next-track, choose-track), join, leave, skip-turn (chooser pass), skip-pending-race (forfeit a pending race).
 - Future consideration: `password_hash` column for session passwords. Deferred — the `POST /sessions/:id/join` endpoint is designed as a dedicated action so password checking can be added later without restructuring the join flow.
 - A user can only be active in one session at a time (enforced by a partial unique index on `session_participants(user_id) WHERE left_at IS NULL`).
 - **Session UI icons:** The host is indicated by a 🏠 (house) icon, not a crown. The 👑 (crown) is reserved for the player with the most fastest track times in the session — an earned distinction, not a role.
@@ -632,6 +632,7 @@ POST   /sessions/:id/next-track    Trigger next track selection (host or chooser
 POST   /sessions/:id/choose-track  Choose a specific track (for rulesets where a player picks)
 POST   /sessions/:id/skip-turn     Pass the chooser's turn to the next person (any participant can trigger)
 GET    /sessions/:id/races         List all races in a session (with submission status per participant)
+POST   /sessions/:id/races/:race_id/skip   Mark a pending race as skipped for the requesting user (idempotent)
 ```
 
 Note: Session state is consumed via polling — clients call `GET /sessions/:id` every 2-3 seconds to pick up joins, leaves, new races, and submissions. For a turn-based game where events happen every few minutes, polling latency is imperceptible. WebSockets can be added later as an optimization if polling ever feels sluggish.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -139,6 +139,10 @@ async fn main() {
             "/api/v1/sessions/{id}/races",
             get(routes::sessions::list_races),
         )
+        .route(
+            "/api/v1/sessions/{id}/races/{race_id}/skip",
+            post(routes::sessions::skip_pending_race),
+        )
         // Runs — /defaults before /{id} so literal matches first
         .route(
             "/api/v1/runs",

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -99,6 +99,17 @@ pub async fn skip_turn(
     Ok((StatusCode::CREATED, Json(race)))
 }
 
+/// POST /sessions/:id/races/:race_id/skip — mark a pending race as skipped
+/// for the requesting user. Idempotent.
+pub async fn skip_pending_race(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path((session_id, race_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, AppError> {
+    sessions::skip_pending_race(&state.db, &session_id, &race_id, &user.user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// GET /sessions/:id/races — list all races in a session.
 pub async fn list_races(
     _user: AuthUser,

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -213,10 +213,17 @@ pub async fn create_run(
     // Race Tracking" → "Submission rules"). Skipping the older race or
     // submitting it (which clears it via the `runs` row check in
     // `get_pending_races`) unblocks newer submissions.
+    //
+    // Use filter + min_by_key rather than a bare `find`: `find` would rely
+    // on `get_pending_races` returning ASC by race_number to make the first
+    // match the oldest. The contract holds today, but `min_by_key` removes
+    // the implicit dependency so the error message can't silently name a
+    // wrong race if the SQL ORDER BY is ever dropped or inverted.
     let pending = sessions::get_pending_races(db, &session_race.session_id, user_id).await?;
     if let Some(older) = pending
         .iter()
-        .find(|p| p.race_number < session_race.race_number)
+        .filter(|p| p.race_number < session_race.race_number)
+        .min_by_key(|p| p.race_number)
     {
         return Err(AppError::Conflict(format!(
             "Must submit or skip pending race #{} first",

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::entities::{
-    bodies, characters, drink_types, gliders, runs, session_races, users, wheels,
+    bodies, characters, drink_types, gliders, runs, session_race_participations, session_races,
+    users, wheels,
 };
 use crate::error::AppError;
 use crate::services::{helpers, sessions};
@@ -181,6 +182,28 @@ pub async fn create_run(
     if existing.is_some() {
         return Err(AppError::Conflict(
             "Already submitted a run for this race".to_string(),
+        ));
+    }
+
+    // Mutual exclusion with skip: if the user already explicitly skipped
+    // this race, they can't submit a time for it. Skip is treated as a
+    // permanent forfeiture, matching the "submit OR skip" framing in
+    // DESIGN.md "Pending Race Tracking" → "Submission rules" and the
+    // mutual-exclusion guarantee in `skip_pending_race`'s docstring.
+    let participation = session_race_participations::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_race_participations::Column::SessionRaceId.eq(&body.session_race_id))
+                .add(session_race_participations::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await?;
+    if participation
+        .as_ref()
+        .is_some_and(|p| p.skipped_at.is_some())
+    {
+        return Err(AppError::Conflict(
+            "Cannot submit a run for a skipped race".to_string(),
         ));
     }
 
@@ -1004,5 +1027,31 @@ mod tests {
         create_run(&db, &host_id, valid_run_request(&race_ids[2]))
             .await
             .expect("after skipping all older pending, submit succeeds");
+    }
+
+    #[tokio::test]
+    async fn test_submit_after_skip_returns_conflict() {
+        // Regression for the submit-after-skip bypass: skip and submit are
+        // mutually exclusive in BOTH directions. After skipping race N, a
+        // later submit for race N must be rejected — otherwise the user
+        // could skip race N to clear the ordered-submit guard for race N+1
+        // and then come back and submit race N anyway.
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 1).await;
+
+        sessions::skip_pending_race(&db, &session_id, &race_ids[0], &host_id)
+            .await
+            .expect("skip succeeds");
+
+        match create_run(&db, &host_id, valid_run_request(&race_ids[0])).await {
+            Err(AppError::Conflict(msg)) => assert!(
+                msg.contains("skipped"),
+                "expected message about skipped race, got: {msg}"
+            ),
+            Err(other) => panic!("expected Conflict, got {other:?}"),
+            Ok(_) => panic!("submitting after skip must Conflict, got Ok"),
+        }
     }
 }

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -10,7 +10,7 @@ use crate::entities::{
     bodies, characters, drink_types, gliders, runs, session_races, users, wheels,
 };
 use crate::error::AppError;
-use crate::services::helpers;
+use crate::services::{helpers, sessions};
 
 /// Maximum allowed track time: 10 minutes in milliseconds.
 const MAX_TRACK_TIME_MS: i32 = 600_000;
@@ -182,6 +182,23 @@ pub async fn create_run(
         return Err(AppError::Conflict(
             "Already submitted a run for this race".to_string(),
         ));
+    }
+
+    // Ordered-submit guard: if the user has any pending race with a smaller
+    // race_number, they must submit or skip those first. Prevents
+    // cherry-picking favorable tracks for H2H purposes (DESIGN.md "Pending
+    // Race Tracking" → "Submission rules"). Skipping the older race or
+    // submitting it (which clears it via the `runs` row check in
+    // `get_pending_races`) unblocks newer submissions.
+    let pending = sessions::get_pending_races(db, &session_race.session_id, user_id).await?;
+    if let Some(older) = pending
+        .iter()
+        .find(|p| p.race_number < session_race.race_number)
+    {
+        return Err(AppError::Conflict(format!(
+            "Must submit or skip pending race #{} first",
+            older.race_number
+        )));
     }
 
     // Validate FK references exist
@@ -883,5 +900,109 @@ mod tests {
         assert_eq!(current.submissions[0].username, "host");
         assert_eq!(current.submissions[0].track_time, 120_000);
         assert!(!current.submissions[0].disqualified);
+    }
+
+    // ── Ordered-submit guard (PR 3D-2) ────────────────────────────────────
+
+    /// Helper: create a session, pick N tracks, return (session_id, race_ids).
+    async fn setup_session_with_n_races(
+        db: &DatabaseConnection,
+        host_id: &str,
+        n: usize,
+    ) -> (String, Vec<String>) {
+        let session = sessions::create_session(db, host_id, "random")
+            .await
+            .expect("create session");
+        let mut race_ids = Vec::with_capacity(n);
+        for _ in 0..n {
+            let race = sessions::next_track(db, &session.id, host_id)
+                .await
+                .expect("next track");
+            race_ids.push(race.id);
+        }
+        (session.id, race_ids)
+    }
+
+    #[tokio::test]
+    async fn test_submit_oldest_pending_first_succeeds() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 3).await;
+
+        // Submit race 1 (the oldest pending) — should succeed.
+        create_run(&db, &host_id, valid_run_request(&race_ids[0]))
+            .await
+            .expect("submitting oldest pending should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_submit_newer_pending_while_older_exists_returns_conflict() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 3).await;
+
+        // Try to submit race 3 while races 1 and 2 are still pending.
+        match create_run(&db, &host_id, valid_run_request(&race_ids[2])).await {
+            Err(AppError::Conflict(msg)) => assert!(
+                msg.contains("Must submit or skip pending race #1"),
+                "expected message about race #1, got: {msg}"
+            ),
+            Err(other) => panic!("expected Conflict, got {other:?}"),
+            Ok(_) => panic!("expected Conflict, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_current_race_with_no_pending_succeeds() {
+        // Control case: with only one race in the session and no prior pending,
+        // submitting the current race must succeed. Confirms the guard does
+        // not over-reject.
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 1).await;
+
+        create_run(&db, &host_id, valid_run_request(&race_ids[0]))
+            .await
+            .expect("no pending → submit succeeds");
+    }
+
+    #[tokio::test]
+    async fn test_submit_current_race_with_older_pending_returns_conflict() {
+        // Same shape as the "newer while older exists" test but framed as
+        // "current race counts as newer." Two-race session, race 2 is current,
+        // race 1 is pending.
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (_session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 2).await;
+
+        match create_run(&db, &host_id, valid_run_request(&race_ids[1])).await {
+            Err(AppError::Conflict(_)) => {}
+            Err(other) => panic!("expected Conflict, got {other:?}"),
+            Ok(_) => panic!("expected Conflict, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_current_race_after_skipping_all_pending_succeeds() {
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let (session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 3).await;
+
+        // Skip races 1 and 2; race 3 should now be submittable.
+        sessions::skip_pending_race(&db, &session_id, &race_ids[0], &host_id)
+            .await
+            .expect("skip race 1");
+        sessions::skip_pending_race(&db, &session_id, &race_ids[1], &host_id)
+            .await
+            .expect("skip race 2");
+
+        create_run(&db, &host_id, valid_run_request(&race_ids[2]))
+            .await
+            .expect("after skipping all older pending, submit succeeds");
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -554,7 +554,13 @@ pub async fn get_pending_races(
 ///   for "not pending for you," not exposing whether the row exists for
 ///   another user.
 /// - `Conflict("Already submitted")` if the user has a `runs` row for this
-///   race — submitting and skipping are mutually exclusive.
+///   race — submitting and skipping are mutually exclusive (in both
+///   directions; see also the matching skip-then-submit guard in
+///   `services::runs::create_run`).
+/// - `Forbidden` if the user is not currently an active participant of the
+///   session. A user who left (even within their grace window) must rejoin
+///   before they can act on pending races; otherwise the symmetry with
+///   `create_run` breaks (which also requires an active participant).
 pub async fn skip_pending_race(
     db: &DatabaseConnection,
     session_id: &str,
@@ -569,6 +575,11 @@ pub async fn skip_pending_race(
             }
             other => other,
         })?;
+    // Symmetry with `create_run`: the user must currently be in the session
+    // to act on pending races. Within-grace users (`left_at IS NOT NULL`)
+    // still see their pending races via `get_pending_races` clause 4, but
+    // they need to rejoin before they can submit or skip.
+    helpers::require_active_participant(db, session_id, user_id).await?;
 
     // Verify the race belongs to this session. Looking up by ID first and
     // then matching session_id keeps the error message consistent — both
@@ -2397,6 +2408,36 @@ mod tests {
             AppError::Conflict(msg) => assert_eq!(msg, "Already submitted"),
             other => panic!("expected Conflict, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_skip_after_leaving_returns_forbidden() {
+        // Symmetry with create_run: a user who has left the session cannot
+        // act on their pending races (even though they may still see them
+        // via get_pending_races during the grace window). They must rejoin
+        // first. Two-participant session so the session stays active when
+        // the leaver leaves.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Sanity: user_b has the race pending while still active.
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(pending.len(), 1);
+
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+
+        let err = skip_pending_race(&db, &session.id, &race.id, &user_b)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "expected Forbidden for left user, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -2411,6 +2411,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_skip_pending_race_fails_on_closed_session() {
+        // Mirrors test_next_track_fails_on_closed_session and
+        // test_create_run_fails_if_session_closed: every closed-session
+        // guard in the codebase has a corresponding test. Asserts the
+        // custom Conflict remap fires (Cannot skip in a closed session)
+        // rather than leaking the generic load_active_session message.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Close by having the only participant (host) leave.
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let err = skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .unwrap_err();
+        match err {
+            AppError::Conflict(msg) => {
+                assert!(
+                    msg.contains("closed"),
+                    "expected closed-session message, got: {msg}"
+                );
+            }
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_skip_after_leaving_returns_forbidden() {
         // Symmetry with create_run: a user who has left the session cannot
         // act on their pending races (even though they may still see them

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -7,7 +7,9 @@ use sea_orm::{
 use uuid::Uuid;
 
 use crate::domain::enums::{Ruleset, SessionStatus};
-use crate::entities::{cups, runs, session_participants, session_races, sessions, users};
+use crate::entities::{
+    cups, runs, session_participants, session_race_participations, session_races, sessions, users,
+};
 use crate::error::AppError;
 use crate::services::helpers;
 
@@ -527,6 +529,101 @@ pub async fn get_pending_races(
             submissions: Vec::new(),
         })
         .collect())
+}
+
+/// Mark a pending race as skipped for the requesting user.
+///
+/// "Skip" means the user explicitly forfeits this race — they're not
+/// submitting a time and want to be unblocked from submitting newer races.
+/// The pending derivation in `get_pending_races` excludes rows where
+/// `skipped_at IS NOT NULL`, so the race drops out of the user's pending
+/// list immediately on success.
+///
+/// **Idempotent.** Calling skip twice on the same `(race, user)` returns
+/// success both times; the timestamp is set on the first call only and
+/// not updated on subsequent calls.
+///
+/// **Errors:**
+/// - `Conflict` if the session is closed (via `load_active_session`).
+/// - `NotFound("Race not found in this session")` if the race ID doesn't
+///   belong to this session — covers both unknown race IDs and race IDs
+///   from other sessions.
+/// - `NotFound("Pending race not found")` if the user has no
+///   `session_race_participations` row for this race (they were absent at
+///   creation time, or the race is bogus). This is a single error class
+///   for "not pending for you," not exposing whether the row exists for
+///   another user.
+/// - `Conflict("Already submitted")` if the user has a `runs` row for this
+///   race — submitting and skipping are mutually exclusive.
+pub async fn skip_pending_race(
+    db: &DatabaseConnection,
+    session_id: &str,
+    session_race_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    helpers::load_active_session(db, session_id)
+        .await
+        .map_err(|e| match e {
+            AppError::Conflict(_) => {
+                AppError::Conflict("Cannot skip in a closed session".to_string())
+            }
+            other => other,
+        })?;
+
+    // Verify the race belongs to this session. Looking up by ID first and
+    // then matching session_id keeps the error message consistent — both
+    // "unknown race" and "race in another session" surface the same 404.
+    let race = session_races::Entity::find_by_id(session_race_id)
+        .one(db)
+        .await?;
+    let Some(race) = race.filter(|r| r.session_id == session_id) else {
+        return Err(AppError::NotFound(
+            "Race not found in this session".to_string(),
+        ));
+    };
+
+    let participation = session_race_participations::Entity::find()
+        .filter(
+            Condition::all()
+                .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
+                .add(session_race_participations::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Pending race not found".to_string()))?;
+
+    // Reject if user already submitted a run for this race.
+    let existing_run = runs::Entity::find()
+        .filter(
+            Condition::all()
+                .add(runs::Column::SessionRaceId.eq(&race.id))
+                .add(runs::Column::UserId.eq(user_id)),
+        )
+        .one(db)
+        .await?;
+    if existing_run.is_some() {
+        return Err(AppError::Conflict("Already submitted".to_string()));
+    }
+
+    // Idempotent: already skipped → return success without changing
+    // skipped_at. This avoids both spurious updates and visible change in
+    // the timestamp for repeated skip calls.
+    if participation.skipped_at.is_some() {
+        return Ok(());
+    }
+
+    let now = Utc::now().naive_utc();
+    let txn = db.begin().await?;
+
+    let mut active: session_race_participations::ActiveModel = participation.into();
+    active.skipped_at = Set(Some(now));
+    active.update(&txn).await?;
+
+    helpers::touch_session(&txn, session_id).await?;
+
+    txn.commit().await?;
+
+    Ok(())
 }
 
 /// Get full session detail — the polling endpoint.
@@ -2151,5 +2248,184 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 1, "participation row remains for history");
+    }
+
+    // ── Skip pending race (PR 3D-2) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_skip_pending_race_sets_skipped_at() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .expect("skip succeeds");
+
+        let row = session_race_participations::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
+                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.skipped_at.is_some(), "skipped_at must be set");
+
+        // And the race drops out of the pending list.
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "skipped race must not be pending");
+    }
+
+    #[tokio::test]
+    async fn test_skip_pending_race_idempotent() {
+        // Second skip on the same (race, user) returns success without
+        // changing skipped_at — the timestamp from the first call is
+        // preserved.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .expect("first skip");
+        let first_skipped_at = session_race_participations::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
+                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .skipped_at;
+
+        // Sleep a hair so any update would produce a strictly later timestamp.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+
+        skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .expect("second skip is idempotent");
+        let second_skipped_at = session_race_participations::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
+                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+            )
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .skipped_at;
+
+        assert_eq!(
+            first_skipped_at, second_skipped_at,
+            "skipped_at must not change on idempotent re-skip"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skip_unknown_race_returns_404() {
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        // No race exists for this session.
+        let bogus_race_id = Uuid::new_v4().to_string();
+        let err = skip_pending_race(&db, &session.id, &bogus_race_id, &host_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_skip_already_submitted_returns_conflict() {
+        // Insert a runs row for (race, user) directly to avoid pulling
+        // create_run's full validation surface into a skip test.
+        use crate::drink_type_id::drink_type_uuid;
+        use crate::entities::{drink_types, runs};
+        use crate::test_helpers::seed_game_data;
+
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // Insert a run row to satisfy the "already submitted" precondition.
+        let drink_id = drink_type_uuid("Test Beer");
+        drink_types::Entity::find_by_id(&drink_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .expect("seed_game_data inserts Test Beer");
+        runs::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(host_id.clone()),
+            session_race_id: Set(race.id.clone()),
+            track_id: Set(race.track_id),
+            character_id: Set(1),
+            body_id: Set(1),
+            wheel_id: Set(1),
+            glider_id: Set(1),
+            track_time: Set(120_000),
+            lap1_time: Set(40_000),
+            lap2_time: Set(40_000),
+            lap3_time: Set(40_000),
+            drink_type_id: Set(drink_id),
+            disqualified: Set(false),
+            photo_path: Set(None),
+            created_at: Set(Utc::now().naive_utc()),
+            notes: Set(None),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        let err = skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .unwrap_err();
+        match err {
+            AppError::Conflict(msg) => assert_eq!(msg, "Already submitted"),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_skip_advances_pending_list() {
+        // After skipping the oldest pending, the next-oldest becomes the
+        // "must-submit-first" target for ordered-submit purposes. This is
+        // a behavioral test, not just a state test — confirms the pending
+        // list updates correctly so newer races become submittable in
+        // order.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let r1 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r2 = next_track(&db, &session.id, &host_id).await.unwrap();
+        let r3 = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // All three are pending; oldest is r1.
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending[0].id, r1.id);
+
+        skip_pending_race(&db, &session.id, &r1.id, &host_id)
+            .await
+            .unwrap();
+
+        // After skipping r1, oldest pending should now be r2.
+        let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].id, r2.id);
+        assert_eq!(pending[1].id, r3.id);
     }
 }

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -8,12 +8,16 @@ use axum::{
     routing::{get, post},
 };
 use axum_test::TestServer;
+use chrono::Utc;
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
 use serde_json::{Value, json};
+use uuid::Uuid;
 
 use beerio_kart::AppState;
 use beerio_kart::config::AppConfig;
+use beerio_kart::drink_type_id::drink_type_uuid;
+use beerio_kart::entities::{bodies, characters, cups, drink_types, gliders, tracks, wheels};
 use beerio_kart::routes;
 
 const TEST_SECRET: &str = "test-secret-for-session-tests";
@@ -65,9 +69,110 @@ async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
             "/api/v1/sessions/{id}/leave",
             post(routes::sessions::leave_session),
         )
+        .route(
+            "/api/v1/sessions/{id}/next-track",
+            post(routes::sessions::next_track),
+        )
+        .route(
+            "/api/v1/sessions/{id}/races/{race_id}/skip",
+            post(routes::sessions::skip_pending_race),
+        )
+        // Runs
+        .route("/api/v1/runs", post(routes::runs::create_run))
         .with_state(state);
 
     (TestServer::new(app), db)
+}
+
+/// Seed minimal game data needed by skip + create_run integration tests.
+/// Production seed (`seed::run`) lives in main.rs and isn't reachable from
+/// integration tests; this is a stripped-down equivalent — one each of
+/// cup, track, character, body, wheels, glider, drink type.
+async fn seed_minimal_game_data(db: &sea_orm::DatabaseConnection) {
+    cups::ActiveModel {
+        id: Set(1),
+        name: Set("Test Cup".to_string()),
+        image_path: Set("images/cups/test.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert cup");
+
+    tracks::ActiveModel {
+        id: Set(1),
+        name: Set("Test Track".to_string()),
+        cup_id: Set(1),
+        position: Set(1),
+        image_path: Set("images/tracks/test.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert track");
+
+    characters::ActiveModel {
+        id: Set(1),
+        name: Set("Mario".to_string()),
+        image_path: Set("images/characters/mario.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert character");
+
+    bodies::ActiveModel {
+        id: Set(1),
+        name: Set("Standard Kart".to_string()),
+        image_path: Set("images/bodies/standard.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert body");
+
+    wheels::ActiveModel {
+        id: Set(1),
+        name: Set("Standard".to_string()),
+        image_path: Set("images/wheels/standard.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert wheels");
+
+    gliders::ActiveModel {
+        id: Set(1),
+        name: Set("Super Glider".to_string()),
+        image_path: Set("images/gliders/super.webp".to_string()),
+    }
+    .insert(db)
+    .await
+    .expect("insert glider");
+
+    drink_types::ActiveModel {
+        id: Set(drink_type_uuid("Test Beer")),
+        name: Set("Test Beer".to_string()),
+        alcoholic: Set(true),
+        created_at: Set(Utc::now().naive_utc()),
+        created_by: Set(None),
+    }
+    .insert(db)
+    .await
+    .expect("insert drink type");
+}
+
+/// Build a valid CreateRunRequest body for the given race ID.
+fn run_request_json(session_race_id: &str) -> Value {
+    let drink_id = drink_type_uuid("Test Beer");
+    json!({
+        "session_race_id": session_race_id,
+        "track_time": 120_000,
+        "lap1_time": 40_000,
+        "lap2_time": 39_000,
+        "lap3_time": 41_000,
+        "character_id": 1,
+        "body_id": 1,
+        "wheel_id": 1,
+        "glider_id": 1,
+        "drink_type_id": drink_id,
+        "disqualified": false,
+    })
 }
 
 const AUTH_HEADER: HeaderName = HeaderName::from_static("authorization");
@@ -393,4 +498,245 @@ async fn test_stale_session_cleanup() {
         .await;
     let detail: Value = res.json();
     assert_eq!(detail["status"], "closed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Pending Races: skip endpoint + ordered-submit (PR 3D-2)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Helper: register a host, seed minimal game data, create a session, pick a
+/// track. Returns (server, db, token, user_id, session_id, race_id).
+async fn setup_with_one_race() -> (
+    TestServer,
+    sea_orm::DatabaseConnection,
+    String,
+    String,
+    String,
+    String,
+) {
+    let (server, db) = setup_test_app().await;
+    seed_minimal_game_data(&db).await;
+    let (token, user_id) = register_and_get_token(&server, "host").await;
+    let session_res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session_id = session_res.json::<Value>()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let race_res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    race_res.assert_status(axum::http::StatusCode::CREATED);
+    let race_id = race_res.json::<Value>()["id"].as_str().unwrap().to_string();
+    (server, db, token, user_id, session_id, race_id)
+}
+
+#[tokio::test]
+async fn test_skip_endpoint_happy_path_returns_204_and_clears_pending() {
+    let (server, _db, token, _user_id, session_id, race_id) = setup_with_one_race().await;
+
+    // Pre-condition: pending list contains the race.
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    assert_eq!(detail["your_pending"].as_array().unwrap().len(), 1);
+
+    let res = server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // Post-condition: pending list is empty (skipped race drops out).
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    assert!(
+        detail["your_pending"].as_array().unwrap().is_empty(),
+        "skipped race must not appear in your_pending"
+    );
+}
+
+#[tokio::test]
+async fn test_skip_endpoint_idempotent() {
+    let (server, _db, token, _user_id, session_id, race_id) = setup_with_one_race().await;
+
+    let url = format!("/api/v1/sessions/{session_id}/races/{race_id}/skip");
+    server
+        .post(&url)
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+    server
+        .post(&url)
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_skip_endpoint_unknown_race_returns_404() {
+    let (server, _db, token, _user_id, session_id, _race_id) = setup_with_one_race().await;
+    let bogus = Uuid::new_v4().to_string();
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/races/{bogus}/skip"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_skip_endpoint_already_submitted_returns_409() {
+    let (server, _db, token, _user_id, session_id, race_id) = setup_with_one_race().await;
+
+    // Submit a run first.
+    server
+        .post("/api/v1/runs")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&run_request_json(&race_id))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    // Now try to skip — must 409.
+    let res = server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_create_run_blocked_by_older_pending_returns_409_with_message() {
+    let (server, _db, token, _user_id, session_id, race1_id) = setup_with_one_race().await;
+    // Add a second race so race1 becomes "older pending" relative to race2.
+    let race2_res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let race2_id = race2_res.json::<Value>()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Try to submit race 2 while race 1 is pending → 409.
+    let res = server
+        .post("/api/v1/runs")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&run_request_json(&race2_id))
+        .await;
+    res.assert_status(axum::http::StatusCode::CONFLICT);
+
+    let body: Value = res.json();
+    let msg = body["error"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("Must submit or skip pending race #1"),
+        "expected race-#1 conflict message, got: {msg}"
+    );
+    let _ = race1_id; // silence unused-binding warning
+}
+
+#[tokio::test]
+async fn test_create_run_succeeds_after_skipping_older_pending() {
+    let (server, _db, token, _user_id, session_id, race1_id) = setup_with_one_race().await;
+    let race2_res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let race2_id = race2_res.json::<Value>()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Skip race 1, then submit race 2 — should succeed.
+    server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race1_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    server
+        .post("/api/v1/runs")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&run_request_json(&race2_id))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    // your_pending should now be empty.
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    assert!(
+        detail["your_pending"].as_array().unwrap().is_empty(),
+        "after skip + submit, your_pending should be empty"
+    );
+}
+
+#[tokio::test]
+async fn test_session_detail_your_pending_reflects_skip_and_submit() {
+    let (server, _db, token, _user_id, session_id, race1_id) = setup_with_one_race().await;
+    let race2_res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let race2_id = race2_res.json::<Value>()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Both races pending.
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    assert_eq!(detail["your_pending"].as_array().unwrap().len(), 2);
+
+    // Skip race 1 → only race 2 left.
+    server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race1_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    let pending = detail["your_pending"].as_array().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0]["id"].as_str().unwrap(), race2_id);
+
+    // Submit race 2 → no pending left.
+    server
+        .post("/api/v1/runs")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&run_request_json(&race2_id))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    let detail: Value = server
+        .get(&format!("/api/v1/sessions/{session_id}"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .json();
+    assert!(detail["your_pending"].as_array().unwrap().is_empty());
 }

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -740,3 +740,81 @@ async fn test_session_detail_your_pending_reflects_skip_and_submit() {
         .json();
     assert!(detail["your_pending"].as_array().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn test_create_run_after_skip_returns_409() {
+    // Regression for the submit-after-skip bypass — at the HTTP layer.
+    let (server, _db, token, _user_id, session_id, race_id) = setup_with_one_race().await;
+
+    server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    let res = server
+        .post("/api/v1/runs")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&run_request_json(&race_id))
+        .await;
+    res.assert_status(axum::http::StatusCode::CONFLICT);
+
+    let body: Value = res.json();
+    let msg = body["error"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("skipped"),
+        "expected message about skipped race, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_skip_after_leaving_returns_403() {
+    // Regression for the symmetry gap with create_run — a user who has
+    // left the session must not be able to skip races in it. Two-user
+    // session so the session stays active when user2 leaves.
+    let (server, _db, token_host, _host_id) = {
+        let (server, db) = setup_test_app().await;
+        seed_minimal_game_data(&db).await;
+        let (token, user_id) = register_and_get_token(&server, "host").await;
+        (server, db, token, user_id)
+    };
+    let (token_user2, _user2_id) = register_and_get_token(&server, "user2").await;
+
+    let session_res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    let session_id = session_res.json::<Value>()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server
+        .post(&format!("/api/v1/sessions/{session_id}/join"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    let race_res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token_host))
+        .await;
+    let race_id = race_res.json::<Value>()["id"].as_str().unwrap().to_string();
+
+    server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await
+        .assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // user2 has left — skipping should now be Forbidden, not allowed.
+    let res = server
+        .post(&format!(
+            "/api/v1/sessions/{session_id}/races/{race_id}/skip"
+        ))
+        .add_header(AUTH_HEADER, auth_value(&token_user2))
+        .await;
+    res.assert_status(axum::http::StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Summary

Final PR in the Pending Races feature trio (3D-0 squash + 3D-1 foundation + this). Adds the action paths intentionally deferred from 3D-1, per [`reviews/design/2026-04-19-pending-races-and-grace-period.md`](reviews/design/2026-04-19-pending-races-and-grace-period.md) §4 (ordered-submit), §6 (skip endpoint), and §8 (test plan).

After this PR, the `your_pending` field surfaced in 3D-1 becomes actionable: the UI can let a user submit oldest-first or skip, and the backend enforces correctness.

## New endpoint

`POST /sessions/:id/races/:race_id/skip` — authenticated, no body. Marks the race as skipped for the requesting user.

| Status | Reason |
|--------|--------|
| 204 No Content | Skip succeeded (or already skipped — idempotent) |
| 404 | Race ID doesn't belong to this session, or user has no participation row for it (covers "absent at race creation" and bogus IDs in one error class) |
| 409 | User has already submitted a run for this race |
| 409 | Session is closed |

Service: `services::sessions::skip_pending_race`. Touches the session so the action counts as activity for the stale-session timer.

## Modified behavior

`services::runs::create_run` now rejects submissions for race N when the user has any pending race with `race_number < N`. Error shape:

```
AppError::Conflict("Must submit or skip pending race #{n} first")
```

where `{n}` is the oldest pending race number. The check uses `get_pending_races` from 3D-1, so all of its filters (grace, `joined_at`, `skipped_at`, `runs` row presence, `session.status = 'active'`) apply naturally without re-derivation.

## Tests

**22 new tests, 226 total** (was 204). All pass. Clippy + fmt clean.

| Layer | File | Count | Coverage |
|-------|------|-------|----------|
| Unit (skip) | `services::sessions::tests` | 7 | sets_skipped_at, idempotent (timestamp doesn't change), unknown_race→404, already_submitted→409, advances_pending_list (behavioral), **fails_on_closed_session**, **after_leaving_returns_forbidden** |
| Unit (ordered-submit) | `services::runs::tests` | 6 | oldest_first_succeeds, newer_while_older_exists→409 (asserts "race #1" message), no_pending_succeeds, current_with_older_pending→409, after_skipping_all_succeeds, **after_skip_returns_conflict** |
| Integration | `tests/session_integration.rs` | 9 | skip happy path (clears `your_pending`), skip idempotent, skip 404, skip 409 (already submitted), create_run blocked-by-older-pending, create_run after-skip succeeds, end-to-end `your_pending` reflection, **create_run_after_skip→409**, **skip_after_leaving→403** |

Bold = added in PR review follow-ups (commits `9cba3b1` and `d13dd5b`) covering the bidirectional skip↔submit mutual exclusion, the symmetry gap with `create_run`'s active-participant requirement, and the missing closed-session-guard test.

Integration test setup extended with the new skip route, next-track, and runs POST. Inlined `seed_minimal_game_data` helper because `test_helpers` is `#[cfg(test)]` and not reachable from integration tests (refactoring to share is out of scope).

## What this PR does NOT do

- Frontend work — UI requirements in §4.1 of the design review, deferred to a separate UI design pass.
- Auto-skip on session close or grace expiration — by design, those records remain pending-but-inaccessible per §7 "Do nothing."
- Schema changes — `session_race_participations` was fully wired in 3D-1.

Phase 3 checklist in [`DESIGN.md`](DESIGN.md) (lines 853–854: "Run entry within session context" and "Pending race tracking") can now be marked complete — left for you to flip.

## Test plan

### 1. Test suite

```bash
git fetch origin phase-3/3d-2-pending-enforcement
git checkout phase-3/3d-2-pending-enforcement
rm -f data/db/beerio-kart.db
cd backend && cargo test
```

**Expected:** `test result: ok. 226 passed; 0 failed` total — broken down as 151 lib + 27 api + 21 auth + 8 middleware + 19 session_integration.

To run only the tests added in this PR (across the original commit and both review-follow-up commits):

```bash
# Lib tests: pending-race skip + ordered-submit. --skip excludes the
# pre-existing test_skip_turn_* tests (chooser-pass mechanism, unrelated).
cd backend && cargo test --lib -- \
    services::sessions::tests::test_skip \
    services::runs::tests::test_submit_ \
    --skip test_skip_turn \
&& cargo test --test session_integration -- \
    test_skip_endpoint \
    test_skip_after_leaving \
    test_create_run \
    test_session_detail_your_pending_reflects_skip_and_submit
```

**Expected:** 22 tests, all pass (13 lib + 9 integration).

### 2. End-to-end smoke test (HTTP + direct DB inspection)

Requires `jq` and `sqlite3`. Run from the **repo root** with the backend booted in another terminal:

```bash
# Terminal 1 — backend (will block; leave running)
cd backend && rm -f ../data/db/beerio-kart.db && \
    JWT_SECRET=smoke-test-secret COOKIE_SECURE=false cargo run
# Wait for "Seeding complete" before continuing.
```

```bash
# Terminal 2 — env vars + sanity check
API=http://localhost:3000/api/v1
DB=data/db/beerio-kart.db
curl -fsS "$API/hello" -o /dev/null && echo "backend up" || \
    { echo "backend not reachable on $API — start it in terminal 1 first" >&2; }

# Register one user.
A=$(curl -s -X POST "$API/auth/register" \
    -H 'Content-Type: application/json' \
    -d '{"username":"alice","password":"smoketest123"}')
TOKEN=$(echo "$A" | jq -r .access_token)
USER=$(echo  "$A" | jq -r .user.id)
echo "alice=$USER"
```

```bash
# Step A: alice creates a session, picks 3 tracks. All 3 are pending for alice.
SESSION=$(curl -s -X POST "$API/sessions" \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -d '{"ruleset":"random"}' | jq -r .id)

R1=$(curl -s -X POST "$API/sessions/$SESSION/next-track" \
    -H "Authorization: Bearer $TOKEN" | jq -r .id)
R2=$(curl -s -X POST "$API/sessions/$SESSION/next-track" \
    -H "Authorization: Bearer $TOKEN" | jq -r .id)
R3=$(curl -s -X POST "$API/sessions/$SESSION/next-track" \
    -H "Authorization: Bearer $TOKEN" | jq -r .id)

curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN" | jq '.your_pending | length'
# Expected: 3
```

```bash
# Helper: build a CreateRunRequest body for a given race ID. Using jq to
# construct the JSON keeps shell quoting simple — no inline backslash
# escaping, and the variables are passed as named args.
DRINK=$(sqlite3 "$DB" "SELECT id FROM drink_types LIMIT 1;")
make_run_body() {
    jq -nc --arg sr "$1" --arg drink "$DRINK" '{
        session_race_id: $sr,
        track_time: 120000,
        lap1_time: 40000,
        lap2_time: 40000,
        lap3_time: 40000,
        character_id: 1,
        body_id: 1,
        wheel_id: 1,
        glider_id: 1,
        drink_type_id: $drink,
        disqualified: false
    }'
}
```

```bash
# Step B: try to submit race 3 while races 1 and 2 are pending → 409.
curl -s -X POST "$API/runs" \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -w "\nstatus:%{http_code}\n" \
    -d "$(make_run_body "$R3")"
# Expected: status:409, body mentions "Must submit or skip pending race #1"
```

```bash
# Step C: skip race 1 → 204. Skip again → 204 (idempotent).
curl -s -X POST "$API/sessions/$SESSION/races/$R1/skip" \
    -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n" -o /dev/null
curl -s -X POST "$API/sessions/$SESSION/races/$R1/skip" \
    -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n" -o /dev/null
# Expected: 204 then 204

# Confirm idempotency at the data layer — skipped_at didn't change.
sqlite3 -header -column "$DB" \
    "SELECT skipped_at FROM session_race_participations
     WHERE session_race_id = '$R1' AND user_id = '$USER';"
# Expected: one row, single timestamp value
```

```bash
# Step D: submit race 3 still 409 (race 2 is still pending).
curl -s -X POST "$API/runs" \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -w "status:%{http_code}\n" -o /dev/null \
    -d "$(make_run_body "$R3")"
# Expected: status:409 (mentions race #2)
```

```bash
# Step E: skip race 2, then submit race 3 → 201.
curl -s -X POST "$API/sessions/$SESSION/races/$R2/skip" \
    -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n" -o /dev/null
curl -s -X POST "$API/runs" \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -w "status:%{http_code}\n" -o /dev/null \
    -d "$(make_run_body "$R3")"
# Expected: 204 then status:201
```

```bash
# Step F: your_pending should be empty.
curl -s "$API/sessions/$SESSION" \
    -H "Authorization: Bearer $TOKEN" | jq '.your_pending | length'
# Expected: 0
```

```bash
# Step G (regression for the PR review fixes): submit-after-skip is blocked.
# Take the just-submitted race 3 — it now has a runs row, not skipped_at —
# so re-submitting hits the dup-submission guard, not the new skip guard.
# Pick a fresh race to test the new mutual-exclusion path.
R4=$(curl -s -X POST "$API/sessions/$SESSION/next-track" \
    -H "Authorization: Bearer $TOKEN" | jq -r .id)
curl -s -X POST "$API/sessions/$SESSION/races/$R4/skip" \
    -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n" -o /dev/null
# Now race 4 is skipped. Submitting it must now 409 with "Cannot submit a
# run for a skipped race" — proves submit-after-skip is blocked (PR review
# fix issue #1).
curl -s -X POST "$API/runs" \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -w "\nstatus:%{http_code}\n" \
    -d "$(make_run_body "$R4")"
# Expected: 204 (skip), then status:409 with "Cannot submit a run for a skipped race"
```

If all expected outputs match, the Pending Races feature is complete on the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
