### PR TITLE
phase-e/drop-sessions-created-by

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,17 @@ Operating rules:
 
 When we exit prelaunch (decided when we have real user data we don't want to lose), this convention flips back to standard append-only migrations: every schema change becomes a new file, and the consolidated initial migration becomes the immutable starting point. CLAUDE.md will be updated at that time.
 
+### Documentation history
+
+**Scope:** files in `docs/` only (`design.md`, `api-contract.md`, `compliance-plan.md`, and every file in `coding-standards/`). Files under `.claude/` are *not* covered — those describe current behavior, not its history, and don't carry a history section.
+
+Each in-scope file keeps a `## Document history` section at the bottom. Any AI-authored PR (Cowork or Claude Code) that changes the body of one of these files **must append a dated bullet to that section in the same PR**. Brendan is not bound by this rule.
+
+- **Format:** `- YYYY-MM-DD — <one-line summary of the change, with PR # if applicable>`. Use absolute ISO dates, never "today" or "last week."
+- **What requires an entry:** Adding, removing, or rewording a rule; restructuring sections; marking a previously-deferred item as done; changing rationale or sources. Pure typo or formatting fixes do not.
+- **When the previous entry foreshadowed this change** (e.g., "Noted upcoming X removal"), the new entry must explicitly close the loop ("Removed X. PR #N.") so a future reader can see the upcoming/completed pair.
+- **Why:** The history is the durable record of why a `docs/` rule says what it says. Without an entry a reader can't tell whether a rule has stood for a year or was added yesterday, and a reviewer can't audit whether a referenced "upcoming" change was ever completed.
+
 ## Testing
 **Tests are a deliverable, not optional.** Every PR that adds business logic must include tests. PRs should not be opened without them.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![codecov](https://codecov.io/gh/brendanbyrne/beerio-kart/graph/badge.svg)](https://codecov.io/gh/brendanbyrne/beerio-kart)
 
-We're really doing this thing.
-
-A mobile-first web app for tracking times and stats for the Mario Kart 8 Deluxe drinking game. Players race time trials, optionally drink, and the app tracks personal bests, leaderboards, and run history.
+We're really doing this thing.  There are two goals with this project.
+* A mobile-first web app for tracking times and stats for the Mario Kart 8 Deluxe drinking game. Players race time trials, optionally drink, and the app tracks personal bests, leaderboards, and run history.
+* Experimenting with using LLMs, with the intent to never write a line of actual code.  A test to see how far I can push a purely vibe coded project.
 
 ## Project layout
 

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -251,7 +251,6 @@ impl MigrationTrait for Migration {
         conn.execute_unprepared(
             "CREATE TABLE IF NOT EXISTS sessions (
                     id TEXT NOT NULL PRIMARY KEY,
-                    created_by TEXT NOT NULL REFERENCES users(id),
                     host_id TEXT NOT NULL REFERENCES users(id),
                     ruleset TEXT NOT NULL,
                     least_played_drink_category TEXT,

--- a/backend/src/entities/session_races.rs
+++ b/backend/src/entities/session_races.rs
@@ -20,6 +20,8 @@ pub struct Model {
 pub enum Relation {
     #[sea_orm(has_many = "super::runs::Entity")]
     Runs,
+    #[sea_orm(has_many = "super::session_race_participations::Entity")]
+    SessionRaceParticipations,
     #[sea_orm(
         belongs_to = "super::sessions::Entity",
         from = "Column::SessionId",
@@ -52,6 +54,12 @@ impl Related<super::runs::Entity> for Entity {
     }
 }
 
+impl Related<super::session_race_participations::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SessionRaceParticipations.def()
+    }
+}
+
 impl Related<super::sessions::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Sessions.def()
@@ -66,7 +74,14 @@ impl Related<super::tracks::Entity> for Entity {
 
 impl Related<super::users::Entity> for Entity {
     fn to() -> RelationDef {
-        Relation::Users.def()
+        super::session_race_participations::Relation::Users.def()
+    }
+    fn via() -> Option<RelationDef> {
+        Some(
+            super::session_race_participations::Relation::SessionRaces
+                .def()
+                .rev(),
+        )
     }
 }
 

--- a/backend/src/entities/sessions.rs
+++ b/backend/src/entities/sessions.rs
@@ -8,8 +8,6 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
     pub id: String,
     #[sea_orm(column_type = "Text")]
-    pub created_by: String,
-    #[sea_orm(column_type = "Text")]
     pub host_id: String,
     #[sea_orm(column_type = "Text")]
     pub ruleset: String,
@@ -34,15 +32,7 @@ pub enum Relation {
         on_update = "NoAction",
         on_delete = "NoAction"
     )]
-    HostUser,
-    #[sea_orm(
-        belongs_to = "super::users::Entity",
-        from = "Column::CreatedBy",
-        to = "super::users::Column::Id",
-        on_update = "NoAction",
-        on_delete = "NoAction"
-    )]
-    CreatedByUser,
+    Users,
 }
 
 impl Related<super::session_participants::Entity> for Entity {
@@ -54,6 +44,12 @@ impl Related<super::session_participants::Entity> for Entity {
 impl Related<super::session_races::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::SessionRaces.def()
+    }
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Users.def()
     }
 }
 

--- a/backend/src/entities/users.rs
+++ b/backend/src/entities/users.rs
@@ -65,8 +65,12 @@ pub enum Relation {
     // historical participant rows.
     #[sea_orm(has_many = "super::session_participants::Entity")]
     SessionParticipants,
+    #[sea_orm(has_many = "super::session_race_participations::Entity")]
+    SessionRaceParticipations,
     #[sea_orm(has_many = "super::session_races::Entity")]
     SessionRaces,
+    #[sea_orm(has_many = "super::sessions::Entity")]
+    Sessions,
     #[sea_orm(
         belongs_to = "super::wheels::Entity",
         from = "Column::PreferredWheelId",
@@ -113,15 +117,34 @@ impl Related<super::session_participants::Entity> for Entity {
     }
 }
 
-impl Related<super::session_races::Entity> for Entity {
+impl Related<super::session_race_participations::Entity> for Entity {
     fn to() -> RelationDef {
-        Relation::SessionRaces.def()
+        Relation::SessionRaceParticipations.def()
+    }
+}
+
+impl Related<super::sessions::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sessions.def()
     }
 }
 
 impl Related<super::wheels::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Wheels.def()
+    }
+}
+
+impl Related<super::session_races::Entity> for Entity {
+    fn to() -> RelationDef {
+        super::session_race_participations::Relation::SessionRaces.def()
+    }
+    fn via() -> Option<RelationDef> {
+        Some(
+            super::session_race_participations::Relation::Users
+                .def()
+                .rev(),
+        )
     }
 }
 

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -96,7 +96,6 @@ pub async fn create_session(
 
     sessions::ActiveModel {
         id: Set(session_id.clone()),
-        created_by: Set(user_id.to_string()),
         host_id: Set(user_id.to_string()),
         ruleset: Set(parsed.to_string()),
         least_played_drink_category: Set(None),
@@ -274,7 +273,6 @@ struct CurrentRaceRow {
 #[derive(serde::Serialize)]
 pub struct SessionDetail {
     pub id: String,
-    pub created_by: String,
     pub host_id: String,
     pub host_username: String,
     pub ruleset: String,
@@ -671,7 +669,6 @@ pub async fn get_session_detail(
 
     Ok(SessionDetail {
         id: session.id,
-        created_by: session.created_by,
         host_id: session.host_id,
         host_username,
         ruleset: session.ruleset,

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -105,7 +105,6 @@ pub async fn insert_session(db: &DatabaseConnection, host_id: &str, status: &str
     let now = Utc::now().naive_utc();
     sessions::ActiveModel {
         id: Set(id.clone()),
-        created_by: Set(host_id.to_string()),
         host_id: Set(host_id.to_string()),
         ruleset: Set("random".to_string()),
         least_played_drink_category: Set(None),

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -164,6 +164,7 @@ The list of stable `code` values returned in error responses. Add to this list w
 - **Why:** design.md already chose this; restating so it doesn't get lost. The cost of v2 alongside v1 is low for an internal app — the duplication is mostly a thin layer that translates to the v2-internal types.
 - **What counts as breaking:** removing a field, renaming a field, changing a field's type, changing an error `code`, changing default behavior of a query parameter.
 - **What does NOT count as breaking:** adding a new field (frontend tolerates extra fields), adding a new endpoint, loosening validation, fixing a bug where the response shape was wrong.
+- **Prelaunch carve-out.** "Launch" mirrors the definition in [`seaorm.md` § 5](./coding-standards/seaorm.md#5-migrations): the first deploy where we have clients we owe backwards compatibility to. While prelaunch, breaking changes ship directly in `/api/v1` — we don't spin up `/api/v2` to preserve compatibility we don't owe anyone. As of May 2026 the frontend is still being built and there are no deployed external clients, so the project is prelaunch by this definition. Once a real client ships (production frontend, third-party integration), this carve-out closes and breaking changes go through the v2 path. CLAUDE.md will be updated at that time.
 
 ---
 
@@ -181,3 +182,4 @@ The list of stable `code` values returned in error responses. Add to this list w
 ## 10. Document history
 
 - 2026-05-02 — Initial draft. Sets API client generation, error code contract, polling/ETag, refresh flow, idempotency, time format, error code registry, versioning, CORS. Items 1–6 are the "decide before the backend gets much further" set; 7–9 are clarifications of decisions that were already made or implied. To be revisited when the frontend work starts.
+- 2026-05-02 — Added prelaunch carve-out to § 8: while prelaunch, breaking changes ship in `/api/v1` directly rather than spinning up a v2 path. Mirrors the "launch" definition in `seaorm.md` § 5.

--- a/docs/coding-standards/seaorm.md
+++ b/docs/coding-standards/seaorm.md
@@ -368,7 +368,7 @@
 
 - **Rule:** When two FKs link the same pair of tables, give them distinct `Relation` variants and reference them by name.
   - **Why:** Codegen historically produces ambiguous relations when there are multiple FKs between the same two tables (#405). Without distinct names, "find related users" doesn't know which FK to follow.
-  - **Note:** A live instance of this case (`sessions.created_by` and `sessions.host_id` both → `users.id`) is being eliminated by dropping `created_by`. After that change lands, the multi-FK case is hypothetical for current schema but the rule still applies for any future table that reuses a target.
+  - **Note:** No current schema instances; the rule remains in force for any future table that reuses a target.
   - **Source:** <https://github.com/SeaQL/sea-orm/issues/405>
 
 ## 12. Pitfalls (consolidated)

--- a/docs/coding-standards/seaorm.md
+++ b/docs/coding-standards/seaorm.md
@@ -392,3 +392,4 @@ A single-screen review checklist:
 
 - 2026-05-02 — Initial draft as part of `docs/rust-coding-standards.md`.
 - 2026-05-02 — Split into `docs/coding-standards/seaorm.md`. Added explicit "launch" definition to § 5. Updated § 9 to use `?cache=shared`. Added entity↔domain newtype boundary rule to § 6. Noted upcoming `sessions.created_by` removal in § 11.
+- 2026-05-02 — Removed the live-instance reference from § 11 after `sessions.created_by` was dropped (PR #23). Multi-FK rule retained for any future table that reuses a target.

--- a/docs/design.md
+++ b/docs/design.md
@@ -123,6 +123,7 @@ Log output is controlled via the `RUST_LOG` environment variable. Defaults to `i
 - **Nullability defaults to NOT NULL** unless there is a clear reason for the data to be optional. Nullable columns map to `Option<T>` in Rust, adding handling overhead.
 - **"Previous" setup is derived, not stored.** The user's last-used race setup and drink type are queried from their most recent run, not duplicated on the users table. Only "preferred" (explicitly set) values are stored on users.
 - **Database encryption** via SQLCipher is possible but deferred past v1.
+- **No separate `created_by` column on sessions.** `host_id` carries the original creator until host transfers on leave. No current product feature uses the original-creator information. If needed later, re-adding the column is one append-only migration.
 
 ### Users
 
@@ -253,8 +254,7 @@ The organizational unit for group play. A session is like a lobby — players jo
 ```
 sessions
 ├── id: UUID (primary key)
-├── created_by: UUID (foreign key -> users, not null)
-├── host_id: UUID (foreign key -> users, not null — current host, transfers on leave)
+├── host_id: UUID (foreign key -> users, not null — starts as the user who created the session; transfers on leave)
 ├── ruleset: TEXT (not null — "random", "default", "least_played", "round_robin")
 ├── least_played_drink_category: TEXT (nullable — "alcoholic" or "non_alcoholic"; only used when ruleset is "least_played")
 ├── status: TEXT (not null — "active", "closed")
@@ -263,7 +263,7 @@ sessions
 ```
 
 Notes:
-- `host_id` starts as `created_by`. If the host leaves, host role transfers to the earliest-joined remaining participant.
+- `host_id` is set to the creating user when the session is created. If the host leaves, host role transfers to the earliest-joined remaining participant.
 - `least_played_drink_category` stores values as `"alcoholic"` or `"non_alcoholic"` (snake_case, per database convention). The frontend maps these to display text with hyphens ("non-alcoholic").
 - Ruleset-specific config uses explicit nullable columns rather than a JSON blob. With four well-defined rulesets, explicit columns are safer (database can enforce CHECK constraints) and queryable. New config options require a migration, but that's the right tradeoff for known rulesets.
 - Session auto-closes after 1 hour of no activity. No further run submissions accepted after close. A lightweight Tokio background task checks for and closes stale sessions periodically (e.g., every 5 minutes) so they don't linger in the active sessions list. Actions that update `last_activity_at`: run submission, track selection (next-track, choose-track), join, leave, skip-turn (chooser pass), skip-pending-race (forfeit a pending race).

--- a/docs/seaorm_2_0_migration.md
+++ b/docs/seaorm_2_0_migration.md
@@ -1,0 +1,294 @@
+# SeaORM 2.0 Evaluation — Partial Unique Indexes on SQLite
+
+This document captures the May 2026 evaluation of whether to migrate from
+SeaORM's schema-first workflow to the entity-first workflow introduced in
+SeaORM 2.0, given Beerio Kart's use of partial unique indexes on SQLite.
+
+## Context
+
+Beerio Kart uses one partial unique index in its current schema:
+
+```sql
+CREATE UNIQUE INDEX session_participants_one_active_per_user
+  ON session_participants(user_id) WHERE left_at IS NULL;
+```
+
+This expresses "at most one active participation per user" while allowing
+unbounded historical (left) rows. We expect 2-3 more such indexes over the
+project's lifetime.
+
+**The schema-first blocker.** `sea-schema`'s SQLite introspector cannot read
+the `WHERE` clause from `sqlite_master.sql` text in a way that propagates to
+codegen output. Each `sea-orm-cli generate entity` run produces a wrong
+`#[sea_orm(unique)]` attribute on the column and a wrong `has_one`
+cardinality on the inverse `Relation`. The entity must be hand-corrected
+after every codegen.
+
+**The question.** Does SeaORM 2.0's entity-first workflow solve this, or
+does it have the same problem?
+
+## SeaORM 2.0 status (as of 2026-05-03)
+
+**SeaORM 2.0 is not yet stable.** Verified directly against
+crates.io's API:
+
+- `max_stable_version: 1.1.20` (released 2026-03-31)
+- `max_version: 2.0.0-rc.38` (released 2026-04-09)
+- `newest_version: 2.0.0-rc.38`
+- ~38 release candidates over ~7 months (rc.1 ≈ Sept 2025)
+
+The 2026-01-12 SeaORM blog post that uses the title "SeaORM 2.0" is an
+**API freeze announcement**, not a stable release announcement. Verbatim:
+
+> Over the past few months, we've rolled out a series of SeaORM 2.0
+> releases packed with new capabilities. We've stablized our API surface
+> now. Other than dependency upgrades (sqlx 0.9), there won't be more
+> major breaking changes.
+
+API freeze means new attributes can still be added (they're additive,
+non-breaking), but the team is signalling that porting code to 2.0 is
+now safe. Recent RC release notes (rc.34, rc.35, rc.38) show the team
+is still fixing core entity-first / schema-sync bugs:
+
+- rc.34 — "Don't create index if column is already unique (entity first
+  workflow)" (#2950)
+- rc.35 — "Fix unique column in schema sync" (#2971)
+- rc.38 — "Fix schema sync not discovering tables in non-default
+  schemas" (#3016)
+
+## Q1: Can entity-first express a partial unique index? — **No.**
+
+I read `sea-orm-macros/src/derives/entity_model.rs` directly and
+enumerated every accepted `#[sea_orm(...)]` attribute on
+`DeriveEntityModel`:
+
+- Field-level: `column_type`, `auto_increment`, `comment`,
+  `default_value`, `default_expr`, `column_name`, `enum_name`,
+  `select_as`, `save_as`, `ignore`, `primary_key`, `nullable`,
+  `indexed`, `unique`, `unique_key`, `renamed_from`, `extra`
+- Struct-level: `comment`, `table_name`, `schema_name`, `table_iden`,
+  `model_ex`, `rename_all`
+
+There is no `where`, `partial`, `filter`, `condition`, or `index_where`
+attribute. `unique_key = "name"` only groups columns into a plain
+composite unique constraint — no predicate.
+
+The official entity-first doc page never shows a `WHERE` clause, and a
+related ergonomics request (#872, "Index::create().filter(...)") was
+closed `not_planned` in February 2023.
+
+## Q2: Mixing entity-first with a sidecar migration — **Possible, but risky.**
+
+The lower layer supports it. `sea_query::IndexCreateStatement` has a
+`r#where` field with `.and_where(...)` / `.cond_where(...)` builders,
+and emits valid `WHERE ...` clauses for SQLite. Verified in
+`sea-query/src/index/create.rs`. So a hand-written migration can
+declare the partial index in pure Rust.
+
+**The problem is what `sync()` does next boot.** From the entity-first
+docs (footnote):
+
+> schema sync would not attempt to do any destructive actions, so
+> meaning no DROP on tables, columns and foreign keys. **Dropping
+> index is an exception here.**
+
+That is the failure mode. Schema-sync drops indexes it cannot reconcile
+to an entity declaration. Issue **#2812** (closed Nov 2025, fixed in
+rc.34/rc.35) is the receipt: a multi-column unique index, declared
+entirely via `unique_key`, was created on first run and **dropped on
+the second sync**. That was the entity-declared case; the rc.34/rc.35
+fixes do not address the "preserve unknown index" case.
+
+There is no documented opt-out flag (e.g., `preserve_unknown_indexes`).
+On SQLite specifically, the introspector reads `sqlite_master.sql`
+text but does not parse the predicate, so a partial index will look
+"extra" to the diff and get DROPped.
+
+Practical workarounds: gate `schema-sync` to first-boot only, or
+re-create the partial index outside the sync path on every startup.
+Both are uglier than just using a normal migration system.
+
+## Q3: Production maturity — **RC series, still ironing out core bugs.**
+
+- 38 RCs over ~7 months. No `2.x.y` stable patch series.
+- `1.1.20` is the latest stable.
+- GitHub search returns 30 results for `schema-sync`, 175 for
+  `entity-first`. Activity concentrated in 2026 RCs, not stabilized.
+
+Notable issues:
+
+- **#2812** (closed, fixed rc.34/rc.35) — Multi-column unique index
+  dropped by schema-sync. Direct precedent for the partial-index
+  concern.
+- **#2666** (closed Nov 2025) — Entity generation misinterprets partial
+  unique index as fully unique (the schema-first blocker). The fix
+  (sea-schema PR #150) only added an `is_partial` flag for
+  **PostgreSQL** discovery; it does not parse the predicate, does not
+  propagate to entity codegen output, and does not touch SQLite.
+- **#2983** (open, Mar 2026) — "entity first: allow dropping columns and
+  tables." Confirms current schema-sync silently ignores DROP-column
+  actions.
+- **#2953** (open, Feb 2026) — "schema sync does not sync existing
+  foreign key actions."
+- **#2889** (open, Jan 2026) + **PR #3015** (open) — "entity-first
+  migrations." Diff-to-migration codegen is requested but in-progress.
+
+No independent community write-ups (DEV.to, /r/rust, This Week in
+Rust) about teams running entity-first in production were located.
+
+## Q4: SQLite-specific schema-sync caveats
+
+No authoritative per-scenario documentation exists for SQLite. The
+following is stitched from the entity-first doc page, recent RC
+release notes, and #2983.
+
+- **Rename a column.** Supported via `#[sea_orm(renamed_from =
+  "old_name")]`. Emits `ALTER TABLE ... RENAME COLUMN`, which SQLite
+  has supported since 3.25.0 (2018).
+- **Change a column's type.** Not documented. SQLite has no `ALTER
+  COLUMN ... TYPE`; the standard fix is a table rebuild (CREATE NEW +
+  INSERT + DROP + RENAME). No evidence schema-sync performs the
+  rebuild — expect silent no-op or failure. Use a hand-written
+  migration.
+- **Add a `NOT NULL` column without default to a non-empty table.**
+  SQLite rejects this at the engine level. Schema-sync emits the
+  `ALTER` and SQLite returns an error. Either give the column a
+  default or do a rebuild migration.
+- **Remove a foreign key.** Per the entity-first doc footnote,
+  schema-sync **will not** drop FK constraints. On SQLite, removing an
+  FK requires a table rebuild anyway, which schema-sync does not
+  implement. The FK quietly remains.
+
+General SQLite caveat: `ALTER TABLE` is much narrower than on
+PostgreSQL or MySQL, and schema-sync's "non-destructive only" stance
+compounds that. The set of changes sync can do for you on SQLite is a
+strict subset of "things SQLite can do safely with one statement."
+
+## Workaround investigated: generated-column trick
+
+There is a SQL technique for converting a partial unique into a
+regular unique by using a generated column:
+
+```sql
+ALTER TABLE session_participants ADD COLUMN active_user_id
+  GENERATED ALWAYS AS (CASE WHEN left_at IS NULL THEN user_id ELSE NULL END);
+CREATE UNIQUE INDEX ... ON session_participants(active_user_id);
+```
+
+SQLite treats NULLs as distinct in unique constraints, so historical
+rows (NULL `active_user_id`) all coexist while at most one non-NULL
+value per `user_id` is allowed. SQLite has supported generated columns
+since 3.31 (2020).
+
+In SeaORM 2.0 entity-first, this could be expressed via the `extra`
+escape hatch:
+
+```rust
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "session_participants")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub user_id: i32,
+    pub left_at: Option<DateTimeUtc>,
+
+    #[sea_orm(
+        unique,
+        nullable,
+        extra = "GENERATED ALWAYS AS (CASE WHEN left_at IS NULL THEN user_id ELSE NULL END) STORED"
+    )]
+    pub active_user_id: Option<i32>,
+}
+```
+
+`extra` is verified to pass strings through to `sea_query::ColumnDef::extra()`,
+which appends arbitrary DDL text to a column definition.
+
+**Three reasons this is not recommended:**
+
+1. **It's an escape hatch, not a DSL.** `sea_query::ColumnDef` has a
+   first-class `.generated(expr, stored)` builder, but the SeaORM
+   entity macro doesn't expose a `#[sea_orm(generated = "...")]`
+   attribute that maps to it. The `extra` approach is a raw SQL
+   string: not type-checked, breaks if columns are renamed, and
+   database-specific.
+2. **Schema-sync will probably misbehave.** sea-schema's introspector
+   likely doesn't surface the generation expression on round-trip
+   discovery, so the diff between entity and live DB will look
+   mismatched. Best case: sync no-ops. Worst case: it tries to rebuild
+   the table or drop the unique index. Untested.
+3. **It changes the data model for ORM-fit reasons.** Anyone reading
+   the table will see two `user_id`-shaped columns and need an
+   explanatory comment.
+
+The clean upstream fix would be a `#[sea_orm(generated = "...")]`
+attribute exposing `sea_query::ColumnDef::generated()`. That is the
+issue worth opening if we want this properly supported.
+
+## Decision: stay schema-first
+
+**Recommendation: stay on schema-first with hand-corrected entities.**
+
+Reasoning:
+
+1. **The DSL doesn't support partial indexes**, and the workaround
+   (sidecar migration) collides with sync's documented index-drop
+   behavior. We'd be trading a known annoyance (post-codegen patch)
+   for a less predictable one (sync silently wiping our partial index
+   on a future cold start).
+2. **2.0 isn't stable yet.** Adopting rc.38 to fix one schema-first
+   irritant means a moving target. Every recent RC has been fixing
+   core entity-first / schema-sync bugs.
+3. **The existing blocker is cheap to script around.** After
+   `sea-orm-cli generate entity`, delete the bogus
+   `#[sea_orm(unique)]` on `user_id` and change the inverse
+   `Relation` to `has_many`. A small post-codegen script (or a clearly
+   commented manual step) is far cheaper than fighting sync semantics.
+
+## Why entity-first probably never gets partial-index DSL support
+
+The pattern across SeaQL's libraries is that the *entity* layer is for
+type/relation mapping and the *schema construction* layer (sea_query)
+is where DDL flexibility lives. The capability exists at the lower
+layer (`sea_query::IndexCreateStatement::and_where`); it's just not
+surfaced in the entity DSL. There is no clean Rust syntax for
+"WHERE left_at IS NULL" in a derive macro — the options are all bad
+(string predicate loses type safety; full predicate DSL is huge surface
+area; closures don't fit derive macros). The team has likely decided
+"leave that to migrations."
+
+Issue #872 closing as `not_planned` reinforces this read.
+
+## Things to watch
+
+These would change the calculus enough to revisit the decision:
+
+- **2.0 actually ships stable.** Removes the moving-target argument.
+- **A `preserve_unknown_indexes` flag** for schema-sync. Would let a
+  sidecar migration coexist with entity-first sync without index
+  deletion. Non-breaking, plausible post-stable addition.
+- **A `#[sea_orm(generated = "...")]` attribute** exposing
+  `sea_query::ColumnDef::generated()`. Would make the generated-column
+  trick a clean, type-checked solution.
+- **#3015 ("entity-first migrations") lands.** Diff-to-migration
+  codegen would replace schema-sync's destructive-vs-non-destructive
+  tension with a reviewable migration generator.
+- **sea-schema gains SQLite WHERE-clause parsing** (parallel to the PG
+  `is_partial` work in PR #150). Would fix the original schema-first
+  codegen bug at the root.
+
+## Sources
+
+- [Entity-first docs](https://www.sea-ql.org/SeaORM/docs/generate-entity/entity-first/)
+- [SeaORM what's new](https://www.sea-ql.org/SeaORM/docs/introduction/whats-new/)
+- [SeaORM 2.0 API freeze blog post — 2026-01-12](https://www.sea-ql.org/blog/2026-01-12-sea-orm-2.0/)
+- [crates.io API for sea-orm](https://crates.io/api/v1/crates/sea-orm)
+- [SeaQL/sea-orm releases](https://github.com/SeaQL/sea-orm/releases)
+- [sea-orm-macros entity_model.rs](https://github.com/SeaQL/sea-orm/blob/master/sea-orm-macros/src/derives/entity_model.rs)
+- [sea-query table/column.rs (extra, generated)](https://github.com/SeaQL/sea-query/blob/master/src/table/column.rs)
+- [sea-query index/create.rs (and_where)](https://github.com/SeaQL/sea-query/blob/master/src/index/create.rs)
+- Issues: [#872](https://github.com/SeaQL/sea-orm/issues/872), [#2666](https://github.com/SeaQL/sea-orm/issues/2666), [#2812](https://github.com/SeaQL/sea-orm/issues/2812), [#2889](https://github.com/SeaQL/sea-orm/issues/2889), [#2953](https://github.com/SeaQL/sea-orm/issues/2953), [#2983](https://github.com/SeaQL/sea-orm/issues/2983), [#3015](https://github.com/SeaQL/sea-orm/pull/3015)
+
+## Document history
+
+- 2026-05-03 — Initial document. Captures the SeaORM 2.0 entity-first evaluation and the decision to stay on schema-first with hand-corrected entities for tables that have partial unique indexes.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -151,7 +151,6 @@ export interface RaceInfo {
 
 export interface SessionDetail {
   id: string
-  created_by: string
   host_id: string
   host_username: string
   ruleset: string

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ test:
 
 # Regenerate SeaORM entities from the database
 entities:
-    cd backend && sea-orm-cli generate entity -o src/entities --lib
+    cd backend && sea-orm-cli generate entity -o src/entities
 
 # Production build (backend + frontend)
 build:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 # Beerio Kart development recipes
 
+set dotenv-load := true
+
 # Start backend and frontend in dev mode (run in separate terminals)
 dev:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Drop the unused `sessions.created_by` column and FK. `host_id` continues to behave as documented (set to creator at session creation; transfers to earliest-joined remaining participant on host leave).

No product feature reads `created_by` — the UI surfaces only the current host (🏠 icon), and host-on-leave logic only consults `host_id` and the participant list. Removing the column also eliminates a live instance of the multi-FK-to-same-target case that codegen historically gets wrong ([sea-orm #405](https://github.com/SeaQL/sea-orm/issues/405)); the rule in `docs/coding-standards/seaorm.md` § 11 stays, but its footnote tightens to "no current schema instances."

This is **PR-E3** in [`docs/compliance-plan.md`](docs/compliance-plan.md), approved in [`reviews/design/2026-05-02-sessions-created-by-removal.md`](reviews/design/2026-05-02-sessions-created-by-removal.md) (all eight section sign-offs + the final clear-to-implement box).

## Changes

- **Migration** (`backend/migration/src/m20260101_000001_initial_schema.rs`): drop the `created_by` column from the raw-SQL `CREATE TABLE sessions`. Edited in place per the prelaunch consolidated-migration policy.
- **Entity** (`backend/src/entities/sessions.rs`): regenerated via `sea-orm-cli generate entity`. With only one FK to `users` remaining, codegen collapses `HostUser` → `Users` and adds the `Related<users::Entity>` impl. No call sites referenced `Relation::HostUser` by name (verified via grep).
- **Group (2) relations re-added** (`backend/src/entities/users.rs`, `backend/src/entities/session_races.rs`): the simplified `sessions` schema unlocks legitimate new codegen output that the initial PR commit reverted along with the hand-corrections. Re-added on top: `users.has_many sessions` + `Related<sessions::Entity>` impl, a many-to-many between `users` and `session_races` via `session_race_participations` (with `via()` impls on both sides), and a `session_races.has_many session_race_participations` + `Related` impl. Documented in [`reviews/design/2026-05-02-entity-codegen-strategy.md`](reviews/design/2026-05-02-entity-codegen-strategy.md) § 1.
- **Group (1) hand-corrections preserved** (`backend/src/entities/session_participants.rs`, `backend/src/entities/users.rs`, `backend/src/entities/session_race_participations.rs`): the partial unique index on `session_participants.user_id` (`WHERE left_at IS NULL`) is mis-introspected by `sea-schema` as a full uniqueness constraint, which produces a wrong `unique` attribute and flips `users → session_participants` from `has_many` to `has_one`. Both kept corrected in the existing in-file-comment style. PR-X1 (already designed, gated separately) will eliminate this convention by stripping `@generated` headers and treating entities as committed source. Root cause discussed in design record § 2.
- **Service / DTO** (`backend/src/services/sessions.rs`): drop `created_by` from session creation (`create_session`), from the public `SessionDetail` DTO, and from the DTO-construction site in `get_session_detail`.
- **Test helpers** (`backend/src/test_helpers.rs`): drop `created_by: Set(...)` from `insert_session`.
- **Frontend type** (`frontend/src/api/types.ts`): drop `created_by` from the `SessionDetail` interface. The field had no consumers — type-only cleanup to match the new API shape, included here to keep the wire contract consistent in one atomic PR.
- **Docs** (`docs/design.md`): updated the sessions schema block, the host_id note, and added a new bullet to Design Decisions per § 5.1 / 5.2 / 5.3 of the design record.
- **Standards** (`docs/coding-standards/seaorm.md` § 11): footnote tightened to "no current schema instances; the rule remains in force for any future table that reuses a target."
- **Tooling — drop `--lib`** (`justfile`): the `--lib` flag tells `sea-orm-cli` to emit `lib.rs` (a crate root for a standalone library crate). Entities live as a sub-module of the binary via `mod.rs`, so `--lib` produced an orphan `lib.rs` that nothing imports while leaving the live `mod.rs` untouched. Without the flag, regen writes `mod.rs` (matching the existing module structure and the rest of the codebase's Rust 2015 style).
- **Tooling — enable `dotenv-load`** (`justfile`): `set dotenv-load := true` at the top so recipes auto-load `.env`. The `entities` recipe needed `DATABASE_URL`; without auto-loading, `just entities` failed unless the user happened to have it in their shell. `.env.example` already documents `DATABASE_URL` with the project default — `.env` is now the single source of config.

## Non-obvious notes

- A separate Cowork session produced [`reviews/design/2026-05-02-entity-codegen-strategy.md`](reviews/design/2026-05-02-entity-codegen-strategy.md) (signed off) and [`docs/seaorm_2_0_migration.md`](docs/seaorm_2_0_migration.md) — a primary-source evaluation of SeaORM 2.0's entity-first workflow. They aren't part of this PR (the design record is gitignored under `reviews/`; the migration eval doc is untracked locally and will land with PR-X1). Linked here so reviewers have the full architectural context for why the Group (1) hand-corrections still exist in this PR rather than being eliminated.
- Migrating the project from `mod.rs` (Rust 2015) to `<modname>.rs` (Rust 2018) is a separate stylistic refactor — `sea-orm-cli`'s `--lib` flag does not produce that style (it produces a crate root, not a sibling module file). The rest of the backend (`services/mod.rs`, `routes/mod.rs`, etc.) all use Rust 2015 style, so flipping just `entities` would be inconsistent. Out of scope here.

## Test plan

- [x] `cd backend && cargo build --all-targets` — clean build (verified locally; ~25s)
- [x] `cd backend && cargo test` — all 226 tests pass (151 unit + 27 + 21 + 8 + 19 integration; verified locally on `100a4e2`)
- [x] `cd frontend && bunx tsc --noEmit` — type-check clean (verified locally)
- [x] `grep -rn created_by backend/src/ backend/tests/ backend/migration/src/` — only `drink_types` hits remain (a different table that legitimately has `created_by`)
- [x] `just entities` (after `rm data/db/beerio-kart.db && cargo run` to populate, with `DATABASE_URL` uncommented in your local `.env`) — writes `backend/src/entities/mod.rs`, no `lib.rs` produced. Output diff against this branch should reveal only the two known partial-index hand-corrections (`session_participants.rs` and `users.rs`) plus the doc header on `session_race_participations.rs`.
- [x] Smoke: start the app (`just dev`), create a session, verify the host UI still shows 🏠 and the session detail JSON no longer includes `created_by`. Leave/rejoin and confirm host transfer still works.
- [x] **Important — reset the dev DB before booting:** `rm data/db/beerio-kart.db` so SeaORM recreates the schema from the consolidated migration. (Required because the schema changed; per the prelaunch policy in CLAUDE.md.)

## Follow-ups (not in scope)

- After this merges, check the PR-E3 row in [`docs/compliance-plan.md`](docs/compliance-plan.md).
- Archive [`reviews/design/2026-05-02-sessions-created-by-removal.md`](reviews/design/2026-05-02-sessions-created-by-removal.md) per project convention (kept in `reviews/design/` as historical record).
- **PR-X1** will convert entity files to hand-written source (strip `@generated` headers, repurpose `just entities` → `just entities-bootstrap`, update `seaorm.md` § 6) — design record signed off, ready to start whenever.
- **PR-X2** adds the schema-drift verification test (`Entity::find().limit(0).all(&db)` per entity against a fresh in-memory migrated DB) — depends on PR-X1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)