### PR TITLE
docs: update CLAUDE.md for GitHub MCP and move handoffs to docs/handoffs/

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,14 +4,21 @@
 Read `docs/design.md` at the start of every session. It is the single source of truth for the project's design and reflects the full history of design decisions.
 
 ### Handoff files
-Two handoff files enable async task passing between assistants. The writer creates the file, the reader deletes it when done — the file's existence is the signal.
 
-- **`.claude/cowork-handoff.md`** — Cowork → Claude Code. Check before starting work. Contains task instructions from the architecture/design assistant. Delete after completing the work.
-- **`.claude/claude-code-handoff.md`** — Claude Code → Cowork. Write this when you have questions, research requests, or design decisions for Cowork. Cowork deletes it after addressing.
+Two handoff channels enable async task passing between assistants. The writer creates the file; the reader deletes it when done — the file's existence is the signal.
+
+Handoff files live under `docs/handoffs/`. The directory is gitignored (handoffs are transient and shouldn't pollute git history); only `docs/handoffs/README.md` is checked in, and it documents the format and lifecycle for humans browsing the repo.
+
+- **`docs/handoffs/cowork-handoff.md`** — Cowork → Claude Code. Check before starting work. Contains task instructions from the architecture/design assistant. Claude Code deletes after completing the work.
+- **`docs/handoffs/claude-code-handoff.md`** — Claude Code → Cowork. Write this when you have questions, research requests, or design decisions for Cowork. Brendan or the next Claude Code session deletes after Cowork acknowledges in chat — Cowork's sandbox blocks `unlink()` repo-wide, so Cowork can't clean up its own inbox.
+
+For task-specific handoffs that shouldn't collide with the canonical filenames, use a dated variant: `cowork-handoff-<YYYY-MM-DD>-<slug>.md` or `claude-code-handoff-<YYYY-MM-DD>-<slug>.md`.
 
 **Anything intended for the other assistant to act on — task specs, code review findings, bug reports, design decisions, answers to their questions — MUST be written to the appropriate handoff file.** Delivering it only in chat means the other assistant won't see it. If you find yourself composing a substantive response that the other assistant needs, stop and write it to the handoff file instead.
 
-**Do not use handoff files for your own session notes.** The handoff files are one-way channels between assistants — if the file exists, the recipient assumes there's work to do. For self-notes or session state you want to preserve across your own sessions, use `.claude/cowork-notes.md` (Cowork) or a similar assistant-specific notes file.
+**Do not use handoff files for your own session notes.** The handoff files are one-way channels between assistants — if the file exists, the recipient assumes there's work to do. For self-notes or session state you want to preserve across your own sessions, use `.claude/cowork-notes.md` (Cowork) or `.claude/claude-code-notes.md` (Claude Code).
+
+**Why `docs/handoffs/` and not `.claude/`:** Cowork's `Write` and `Edit` tools refuse to write under `.claude/` — that path is protected at the Cowork tool layer to prevent the AI from silently rewriting its own context (CLAUDE.md, skills, settings). Bash writes still succeed, but routing routine handoffs through bash is awkward and obscures intent. `docs/handoffs/` keeps the protected zone protected and lets handoffs use the normal file tools.
 
 ## Project Phase
 Phase 3 — Sessions & Run Recording (core gameplay loop).
@@ -88,8 +95,30 @@ Each in-scope file keeps a `## Document history` section at the bottom. Any AI-a
 
 This project uses two AI environments:
 
-- **Cowork (Claude Desktop):** Design, architecture, documentation, research, review. Accesses the repo via a Windows mount (`C:\Users\obiva\beerio-kart`). Cannot access WSL2 filesystem, cannot access GitHub directly, and **cannot run git commands** — the Cowork sandbox mounts the repo via virtiofs with `unlink()` blocked at the mount layer (every file delete returns `EPERM`, including files Cowork just created). Git relies on creating and removing `.git/index.lock` and temp objects, so any git invocation from Cowork either fails outright or leaves a stale lock that breaks the next attempt. Cowork edits files only.
+- **Cowork (Claude Desktop):** Design, architecture, documentation, research, review. Accesses the repo via a Windows mount (`C:\Users\obiva\beerio-kart`). Cannot access WSL2 filesystem and **cannot run git commands** — the Cowork sandbox mounts the repo via virtiofs with `unlink()` blocked at the mount layer (every file delete returns `EPERM`, including files Cowork just created). Git relies on creating and removing `.git/index.lock` and temp objects, so any git invocation from Cowork either fails outright or leaves a stale lock that breaks the next attempt. Cowork edits files only. For GitHub API operations (issues, PRs, project board) see § GitHub access below.
 - **Claude Code (WSL2 CLI):** Coding, building, testing, git operations. Accesses the same checkout via `/mnt/c/Users/obiva/beerio-kart/`. WSL2's `/mnt/c` (9P/DrvFs) supports unlink, so git works fine there.
+
+### GitHub access
+
+Cowork can read and write GitHub data — issues, pull requests, project board items, milestones — through Composio's GitHub MCP connector. The connection authenticates as the GitHub user `brendanbyrne`. Anything Cowork does via the MCP appears in the GitHub UI under that account.
+
+**What Cowork can do via the MCP:**
+
+- File, label, assign, triage, and close issues; add comments.
+- Read PR diffs, conversation threads, and review state. (Creating commits or PRs still requires Claude Code — that's a git operation, not an API operation.)
+- Add items to the project board, move them between Status columns, set custom field values, attach milestones.
+- Create and manage milestones.
+- Run arbitrary GraphQL queries against `api.github.com/graphql` when no purpose-built tool exists.
+
+**What the MCP cannot do, regardless of which assistant calls it:**
+
+- **Run `git`.** The MCP only talks to GitHub's API. Branch creation, commits, pushes, and merges remain Claude Code's job.
+- **Create or edit project custom fields, status field options (board columns), views, or built-in workflows.** GitHub's API does not expose these — they are configured in the project Settings UI only.
+- **Set Assignees, Labels, Milestone, or Repository via the project field mutation.** Those are properties of the underlying issue/PR; use the issue/PR mutations instead.
+
+**Field IDs reference:** `docs/project-field-ids.md` caches the project's field IDs and Status option IDs. Consult that file before issuing project-board write calls — Composio's tools require IDs, not names. Update the file if anyone changes the project's fields in the GitHub UI.
+
+**When to use Cowork vs. Claude Code for GitHub work:** anything that ends in a commit, push, or merge → Claude Code. Anything that stays inside GitHub's API surface (issue triage, project board updates, PR comments, milestone management) → Cowork is fine, and often faster because it can stay in conversation.
 
 ### Git workflow
 
@@ -113,7 +142,7 @@ This project uses two AI environments:
 **Coordination between assistants:**
 
 - Both assistants work on the same checkout — no push/pull needed to see each other's changes.
-- **Cowork** cannot run git at all (its sandbox mount blocks `unlink`). When Cowork wants a change committed, it edits the working tree and notes the intended commit in `.claude/cowork-handoff.md` or chat; Brendan or Claude Code then stages, commits, and pushes.
+- **Cowork** cannot run git at all (its sandbox mount blocks `unlink`). When Cowork wants a change committed, it edits the working tree and notes the intended commit in `docs/handoffs/cowork-handoff.md` or chat; Brendan or Claude Code then stages, commits, and pushes.
 - **Claude Code** must `git push` after making changes so the remote stays current.
 - Both should check `git status` before starting work to avoid conflicts.
 - If both need to edit the same file, coordinate through the user (Brendan).
@@ -128,6 +157,7 @@ This project uses two AI environments:
 | Git commits | Claude Code or Brendan (Cowork cannot run git) |
 | Git pushes | Claude Code (or Brendan) |
 | Code review & research | Either |
+| Project board / issue triage | Either (Cowork via MCP, Claude Code via `gh`) |
 | Deployment config | Claude Code (with Cowork for planning) |
 | Browser-based tasks | Cowork |
 | Design reviews | Cowork (writes to `reviews/design/`) |

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,9 @@ target/
 # Environment files
 .env
 
-# Assistant handoff files (ephemeral)
-.claude/*-handoff.md
+# Assistant handoff files (ephemeral; live under docs/handoffs/, only the README is tracked)
+docs/handoffs/*
+!docs/handoffs/README.md
 
 # Assistant self-notes (ephemeral session state)
 .claude/*-notes.md

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,47 @@
+# Handoff files
+
+This directory holds short-lived task specs and questions that pass between Cowork (Claude Desktop, design/docs/research) and Claude Code (WSL2 CLI, code/build/test/git). It exists because the two assistants don't share a chat history — anything one needs the other to act on has to be written down somewhere they'll both look.
+
+## The convention
+
+Two channels:
+
+- **`cowork-handoff.md`** — Cowork → Claude Code. Cowork writes; Claude Code reads, acts on it, and deletes it.
+- **`claude-code-handoff.md`** — Claude Code → Cowork. Claude Code writes; Cowork reads and acknowledges in chat. Brendan or the next Claude Code session deletes it (Cowork's sandbox blocks `unlink()` repo-wide, so Cowork can't clean up its own inbox).
+
+**The writer creates the file; the file's existence is the signal that there is work to do.** No file means no work.
+
+For task-specific handoffs that shouldn't collide with the canonical filenames (e.g. multiple parallel work items), use a dated slug:
+
+- `cowork-handoff-<YYYY-MM-DD>-<slug>.md`
+- `claude-code-handoff-<YYYY-MM-DD>-<slug>.md`
+
+## What goes here
+
+- **Task specs.** "Apply these three edits to file X, open a PR, and delete this handoff."
+- **Questions and research requests.** "What should the API contract say about idempotency keys on `POST /runs`?"
+- **Code review findings, bug reports, design decisions, answers to the other assistant's questions.**
+
+If you find yourself composing a substantive response in chat that the other assistant needs to see in order to do their next piece of work, **stop and write it here instead**. Anything delivered only in chat is invisible to the other assistant.
+
+## What does NOT go here
+
+- **Self-notes / session state.** Those go in `.claude/cowork-notes.md` (Cowork) or `.claude/claude-code-notes.md` (Claude Code). Self-notes are persistent memory you keep for your own future sessions; handoffs are one-way coordination channels to the *other* assistant. Mixing them breaks the existence-as-signal rule.
+- **Anything intended for git history.** This directory is gitignored except for this README — handoffs are by definition transient and shouldn't pollute the log.
+
+## Lifecycle and constraints
+
+- **Cowork → Claude Code** is the easy direction. Cowork writes the file (via the normal Write tool — `docs/` is not in Cowork's protected zone). Claude Code reads it, applies the changes, commits, opens a PR, and `rm`s the handoff file as part of the PR. One round trip.
+- **Claude Code → Cowork** is messier because Cowork can't delete files. The flow:
+  1. Claude Code writes `claude-code-handoff.md` and pushes (or just leaves it on the working tree, since it's gitignored).
+  2. Cowork reads it on next session start and addresses it in chat.
+  3. Cowork tells Brendan it's been addressed and asks for the file to be deleted, OR notes in `.claude/cowork-notes.md` that the next Claude Code session should `rm` it.
+  4. Brendan or Claude Code deletes the file.
+
+Yes, this is awkward — it's the cost of Cowork's sandbox blocking `unlink()` (which is otherwise the *right* default for an AI agent that shouldn't be deleting files unsupervised).
+
+## Why `docs/handoffs/` and not `.claude/`
+
+Cowork's `Write` and `Edit` tools refuse to write any file under `.claude/`. The error string is "resolves to a protected location or a path outside the connected folder," and it's a Cowork tool-layer rule, not a filesystem permission — bash writes to `.claude/` succeed. The point of the rule is to prevent Cowork from silently rewriting its own context (`.claude/CLAUDE.md`, skills, `settings.local.json`), which is a healthy default for an AI agent. We don't want to poke holes in it just for handoffs.
+
+`docs/handoffs/` sits outside the protected zone, supports the normal file tools, and reads naturally to humans browsing the repo.

--- a/docs/project-field-ids.md
+++ b/docs/project-field-ids.md
@@ -1,0 +1,93 @@
+# Project field IDs reference
+
+Reference for the GitHub Projects V2 board associated with this repo. Cowork (via Composio's GitHub MCP) and Claude Code (via the official github-mcp-server) both need these IDs — particularly the Status option IDs — to move items between columns or update field values. Looking them up costs an API call each time, so they're cached here.
+
+If anyone changes the project's fields or option names in the GitHub UI, this file must be updated. There's no tooling to detect drift; treat it as schema documentation.
+
+## Project
+
+| Field | Value |
+|---|---|
+| Owner | `brendanbyrne` (user, not org) |
+| Project number | `3` |
+| Project node ID | `PVT_kwHOAA6jO84BWue2` |
+| URL | https://github.com/users/brendanbyrne/projects/3 |
+
+## Custom fields
+
+The project currently uses only GitHub's default fields — no custom fields have been added. Per `CLAUDE.md`, phases are tracked via Milestones rather than a custom Phase field.
+
+## Status field (single-select — the board columns)
+
+| Field | Value |
+|---|---|
+| Field name | `Status` |
+| Field node ID | `PVTSSF_lAHOAA6jO84BWue2zhSAUeI` |
+| Field numeric ID | `343953890` |
+
+| Option | Color | Option ID |
+|---|---|---|
+| Todo | green | `f75ad846` |
+| In Progress | yellow | `47fc9ee4` |
+| Done | purple | `98236657` |
+
+## Other built-in fields
+
+These rarely need to be set via the API (most are populated automatically by GitHub when an issue/PR is added), but listed for completeness.
+
+| Field | Type | Node ID |
+|---|---|---|
+| Title | title | `PVTF_lAHOAA6jO84BWue2zhSAUeA` |
+| Assignees | assignees | `PVTF_lAHOAA6jO84BWue2zhSAUeE` |
+| Labels | labels | `PVTF_lAHOAA6jO84BWue2zhSAUeM` |
+| Linked pull requests | linked_pull_requests | `PVTF_lAHOAA6jO84BWue2zhSAUeQ` |
+| Milestone | milestone | `PVTF_lAHOAA6jO84BWue2zhSAUeU` |
+| Repository | repository | `PVTF_lAHOAA6jO84BWue2zhSAUeY` |
+| Reviewers | reviewers | `PVTF_lAHOAA6jO84BWue2zhSAUec` |
+| Parent issue | parent_issue | `PVTF_lAHOAA6jO84BWue2zhSAUeg` |
+| Sub-issues progress | sub_issues_progress | `PVTF_lAHOAA6jO84BWue2zhSAUek` |
+
+Per the Projects V2 GraphQL API, `updateProjectV2ItemFieldValue` cannot set Assignees, Labels, Milestone, or Repository — those are properties of the underlying issue/PR, not the project item. Use the issue/PR mutations (`addAssigneesToAssignable`, `addLabelsToLabelable`, `updateIssue`, etc.) instead.
+
+## Common write patterns
+
+Reference snippets for the most common project-board operations. Argument shapes follow Composio's GitHub toolkit.
+
+### Move an item to In Progress
+
+```
+GITHUB_UPDATE_USER_PROJECT_ITEM
+  projectId  = PVT_kwHOAA6jO84BWue2
+  itemId     = <PVTI_... node ID of the project item, NOT the issue ID>
+  fieldId    = PVTSSF_lAHOAA6jO84BWue2zhSAUeI
+  value      = { "singleSelectOptionId": "47fc9ee4" }
+```
+
+### Set a date field
+
+```
+value = { "date": "2026-05-15" }
+```
+
+### Set a number field
+
+```
+value = { "number": 3 }
+```
+
+### Set an iteration field
+
+```
+value = { "iterationId": "<iteration node ID>" }
+```
+
+### Clear a field
+
+```
+GITHUB_CLEAR_PROJECT_V2_ITEM_FIELD_VALUE
+  projectId, itemId, fieldId
+```
+
+## Document history
+
+- 2026-05-05 — Initial capture after first successful Composio MCP connection. Project was created with default fields only (Board template).


### PR DESCRIPTION
## Summary

Documentation-only catch-up to two changes that already happened in the working environment:

1. **GitHub MCP is wired up.** Cowork now operates on GitHub (issues, PRs, project board, milestones) via Composio's GitHub MCP, authenticated as `brendanbyrne`. The old `cannot access GitHub directly` clause is stale.
2. **Handoff files moved.** They now live in `docs/handoffs/` instead of `.claude/`. Cowork's `Write`/`Edit` tools refuse to touch `.claude/` (tool-layer safety rule), which made the old location awkward.

## What changed

- **`.claude/CLAUDE.md`**:
  - Cowork bullet under § Two-assistant setup: removed `cannot access GitHub directly`, added cross-reference to the new GitHub access subsection.
  - New § GitHub access subsection between Two-assistant setup and Git workflow — covers what the MCP can/can't do and when to use Cowork vs. Claude Code for GitHub work.
  - New `Project board / issue triage` row in the "Who does what" table.
  - § Handoff files (under Start of Session) rewritten — points at `docs/handoffs/`, documents the dated-variant naming convention, and explains *why* `.claude/` doesn't work for handoffs.
  - One additional stale `.claude/cowork-handoff.md` reference under § Coordination between assistants — fixed inline (not enumerated in Cowork's handoff but clearly part of the same logical change).
- **`.gitignore`**: replaces `.claude/*-handoff.md` block with `docs/handoffs/*` + `!docs/handoffs/README.md` exception. (Cowork already made this edit in the working tree before I picked up the handoff.)
- **`docs/handoffs/README.md`** (new): documents the format and lifecycle for humans browsing the repo.
- **`docs/project-field-ids.md`** (new): caches the GitHub Projects V2 field/option IDs that the MCP needs for write calls. Brendan asked to bundle this into the same PR rather than land it separately, since the new GitHub access subsection references it.

## Things worth calling out

- The handoff Cleanup E step (`rm .claude/.writability-test.md`) was a no-op — the file did not exist in this checkout.
- I caught one stale `.claude/cowork-handoff.md` reference (line 145 in the original CLAUDE.md, under § Coordination between assistants) that the handoff didn't enumerate. Fixed it because leaving it inconsistent in the same PR that's supposed to clean these up would be sloppy.
- `docs/drafts/` shows as untracked in `git status` but is **not** part of this PR. It's a separate Cowork-side scratch directory that hasn't been gitignored or committed yet — out of scope here.

## Test plan

This is a documentation-only PR (no code, no tests, no build artifacts). Verification is manual reading:

- [ ] In the rendered diff on GitHub, confirm the new § GitHub access subsection sits between § Two-assistant setup and § Git workflow with one blank line on each side.
- [ ] Confirm the new `Project board / issue triage` row in the "Who does what" table aligns visually with the existing column widths.
- [ ] Confirm the rewritten § Handoff files subsection sits between the "Read docs/design.md" paragraph and § Project Phase.
- [ ] Confirm `.gitignore` now has `docs/handoffs/*` and `!docs/handoffs/README.md`, and the old `.claude/*-handoff.md` line is gone.
- [ ] Spot-check `docs/handoffs/README.md` and `docs/project-field-ids.md` render correctly on the GitHub PR view.
- [ ] Optional: re-grep `git grep -n "\.claude/.*handoff"` on the branch — should return zero hits in `.claude/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)