### PR TITLE
PR 2: Resolved Decisions → ADRs

### DIFF
--- a/docs/decisions/0002-sqlite-strict-mode-on-static-tables.md
+++ b/docs/decisions/0002-sqlite-strict-mode-on-static-tables.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0002 — SQLite STRICT mode on lookup tables; DATETIME on timestamped tables
+
+## Context and problem statement
+
+SQLite's `STRICT` table modifier rejects rows whose column values don't match the declared type. It's stricter and safer than the default (where SQLite happily stores any type in any column). The catch: SeaORM's codegen, when reading STRICT tables that include `TEXT NOT NULL` timestamp columns, produces stringly-typed Rust models — `String`-shaped timestamps everywhere, with manual parsing at every boundary.
+
+We wanted the type safety of STRICT for the static game-data tables (where data shape is small, well-defined, and inserted at seed time) without paying the stringly-typed timestamp cost on the runtime tables (sessions, runs, etc., which have lots of `created_at` / `last_activity_at` columns).
+
+## Decision drivers
+
+- Type safety at insert time for the parts of the schema where shape is fixed (characters, tracks, cups, bodies, wheels, gliders).
+- Ergonomic Rust types for timestamps on the runtime side — `DateTime<Utc>` rather than `String`-and-parse-on-every-read.
+- One consistent SeaORM codegen flow rather than a manual override per timestamp column.
+
+## Considered options
+
+- **Option A:** STRICT everywhere. Maximum type safety, but every timestamp column becomes `String` in Rust.
+- **Option B:** STRICT nowhere. Clean Rust types via DATETIME columns, but no insert-time guarantees on static-data shape.
+- **Option C:** STRICT on lookup/static tables, DATETIME (no STRICT) on tables with timestamps.
+
+## Decision outcome
+
+Chosen: **Option C** — STRICT on the static lookup tables; drop STRICT on timestamped tables so columns can use the `DATETIME` type and SeaORM codegen produces `DateTime<Utc>`.
+
+### Positive consequences
+
+- Static-data tables retain insert-time type guarantees.
+- Runtime tables get ergonomic timestamp handling — no manual `parse` / `to_string` at every boundary.
+- Codegen produces the right Rust shape automatically.
+
+### Negative consequences / trade-offs
+
+- The schema's strictness rules are non-uniform — readers have to remember which tables are STRICT. Mitigated by the rule being predictable ("STRICT iff no timestamp columns").
+
+## Links
+
+- Source: `ad-hoc` (resolved during early schema work; captured in `docs/design.md`'s Resolved Decisions section pre-PR-2).

--- a/docs/decisions/0003-global-leaderboard-most-track-records.md
+++ b/docs/decisions/0003-global-leaderboard-most-track-records.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0003 — Global leaderboard: most track records held
+
+## Context and problem statement
+
+The global leaderboard needs a meaningful ranking signal that works across different track variants and ruleset preferences. A simple "fastest time" approach doesn't capture the breadth of a player's skill — someone with several track records is stronger than someone with one.
+
+## Decision drivers
+
+- A single ranking metric that's easy to understand and compare across all players.
+- Encourages diversified skill development across multiple tracks.
+- Reflects competitive achievement (holding records) rather than one-off lucky runs.
+
+## Considered options
+
+- **Option A:** Rank by fastest single lap time across any track. Simple, but doesn't reflect breadth.
+- **Option B:** Rank by most track records held. Rewards consistent competence across the roster.
+- **Option C:** Cumulative ranking system (e.g., points per place on each track). Complex to maintain and explain.
+
+## Decision outcome
+
+Chosen: **Option B** — Global leaderboard ranks players by number of track records held across all tracks.
+
+### Positive consequences
+
+- Clear, single-number ranking that's easy to explain and compete for.
+- Naturally encourages players to practice multiple tracks.
+- Stable metric — moving between positions requires flipping a record, not grinding one session.
+
+### Negative consequences / trade-offs
+
+- Players with one very-fast time but no breadth rank lower than someone with modest records on many tracks. Acceptable: the metric intentionally favors consistency.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0004-account-recovery-admin-reset.md
+++ b/docs/decisions/0004-account-recovery-admin-reset.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0004 — Account recovery: admin reset for now
+
+## Context and problem statement
+
+Players need a way to regain access to their accounts if they forget their password. A full self-service recovery flow (email tokens, recovery codes) adds complexity to MVP. For a small, trusted user base in early phases, a simpler path works.
+
+## Decision drivers
+
+- Minimize account-recovery infrastructure for MVP.
+- Support real-world password-loss scenarios without friction.
+- Revisit later when player base scales beyond manual admin intervention.
+
+## Considered options
+
+- **Option A:** Full self-service password reset via email tokens. Secure, scalable, but requires email infrastructure.
+- **Option B:** Admin-initiated password reset. Simple to implement, manual, works for MVP.
+- **Option C:** No recovery path; user creates a new account. Poor UX, loses history.
+
+## Decision outcome
+
+Chosen: **Option B** — Admin can reset a player's password directly. Player contacts host/admin (out-of-band), admin updates their password to a temporary value via the admin page.
+
+### Positive consequences
+
+- No email infrastructure, token lifecycle, or replay-attack surface.
+- Straightforward admin UX — one button.
+- Low implementation cost.
+
+### Negative consequences / trade-offs
+
+- Requires admin involvement for every reset; doesn't scale past small groups. Acceptable for MVP; email-based self-service can be added when player count justifies it.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0005-no-time-entry-validation.md
+++ b/docs/decisions/0005-no-time-entry-validation.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0005 — Time entry: no validation against plausible track times
+
+## Context and problem statement
+
+When a player submits a race time, the system could validate it against known physics constraints (fastest real 150cc times, lap speed bounds) to catch typos or fraud. Adding that validation complicates the ingestion path and requires maintaining a reference database of plausibility bounds.
+
+## Decision drivers
+
+- Simplify time-entry logic in MVP.
+- Rely on downstream controls (photos, eventual OCR) to catch errors and fraud.
+- Players are incentivized to be honest (leaderboard reputation) in small, social groups.
+
+## Considered options
+
+- **Option A:** Validate entered times against a plausibility range. Catches typos, but requires maintaining bounds.
+- **Option B:** Accept times as-is; rely on photos and later OCR to verify.
+- **Option C:** Require photo upload before accepting any time. More friction, but guaranteed evidence.
+
+## Decision outcome
+
+Chosen: **Option B** — No server-side validation of time plausibility. Photos are the audit trail; OCR will eventually automate verification.
+
+### Positive consequences
+
+- Minimal ingestion logic; times accepted immediately.
+- Photo is the source of truth; typos are caught when photos are reviewed.
+- No need to maintain a database of reference bounds.
+
+### Negative consequences / trade-offs
+
+- Obviously-wrong times (e.g., 1:05 for 150cc) can linger until photos are reviewed. Acceptable: photos are fast turnaround, and social pressure is strong in small groups.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0006-beer-vs-water-separate-leaderboards.md
+++ b/docs/decisions/0006-beer-vs-water-separate-leaderboards.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0006 — Beer vs water: separate leaderboards by default, with combined view
+
+## Context and problem statement
+
+Some players drink beer, others drink water or skip the game entirely. Comparing times across drink categories isn't fair — alcohol affects performance. The leaderboard must separate them while letting players see how they compare across both categories if they choose.
+
+## Decision drivers
+
+- Fair competition within each drink category.
+- Inclusive by default — non-drinkers have their own valid leaderboard.
+- Flexible exploration of cross-category comparisons.
+
+## Considered options
+
+- **Option A:** Single unified leaderboard with a drink filter. Requires scrolling past non-preferred drinks.
+- **Option B:** Separate leaderboards (beer, water) with a combined-view toggle. More work, better defaults.
+- **Option C:** Per-session drink rules; leaderboards vary per ruleset. Overcomplicates early design.
+
+## Decision outcome
+
+Chosen: **Option B** — Separate leaderboards by default (beer vs water). A "combined view" toggle shows all categories ranked together, with drink category labeled per entry.
+
+### Positive consequences
+
+- Users see their category's leaderboard by default — no scroll-past-others friction.
+- Default toggle setting matches the user's preferred drink category (stored in profile).
+- Combined view is available for curiosity without making it the default.
+
+### Negative consequences / trade-offs
+
+- Slightly higher schema/query complexity (per-category indexes on leaderboards). Negligible: only two categories.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0007-track-variants-150cc-only.md
+++ b/docs/decisions/0007-track-variants-150cc-only.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0007 — Track variants: 150cc only
+
+## Context and problem statement
+
+Mario Kart 8 Deluxe supports multiple engine classes (50cc, 100cc, 150cc, 200cc) and vehicle configurations. Tracking all of them in Beerio Kart's leaderboards and stats multiplies schema complexity. A focused scope on one variant captures the core gameplay without dilution.
+
+## Decision drivers
+
+- 150cc is the most popular competitive variant in Mario Kart communities.
+- Simpler leaderboards, fewer per-track records to track, less UI clutter.
+- Can expand to other variants later if demand emerges.
+
+## Considered options
+
+- **Option A:** Support all engine classes. Comprehensive, but 4× schema complexity.
+- **Option B:** Support 150cc only. Focused, simple, MVP-appropriate.
+- **Option C:** Make engine class configurable per-session, but only track 150cc on global leaderboards. Adds UI complexity for unclear benefit.
+
+## Decision outcome
+
+Chosen: **Option B** — 150cc only. The schema and leaderboards assume 150cc throughout.
+
+### Positive consequences
+
+- Schema is clean and uniform; no branching logic per engine class.
+- Leaderboards are focused and easier to understand.
+- MVP ships faster.
+
+### Negative consequences / trade-offs
+
+- Players who prefer other variants are out of scope until post-MVP expansion. Acceptable: 150cc is the standard competitive class.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0008-admin-model-env-var-gated.md
+++ b/docs/decisions/0008-admin-model-env-var-gated.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0008 — Admin model: lightweight admin page gated by user ID in env variable
+
+## Context and problem statement
+
+Some operations need admin privileges (resetting passwords, editing/deleting runs, resolving flags). A full role-based access control (RBAC) system is overengineered for MVP. A simpler gate — user ID checked against an env variable — provides the security we need without the infrastructure.
+
+## Decision drivers
+
+- MVP doesn't need dynamic role assignment; the admin is known and fixed.
+- Env-var gate is trivial to implement and deploy.
+- Upgrade path to RBAC is clear if roles later need more flexibility.
+
+## Considered options
+
+- **Option A:** Full RBAC with database roles, permissions, audit logs. Over-engineered for MVP.
+- **Option B:** Lightweight gate: admin user ID in env variable. Simple, sufficient, upgradeable.
+- **Option C:** No explicit admin at all; rely on Axum middleware checks everywhere. Fragile and error-prone.
+
+## Decision outcome
+
+Chosen: **Option B** — Admin operations are guarded by an `AdminUser` extractor that checks the authenticated user's ID against `ADMIN_USER_ID` from the environment.
+
+### Positive consequences
+
+- Minimal implementation — one extractor, one env var.
+- Admin identity is easy to rotate (redeploy with new env var).
+- All admin checks are explicit and discoverable by code grep.
+
+### Negative consequences / trade-offs
+
+- Only one admin user can be designated at a time. Acceptable for MVP; multi-admin support can be added when needed.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0009-run-immutability-admin-can-edit.md
+++ b/docs/decisions/0009-run-immutability-admin-can-edit.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0009 — Run immutability: users cannot edit runs after creation; admin can
+
+## Context and problem statement
+
+Once a race time is submitted, leaderboards and H2H stats depend on its value. Allowing free edits creates audit nightmares (was this score changed after it affected rankings?) and incentive problems (edit after seeing the H2H result). But admins need to correct OCR errors and typos before photos are available.
+
+## Decision drivers
+
+- Preserve leaderboard integrity; no post-hoc edits that change rankings.
+- Allow admins to fix obvious errors without deleting and re-creating.
+- Clear audit boundary: user creates once, admin can repair.
+
+## Considered options
+
+- **Option A:** Runs are immutable; users delete and re-submit if they made a mistake. Friction, but honest.
+- **Option B:** Users can edit anytime. Audit nightmare; unfair to competitors.
+- **Option C:** Users can edit within a time window (e.g., 1 hour). Still creates ranking uncertainty.
+- **Option D:** Users cannot edit; admins can. Admin-corrected runs are marked as such.
+
+## Decision outcome
+
+Chosen: **Option D** — After a user submits a run, they cannot edit it. Admins can edit runs to correct typos and OCR errors, and edited runs are flagged as admin-modified.
+
+### Positive consequences
+
+- Leaderboard integrity: no player can sneak in edits after ranking changes.
+- Users learn to double-check before submitting.
+- Admins can fix real errors without deleting data.
+
+### Negative consequences / trade-offs
+
+- Users who spot a typo immediately after submission have to ask an admin to fix it. Acceptable: creates accountability and keeps the flow simple.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0009-run-immutability-admin-can-edit.md
+++ b/docs/decisions/0009-run-immutability-admin-can-edit.md
@@ -26,7 +26,7 @@ Once a race time is submitted, leaderboards and H2H stats depend on its value. A
 
 ## Decision outcome
 
-Chosen: **Option D** — After a user submits a run, they cannot edit it. Admins can edit runs to correct typos and OCR errors, and edited runs are flagged as admin-modified.
+Chosen: **Option D** — After a user submits a run, they cannot edit it. Admins can edit runs to correct typos and OCR errors. Whether admin edits surface as a visible flag on the run is a follow-up question (see Negative consequences); the immutability rule itself doesn't depend on it.
 
 ### Positive consequences
 
@@ -37,6 +37,7 @@ Chosen: **Option D** — After a user submits a run, they cannot edit it. Admins
 ### Negative consequences / trade-offs
 
 - Users who spot a typo immediately after submission have to ask an admin to fix it. Acceptable: creates accountability and keeps the flow simple.
+- Admin edits aren't currently distinguishable from user-created runs in the schema. If "this score was changed by an admin" needs to be visible to users (or auditable post-hoc), `run_flags` (ADR 0029) would gain an `admin_edit` reason or `runs` would gain an `admin_modified_at` column. Open follow-up; not blocking the immutability rule itself.
 
 ## Links
 

--- a/docs/decisions/0010-h2h-derived-from-session-races.md
+++ b/docs/decisions/0010-h2h-derived-from-session-races.md
@@ -46,7 +46,7 @@ Chosen: **Option C** — H2H is derived. For any two players, walk the `session_
 
 ### Negative consequences / trade-offs
 
-- Read-time computation. For players with many shared races, the H2H query touches more rows than a stored aggregate. Mitigation: `session_race_id` is indexed; for the realistic data scale this is well within budget. Revisit if performance ever surfaces (it won't at MVP scale).
+- Read-time computation. For players with many shared races, the H2H query touches more rows than a stored aggregate. Mitigation: `session_race_id` is indexed. Revisit if a real query plan shows the cost.
 - DQ'd runs (per ADR 0012) are excluded from H2H — this is intentional but worth flagging: a DQ doesn't count as a loss.
 
 ## Links

--- a/docs/decisions/0010-h2h-derived-from-session-races.md
+++ b/docs/decisions/0010-h2h-derived-from-session-races.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0010 — Head-to-head: derived from session races, not stored
+
+## Context and problem statement
+
+Beerio Kart wants to surface "Player A is 7-3 against Player B" head-to-head records. The natural design instinct is a `head_to_head_records` table, updated whenever a comparable race finishes. That instinct collides with two observations:
+
+1. **What counts as a "comparable race" is fuzzy.** An earlier draft used timestamp clustering — runs submitted within ~10 minutes of each other on the same track were treated as the same race. That clustering is a heuristic; it both over-counts (two players who happened to race the same track around the same time but weren't in the same session) and under-counts (network blip pushes one submission past the window).
+2. **Sessions already give us the exact-match anchor.** Once `session_races` exists, "two players ran the same race" is no longer fuzzy — they share a `session_race_id`. The H2H signal falls out of the session schema for free.
+
+A second design question — what to do about ties, and whether drink category (alcoholic vs non-alcoholic) splits H2H counts — gets folded into the same ADR because the answers are tightly coupled to how H2H is computed.
+
+## Decision drivers
+
+- The schema already tells us "these two players ran the same race" via `session_race_id`. A separate H2H table would duplicate that signal.
+- Avoid the timestamp-clustering heuristic and its false-positive / false-negative failure modes.
+- Schema simplicity: no new table, no maintenance code to keep H2H counts consistent with the underlying runs.
+- Honesty about edge cases: ties happen, and the drink-category split (which matters for leaderboards) doesn't naturally apply to H2H.
+
+## Considered options
+
+- **Option A:** `head_to_head_records` table updated on race completion. Read-fast, write-coupled, easy to drift from `runs` truth.
+- **Option B:** Timestamp-clustering derivation — group runs within ~10 minutes on the same track as one "race." (Earlier draft.) Stateless, but heuristic-driven.
+- **Option C:** Derive from `session_races` — two players have an H2H record on a given session race iff both submitted non-DQ'd runs for that race. (Chosen.) Exact-match anchor, no separate table.
+
+## Decision outcome
+
+Chosen: **Option C** — H2H is derived. For any two players, walk the `session_races` they both have non-DQ'd runs on; tally wins/losses/draws by comparing their times.
+
+**Tie handling.** Identical times → 0-0 draw. Neither player gets a win or a loss. Ties are rare enough that a special "tie" counter isn't worth surfacing; the absence of a win/loss is itself the signal.
+
+**Drink category.** H2H does not split by alcoholic vs non-alcoholic. A drinker and a non-drinker in the same session race have their result counted normally. Drink category matters for leaderboards (separate alcoholic / non-alcoholic / combined views) but not for H2H — H2H is "did you beat them in a real race," and the answer doesn't depend on what they were drinking.
+
+### Positive consequences
+
+- No `head_to_head_records` table, no maintenance code keeping it in sync.
+- H2H counts can never drift from underlying run data — they are a SQL query over `runs` joined on `session_races`.
+- Replaces the timestamp-clustering heuristic outright; the failure modes don't apply.
+- Drink category doesn't combinatorially split H2H counts, keeping the UI surface small.
+
+### Negative consequences / trade-offs
+
+- Read-time computation. For players with many shared races, the H2H query touches more rows than a stored aggregate. Mitigation: `session_race_id` is indexed; for the realistic data scale this is well within budget. Revisit if performance ever surfaces (it won't at MVP scale).
+- DQ'd runs (per ADR 0012) are excluded from H2H — this is intentional but worth flagging: a DQ doesn't count as a loss.
+
+## Links
+
+- Source: `ad-hoc`
+- Related ADRs: [0011 (sessions replace standalone runs)](0011-sessions-replace-standalone-runs.md), [0012 (DQ'd runs excluded)](0012-dqd-runs-recorded-but-excluded.md), [0006 (beer vs water leaderboards split — drink category context)](0006-beer-vs-water-separate-leaderboards.md)

--- a/docs/decisions/0010-h2h-derived-from-session-races.md
+++ b/docs/decisions/0010-h2h-derived-from-session-races.md
@@ -9,47 +9,47 @@ source: ad-hoc
 
 ## Context and problem statement
 
-Beerio Kart wants to surface "Player A is 7-3 against Player B" head-to-head records. The natural design instinct is a `head_to_head_records` table, updated whenever a comparable race finishes. That instinct collides with two observations:
+Beerio Kart wants to surface "Player A is 7-3 against Player B" head-to-head records. The natural design instinct is a `head_to_head_records` table updated on each comparable race. We chose against that — H2H is **derived** from the session schema instead.
 
-1. **What counts as a "comparable race" is fuzzy.** An earlier draft used timestamp clustering — runs submitted within ~10 minutes of each other on the same track were treated as the same race. That clustering is a heuristic; it both over-counts (two players who happened to race the same track around the same time but weren't in the same session) and under-counts (network blip pushes one submission past the window).
-2. **Sessions already give us the exact-match anchor.** Once `session_races` exists, "two players ran the same race" is no longer fuzzy — they share a `session_race_id`. The H2H signal falls out of the session schema for free.
+The earlier draft used **timestamp clustering**: runs submitted within ~10 minutes of each other on the same track were treated as the same race. That heuristic has two failure modes — it over-counts (two players who happened to race the same track around the same time) and under-counts (a network blip pushes a submission past the window). Once `session_races` exists, "two players ran the same race" stops being fuzzy: they share a `session_race_id`. The H2H signal falls out of the session schema for free.
 
-A second design question — what to do about ties, and whether drink category (alcoholic vs non-alcoholic) splits H2H counts — gets folded into the same ADR because the answers are tightly coupled to how H2H is computed.
+Two related questions get folded in here because they're tightly coupled to *how* H2H is computed: tie handling, and whether drink category splits H2H counts.
 
 ## Decision drivers
 
-- The schema already tells us "these two players ran the same race" via `session_race_id`. A separate H2H table would duplicate that signal.
+- The schema already encodes "these two players ran the same race" via `session_race_id`. A separate H2H table duplicates that signal.
 - Avoid the timestamp-clustering heuristic and its false-positive / false-negative failure modes.
-- Schema simplicity: no new table, no maintenance code to keep H2H counts consistent with the underlying runs.
-- Honesty about edge cases: ties happen, and the drink-category split (which matters for leaderboards) doesn't naturally apply to H2H.
+- Schema simplicity: no new table, no maintenance code keeping H2H counts consistent with the underlying runs.
+- **Unbounded rivals.** H2H is computed against any other player; we don't pay a per-pair storage cost. A friend group of arbitrary size doesn't change the schema.
 
 ## Considered options
 
-- **Option A:** `head_to_head_records` table updated on race completion. Read-fast, write-coupled, easy to drift from `runs` truth.
-- **Option B:** Timestamp-clustering derivation — group runs within ~10 minutes on the same track as one "race." (Earlier draft.) Stateless, but heuristic-driven.
-- **Option C:** Derive from `session_races` — two players have an H2H record on a given session race iff both submitted non-DQ'd runs for that race. (Chosen.) Exact-match anchor, no separate table.
+- **Option A:** A `head_to_head_records` table updated on race completion. Read-fast, write-coupled, easy to drift from `runs` truth.
+- **Option B:** Timestamp-clustering derivation — group runs within ~10 minutes on the same track as one "race." Stateless, but heuristic-driven.
+- **Option C:** Derive from `session_races` — two players have an H2H entry on a given session race iff both submitted non-DQ'd runs for that race. Exact-match anchor, no separate table.
 
 ## Decision outcome
 
-Chosen: **Option C** — H2H is derived. For any two players, walk the `session_races` they both have non-DQ'd runs on; tally wins/losses/draws by comparing their times.
+Chosen: **Option C** — H2H is derived. For any two players, walk the `session_races` they both have non-DQ'd runs on; tally wins / losses / draws by comparing `track_time`.
 
-**Tie handling.** Identical times → 0-0 draw. Neither player gets a win or a loss. Ties are rare enough that a special "tie" counter isn't worth surfacing; the absence of a win/loss is itself the signal.
+**Tie handling.** Identical times → 0-0 draw. Neither player gets a win or a loss. Ties are rare enough that a dedicated "draws" counter isn't worth surfacing — the absence of a win or loss is itself the signal.
 
-**Drink category.** H2H does not split by alcoholic vs non-alcoholic. A drinker and a non-drinker in the same session race have their result counted normally. Drink category matters for leaderboards (separate alcoholic / non-alcoholic / combined views) but not for H2H — H2H is "did you beat them in a real race," and the answer doesn't depend on what they were drinking.
+**Drink category.** H2H does *not* split by alcoholic vs non-alcoholic. A drinker and a non-drinker in the same session race have their result counted normally. Drink category matters for *leaderboards* (separate alcoholic / non-alcoholic / combined views per ADR 0006) but not H2H — H2H is "did you beat them in a real race," and the answer doesn't depend on what either player was drinking.
 
 ### Positive consequences
 
-- No `head_to_head_records` table, no maintenance code keeping it in sync.
+- No `head_to_head_records` table; no maintenance code keeping it synced.
 - H2H counts can never drift from underlying run data — they are a SQL query over `runs` joined on `session_races`.
 - Replaces the timestamp-clustering heuristic outright; the failure modes don't apply.
 - Drink category doesn't combinatorially split H2H counts, keeping the UI surface small.
+- Unbounded by the number of opponents — no schema impact when the player pool grows.
 
 ### Negative consequences / trade-offs
 
-- Read-time computation. For players with many shared races, the H2H query touches more rows than a stored aggregate. Mitigation: `session_race_id` is indexed. Revisit if a real query plan shows the cost.
-- DQ'd runs (per ADR 0012) are excluded from H2H — this is intentional but worth flagging: a DQ doesn't count as a loss.
+- **Read-time computation.** For players with many shared races, the H2H query touches more rows than a stored aggregate would. Mitigations available if/when needed: `session_race_id` is already indexed; a materialized cache (per-pair or per-player) can land later without changing the source of truth.
+- **DQ'd runs are excluded** (per ADR 0012). Intentional — a DQ doesn't count as a loss — but worth flagging so reviewers don't get surprised by missing entries.
 
 ## Links
 
 - Source: `ad-hoc`
-- Related ADRs: [0011 (sessions replace standalone runs)](0011-sessions-replace-standalone-runs.md), [0012 (DQ'd runs excluded)](0012-dqd-runs-recorded-but-excluded.md), [0006 (beer vs water leaderboards split — drink category context)](0006-beer-vs-water-separate-leaderboards.md)
+- Related ADRs: [0006 — separate leaderboards by drink category](0006-beer-vs-water-separate-leaderboards.md), [0011 — sessions replace standalone runs](0011-sessions-replace-standalone-runs.md), [0012 — DQ'd runs recorded but excluded](0012-dqd-runs-recorded-but-excluded.md)

--- a/docs/decisions/0011-sessions-replace-standalone-runs.md
+++ b/docs/decisions/0011-sessions-replace-standalone-runs.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0011 — Sessions replace standalone run recording
+
+## Context and problem statement
+
+Early designs allowed players to log individual race times outside of a session context — "I ran a solo time trial, here's my split." This adds two separate code paths (solo runs vs. session runs) and complicates leaderboards and H2H tracking. A unified model where all runs happen within sessions is simpler to reason about.
+
+## Decision drivers
+
+- One run-ingestion path: all runs are children of a session.
+- Simpler service logic — no branching for solo vs. multiplayer runs.
+- All runs have a session context for potential future social features (replay, commentary).
+
+## Considered options
+
+- **Option A:** Standalone runs are their own entity; sessions are separate. Flexibility, complexity.
+- **Option B:** All runs must belong to a session; solo running uses a one-person session. Simpler model.
+- **Option C:** Nullable `session_race_id` allows both; app prefers sessions. Future-compatible but MVP doesn't use it.
+
+## Decision outcome
+
+Chosen: **Option B** — All runs are recorded within session context. Solo racing uses a one-person session. Option C (nullable session_race_id) is deferred post-MVP for lightweight standalone runs if that use case emerges.
+
+### Positive consequences
+
+- Single run-ingestion path; no solo/multiplayer branching.
+- Runs naturally have context (who else was racing, when, on what track).
+- Simpler leaderboard and H2H queries.
+
+### Negative consequences / trade-offs
+
+- Creating a session for a solo time trial has ceremony (create session, add self, start race). Acceptable for MVP; single-button "quick run" mode can be added if friction is real.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0012-dqd-runs-recorded-but-excluded.md
+++ b/docs/decisions/0012-dqd-runs-recorded-but-excluded.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0012 — DQ'd runs: recorded but excluded from leaderboards and H2H
+
+## Context and problem statement
+
+The Beerio Kart rules are simple: finish the race before or while finishing the drink (DQ = didn't finish drink before finishing race). Players submit their own DQ status at race time. These runs are real data (useful for history, personal stats) but shouldn't count toward leaderboard positions or H2H head-to-head comparisons.
+
+## Decision drivers
+
+- Preserve honest runs while allowing players to see DQ history for context.
+- Prevent gaming of leaderboards (submit "fake" runs as DQ).
+- Honor system works in small, social groups.
+
+## Considered options
+
+- **Option A:** DQ'd runs are deleted. No history, harsh.
+- **Option B:** DQ'd runs are recorded but excluded from all rankings. Transparent history, fair competition.
+- **Option C:** Admin must verify DQ status before recording. Adds bottleneck.
+
+## Decision outcome
+
+Chosen: **Option B** — DQ'd runs are recorded in the database. They're excluded from leaderboard positions and H2H tallies. Self-reported at submission time (honor system).
+
+### Positive consequences
+
+- Players can see their full race history, including DQ runs, without losing that data.
+- Leaderboards and H2H remain fair — no artificially-inflated or deflated stats.
+- No admin overhead verifying DQ claims.
+
+### Negative consequences / trade-offs
+
+- Relies on player honesty. Acceptable: social pressure and small-group accountability are strong, and the game is non-competitive (fun, not money).
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0013-pending-race-cap.md
+++ b/docs/decisions/0013-pending-race-cap.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: docs/designs/2026-04-19-pending-races-and-grace-period.md
+---
+
+# 0013 — Pending race cap: UI shows max 3 pending races
+
+## Context and problem statement
+
+When a session host chooses a track for a race, that race becomes "pending" — waiting for times to be entered. If the host is distracted or forgets, pending races accumulate indefinitely. The system needs to prevent logjam without being tyrannical about timing.
+
+## Decision drivers
+
+- Prevent accumulated dead races from cluttering sessions.
+- Give players a grace period to enter times before expiring.
+- UI should limit the visible backlog to encourage prompt completion.
+
+## Considered options
+
+- **Option A:** Unlimited pending races. No enforcement; host responsible.
+- **Option B:** Limit pending races at UI level (cap display). Schema allows unlimited; guardrail is soft.
+- **Option C:** Hard limit in schema; reject new races if limit is reached. Strict, but frustrating if someone falls behind.
+
+## Decision outcome
+
+Chosen: **Option B** — UI shows max 3 pending races (oldest expire first). Schema supports unlimited — the cap is a UX guardrail, adjustable later if experience suggests a different number.
+
+### Positive consequences
+
+- UX doesn't overwhelm; players see the oldest pending races, encouraging completion.
+- Flexible tuning: adjusting "3" to "4" or "2" is a one-line change.
+- Schema isn't restricted unnecessarily.
+
+### Negative consequences / trade-offs
+
+- If a player is far behind and there are 3+ pending races, they can't see the newest one in the current view. Workaround: host can clear old races or players can ask to see them.
+
+## Links
+
+- Source: [`docs/designs/2026-04-19-pending-races-and-grace-period.md`](../designs/2026-04-19-pending-races-and-grace-period.md)

--- a/docs/decisions/0014-session-host-transfer.md
+++ b/docs/decisions/0014-session-host-transfer.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0014 — Session host transfer: earliest-joined remaining participant becomes new host
+
+## Context and problem statement
+
+The session host chooses tracks for the next race. If the host leaves the session (closes the app, navigates away), someone needs to take over hosting duties. The handoff should be automatic and predictable.
+
+## Decision drivers
+
+- Host duties need to transfer immediately when the host leaves.
+- Deterministic rule so all clients agree without a broadcast.
+- Fair: earliest-joined (longest commitment to the group) gets the role.
+
+## Considered options
+
+- **Option A:** Newest participant becomes host. Favors latecomers, feels arbitrary.
+- **Option B:** Earliest-joined remaining participant becomes new host. Rewards continuity; deterministic.
+- **Option C:** Session ends if host leaves. Harsh; forces session recreation.
+
+## Decision outcome
+
+Chosen: **Option B** — When the host leaves, the earliest-joined remaining participant automatically becomes the new host.
+
+### Positive consequences
+
+- Transfer is automatic; no one needs to nominate or agree.
+- Deterministic: both client and server compute the same answer (timestamps are canonical).
+- Feels fair in small groups.
+
+### Negative consequences / trade-offs
+
+- If the longest-committed participant doesn't want hosting duties, they can't decline gracefully. Acceptable: hosting is lightweight (choose a track), and in small groups, rotation happens naturally.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0015-session-timeout-skip-turn.md
+++ b/docs/decisions/0015-session-timeout-skip-turn.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0015 — Session timeout handling (MVP): "skip turn" allows recovery without restart
+
+## Context and problem statement
+
+If the current track chooser leaves the session or is stuck, the whole session halts — no one can choose the next track. The group needs a way to recover without restarting the session and losing progress.
+
+## Decision drivers
+
+- Unblock stuck sessions without restarting.
+- Minimize feature complexity for MVP (vote-to-kick deferred).
+- Lightweight recovery for a small, trusted group.
+
+## Considered options
+
+- **Option A:** Vote-to-kick the chooser; majority rule takes over. Robust, but adds voting logic.
+- **Option B:** "Skip turn" button: any participant can pass the chooser's turn to the next person. Simple, trusting.
+- **Option C:** Session auto-expires if inactive for N minutes. Harsh; loses progress.
+
+## Decision outcome
+
+Chosen: **Option B** — MVP supports "Skip turn": any participant can pass the current chooser's turn to the next participant in rotation. Vote-to-kick is deferred post-MVP.
+
+### Positive consequences
+
+- Simple to implement and explain.
+- Doesn't require consensus or voting machinery.
+- Reasonable fallback for small, trusted groups.
+
+### Negative consequences / trade-offs
+
+- A malicious participant can spam "skip" to sabotage the game. Acceptable for MVP in a trusted context; moderation (vote-to-kick, temporary role revocation) can be added if needed.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0016-session-passwords-deferred.md
+++ b/docs/decisions/0016-session-passwords-deferred.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0016 — Session passwords: deferred post-MVP
+
+## Context and problem statement
+
+Early designs considered session passwords to keep random participants out of a group's session. This adds complexity to the join flow and session data. For MVP, sessions are created by people who know each other (in-person or close circles), so an open join is acceptable.
+
+## Decision drivers
+
+- Defer security features until the product scales beyond friend groups.
+- Keep the join flow simple: `POST /sessions/:id/join` with no credential.
+- Architectural preparedness: the endpoint is already a dedicated action, so passwords can be added later without restructuring.
+
+## Considered options
+
+- **Option A:** Sessions are open; anyone with the ID can join. Simple, no security.
+- **Option B:** Password-protected sessions. Secure, but adds credential management.
+- **Option C:** Invite-only sessions (admin must approve). Heavyweight governance.
+
+## Decision outcome
+
+Chosen: **Option A** — Sessions are open (no password) in MVP. The `POST /sessions/:id/join` endpoint is a dedicated action, so password checking can be added later without restructuring the join flow.
+
+### Positive consequences
+
+- Simple join experience; no credential friction.
+- Endpoint is already isolated, so adding password validation is a one-line service change.
+- Matches MVP's trust model (friend groups).
+
+### Negative consequences / trade-offs
+
+- If the app ever scales to public sessions, random people could infiltrate friend-group sessions. Acceptable: password support is deferred to that phase.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0017-ruleset-changes-mid-session-deferred.md
+++ b/docs/decisions/0017-ruleset-changes-mid-session-deferred.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0017 — Ruleset changes mid-session: deferred post-MVP
+
+## Context and problem statement
+
+A session's ruleset (which determines how the next track is chosen) is set at creation time. Players might want to switch rulesets mid-session (e.g., "let's try Round-robin instead of Random"). Supporting this adds state-synchronization complexity for MVP.
+
+## Decision drivers
+
+- Defer ruleset mutation until the product is stable and MVP ruleset logic is battle-tested.
+- MVP sessions run with one ruleset start-to-finish; switching requires creating a new session.
+- Future-compatible: the data model already supports it; enabling it is a service-layer change.
+
+## Considered options
+
+- **Option A:** Rulesets are immutable for the session's lifetime. Simple, clear.
+- **Option B:** Rulesets can change mid-session if the host requests it. Flexible, but state-sync is complex.
+
+## Decision outcome
+
+Chosen: **Option A** — Rulesets are set at session creation and cannot change. Switching rulesets requires creating a new session. Post-MVP enhancement to allow mid-session changes.
+
+### Positive consequences
+
+- Eliminates state-sync complexity around ruleset changes.
+- Clear mental model: one ruleset for the whole session.
+- Creating a new session is fast (name it, choose ruleset, invite players).
+
+### Negative consequences / trade-offs
+
+- Users must restart the session to try a different ruleset. Minor friction; can be addressed post-MVP if common.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0018-realtime-via-polling-not-websockets.md
+++ b/docs/decisions/0018-realtime-via-polling-not-websockets.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0018 — Real-time updates: polling, not WebSockets
+
+## Context and problem statement
+
+Session state (whose turn it is, pending races, participant list) changes as the game progresses. Clients need to stay in sync. Real-time updates can be delivered via WebSockets (push) or polling (pull). WebSockets are lower-latency but stateful; polling is simple and idempotent.
+
+## Decision drivers
+
+- Turn-based game: events happen every few minutes; latency is imperceptible with polling.
+- Polling is stateless and testable with standard HTTP tools.
+- Avoids WebSocket connection management, reconnection logic, and heartbeat complexity.
+- Can upgrade to WebSockets later if latency becomes a real UX issue.
+
+## Considered options
+
+- **Option A:** Polling. Clients call `GET /sessions/:id` every 2–3 seconds. Simple, testable.
+- **Option B:** WebSockets. Server pushes updates immediately. Lower latency, stateful.
+- **Option C:** Hybrid. WebSockets for speed, fallback to polling. Overengineered for MVP.
+
+## Decision outcome
+
+Chosen: **Option A** — Clients poll `GET /sessions/:id` every 2–3 seconds. This is sufficient for a turn-based game; WebSockets can be added as an optimization if latency becomes a problem.
+
+### Positive consequences
+
+- No server connection state; trivial to scale and test.
+- Standard HTTP tools can debug the sync (curl, replay, etc.).
+- Clients are simple; no reconnect logic needed.
+
+### Negative consequences / trade-offs
+
+- Worst-case update latency is 3 seconds; imperceptible for turn-based gameplay, but might matter later if the game evolves toward real-time action.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0019-admin-defense-in-depth.md
+++ b/docs/decisions/0019-admin-defense-in-depth.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0019 — Admin defense in depth: two independent checks
+
+## Context and problem statement
+
+Admin operations (editing runs, resolving flags) are sensitive — a single missed permission check could expose them. A layered approach, where both the route middleware and the service layer check admin status independently, catches bugs in either layer.
+
+## Decision drivers
+
+- Defense in depth: if the middleware has a bug, the service still blocks unauthorized access.
+- If the service has a bug, the middleware is the backstop.
+- Two independent checks force intentional permission design, not careless shortcuts.
+
+## Considered options
+
+- **Option A:** Check admin status in middleware only. Simpler, but one bug exposes all admin ops.
+- **Option B:** Check admin status in the service only. Relies on consistent implementation.
+- **Option C:** Check in both layers independently. Slightly more code, but bulletproof.
+
+## Decision outcome
+
+Chosen: **Option C** — Admin-only operations (editing runs, resolving flags) are checked in both the route middleware (AdminUser extractor) and the service layer independently. Both must pass; failure in either blocks the request.
+
+### Positive consequences
+
+- A middleware bug doesn't accidentally expose admin operations.
+- A service-layer bug doesn't bypass the middleware wall.
+- Clear separation of concerns: middleware gates the route; service enforces the rule again.
+
+### Negative consequences / trade-offs
+
+- Slightly more code; feels repetitive. Acceptable: the cost is small, and the security benefit is worth it.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0020-photo-upload-validation.md
+++ b/docs/decisions/0020-photo-upload-validation.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0020 — Photo upload: magic-byte validation, format whitelist, size cap
+
+## Context and problem statement
+
+Players upload photos as proof of their race times (for later OCR). The server needs to validate that uploaded files are actually images, not arbitrary content masquerading as photos (security: no executable uploads, no zip bombs).
+
+## Decision drivers
+
+- Prevent abuse (executable uploads, oversized files, malformed images).
+- Check magic bytes, not just Content-Type header (headers are user-controlled).
+- Accept the formats players use (JPEG, PNG, HEIC/HEIF from modern phones).
+- Standardize filenames to prevent path-traversal attacks.
+
+## Considered options
+
+- **Option A:** Trust Content-Type header; accept anything. Simple, insecure.
+- **Option B:** Validate magic bytes; accept JPEG, PNG; reject HEIC. Secure but excludes modern phone formats.
+- **Option C:** Validate magic bytes; accept JPEG, PNG, HEIC/HEIF; cap size at 10MB; use run-ID-based filenames.
+
+## Decision outcome
+
+Chosen: **Option C** — Server-side magic-byte validation. Accept JPEG, PNG, HEIC/HEIF. Max 10MB per file. Generate filenames from run ID (`{run_id}.{ext}`) — never use user-provided names. Optionally strip EXIF data (GPS, device info) for privacy in a future pass.
+
+### Positive consequences
+
+- Immune to Content-Type spoofing; real image validation.
+- Supports modern phone formats without friction.
+- Standardized filenames prevent path-traversal and naming attacks.
+- Size cap prevents disk abuse.
+
+### Negative consequences / trade-offs
+
+- EXIF stripping (privacy) is deferred; device info briefly exposed. Acceptable: low-risk in a friend-group game; EXIF removal is a post-MVP optimization.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0021-upload-path-isolation.md
+++ b/docs/decisions/0021-upload-path-isolation.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0021 — Upload path isolation: separate URL prefix and filesystem directory
+
+## Context and problem statement
+
+The server serves both static assets (CSS, JavaScript, vendor libraries) and user uploads (photos). A path-traversal bug could allow attackers to escape the uploads directory and read/write static files or other sensitive data. Isolation prevents that.
+
+## Decision drivers
+
+- Prevent path-traversal attacks crossing asset and upload boundaries.
+- Different directories on disk are a natural isolation boundary.
+- Different URL prefixes make the separation explicit in routing.
+
+## Considered options
+
+- **Option A:** Serve uploads and static assets from the same directory. Simple, but path-traversal can cross boundaries.
+- **Option B:** Same directory but different subdirs (e.g., `/static/` vs `/static/uploads/`). Still the same filesystem root.
+- **Option C:** Different URL prefixes and different filesystem directories. Clear, secure isolation.
+
+## Decision outcome
+
+Chosen: **Option C** — User uploads are served from `/uploads/...` (from `UPLOAD_DIR` env var). Static assets are served from `/static/...` (from `STATIC_DIR`). Different prefixes and different directories prevent path-traversal across boundaries.
+
+### Positive consequences
+
+- Path-traversal bugs in one handler can't escape to the other directory.
+- Different ACLs or security policies can be applied to each directory.
+- Clear separation in code and on disk.
+
+### Negative consequences / trade-offs
+
+- Slightly more configuration (two env vars). Negligible: standard practice.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0022-rulesets-as-rust-trait.md
+++ b/docs/decisions/0022-rulesets-as-rust-trait.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0022 — Rulesets: implemented as Rust trait with one module per ruleset
+
+## Context and problem statement
+
+The app supports multiple rulesets for choosing the next track: Random, Default, Least Played, Round-robin. Each ruleset has different logic (some deterministic, some probabilistic). The code needs to evolve as new rulesets are added.
+
+## Decision drivers
+
+- Adding a new ruleset should require adding one module, not modifying existing code.
+- Each ruleset's logic is isolated from the others; bugs in one don't spread.
+- Clear architectural pattern; future developers know where to add new rulesets.
+
+## Considered options
+
+- **Option A:** Giant switch statement in session service. Simple, but grows unbounded as rulesets increase.
+- **Option B:** Each ruleset is a separate module implementing a `Ruleset` trait. Extensible, testable per-ruleset.
+- **Option C:** Rulesets are data-driven (lookup table, config file). Adds indirection without clear benefit at this scale.
+
+## Decision outcome
+
+Chosen: **Option B** — Each ruleset (Random, Default, Least Played, Round-robin) is a separate module implementing a `Ruleset` trait. The session service calls the trait method to get the next track.
+
+### Positive consequences
+
+- Adding a new ruleset is one module, no existing-code changes.
+- Each ruleset can have its own tests; logic is isolated.
+- Trait bounds make the interface explicit.
+
+### Negative consequences / trade-offs
+
+- Minimal indirection; negligible performance overhead.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0023-hand-written-seaorm-entities.md
+++ b/docs/decisions/0023-hand-written-seaorm-entities.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: docs/designs/2026-05-02-entity-codegen-strategy.md
+---
+
+# 0023 — Hand-written SeaORM entities: committed source code
+
+## Context and problem statement
+
+SeaORM's `sea-orm-cli generate entity` scaffolds Rust entities from the database schema. Regenerating those entities on every schema change can clobber hand-written corrections (partial-index attributes, relation cardinalities, custom derives). The question is: who owns the source truth — migration or codegen output?
+
+## Decision drivers
+
+- The migration is the schema source of truth; entities mirror that shape.
+- Hand-edits (relation cardinalities, attributes) are authoritative and shouldn't be lost to codegen.
+- Codegen is a one-shot scaffolding tool, not a continuous mirror.
+
+## Considered options
+
+- **Option A:** Regenerate entities from the schema on every migration. Loses hand-edits; forces custom overrides everywhere.
+- **Option B:** Hand-write entities once; never regenerate. Entities must be kept in sync with migrations manually.
+- **Option C:** Hand-write entities; regenerate only when adding a new table. Entities are committed source; partial edits are preserved.
+
+## Decision outcome
+
+Chosen: **Option C** — Entities under `backend/src/entities/` are committed source code, hand-edited as the schema evolves. The migration is the schema source of truth; entities mirror that shape. Codegen (`just entities-bootstrap`) is a one-shot scaffolding tool used only when adding a brand-new table — never run on existing entities, as it will clobber hand-corrections.
+
+### Positive consequences
+
+- Hand-edits (partial-index attributes, relation cardinalities, custom derives) are safe and durable.
+- Entities and migrations can evolve together without clobbering.
+- Clear responsibility: migrations define schema; entities define Rust shapes.
+
+### Negative consequences / trade-offs
+
+- Entities must be kept in sync with the schema manually. Acceptable: schema drift is caught by the `tests/schema_drift.rs` verification test, and changes are infrequent.
+
+## Links
+
+- Source: [`docs/designs/2026-05-02-entity-codegen-strategy.md`](../designs/2026-05-02-entity-codegen-strategy.md)
+- Implementing PRs: PR-X1

--- a/docs/decisions/0024-just-not-make-for-dev-commands.md
+++ b/docs/decisions/0024-just-not-make-for-dev-commands.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0024 — just (not Make) for developer commands
+
+## Context and problem statement
+
+Developers need a convenient way to run common tasks: start the dev server, run tests, bootstrap entities, etc. Build-system options include Make (traditional, complex for non-C projects) and just (task runner, simpler syntax). The choice should complement existing dependency management, not duplicate it.
+
+## Decision drivers
+
+- Cargo handles Rust build dependencies and incremental compilation.
+- Bun handles frontend dependencies and bundling.
+- Docker handles container caching.
+- The remaining need is a task runner for orchestrating these, not file-level dependency tracking.
+
+## Considered options
+
+- **Option A:** Use Make. Powerful, but syntax is geared toward C workflows; Cargo and Bun already handle their domains.
+- **Option B:** Use just. Simple task syntax; no redundant dependency tracking; good at orchestration.
+- **Option C:** No task runner; document shell commands. Error-prone; not convenient.
+
+## Decision outcome
+
+Chosen: **Option B** — Use just for developer commands (`just dev`, `just test`, `just entities-bootstrap`). Justfile is at the repo root. Cargo, Bun, and Docker handle their respective dependency layers; just orchestrates them.
+
+### Positive consequences
+
+- Simple, readable syntax; developers understand what each task does at a glance.
+- Minimal abstraction; just wraps existing tools without pretending to manage their dependencies.
+- Easy to add new tasks; no make-specific learning curve.
+
+### Negative consequences / trade-offs
+
+- One more language/tool to learn. Acceptable: just is simpler than Make, and developers are already using Cargo and Bun.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0025-photo-enforcement-for-records.md
+++ b/docs/decisions/0025-photo-enforcement-for-records.md
@@ -9,21 +9,22 @@ source: ad-hoc
 
 ## Context and problem statement
 
-Beerio Kart's leaderboards are honor-system: users self-report their times. That works fine for everyday runs — there's social pressure within a session and no real incentive to fudge a mediocre lap. The problem starts at the top of the leaderboard: a fabricated record-breaking time has outsized impact (it bumps the legitimate holder, anchors comparisons, and is hard to dislodge once stale).
+Beerio Kart's leaderboards are honor-system: users self-report their times. That works fine for everyday runs — there's social pressure inside a session and no strong incentive to fudge a mediocre lap. The problem is at the top of the leaderboard. A fabricated record-breaking time has outsized impact: it bumps the legitimate holder, anchors comparisons going forward, and is hard to dislodge once stale.
 
-A photo of the in-game results screen is the cheap proof. The question is *how* to enforce it: hard block at submission, manual admin review, or some softer pattern that doesn't require admin intervention on every record but still keeps unverified records out of the leaderboard surface.
+A photo of the in-game results screen is the cheap proof. The question is *how* to enforce it: a hard block at submission, manual admin review, or a softer pattern that doesn't require admin intervention on every record while still keeping unverified records out of the leaderboard surface.
 
 ## Decision drivers
 
-- Records have outsized impact on the leaderboard surface; everyday runs do not. Enforcement should match the asymmetry.
-- Hard-block at submission feels punitive — players in the middle of a session shouldn't have to pull out their phone, take a photo, transfer it, and upload it just to record a time. Half the time the photo arrives a minute later from someone else.
-- Admin manual review doesn't scale and creates a queue. The whole point of MVP automation is no human in the loop for the common case.
-- The system already has a `run_flags` table (ADR 0029) that's designed exactly for this shape: auto-applied conditions that need resolution.
+- **Asymmetry.** Records have outsized impact on the leaderboard; everyday runs do not. Enforcement should match the asymmetry.
+- **Submission ergonomics.** A hard block at submission is punitive — the photo often arrives a minute late from someone else's phone. Forcing synchronous upload at the worst possible moment ruins the flow.
+- **No human in the loop for the common case.** Manual admin review doesn't scale and grows a queue monotonically. The whole point of MVP automation is keeping admin out of the routine path.
+- **Existing primitive.** The schema already has `run_flags` (ADR 0029) — auto-applied conditions that need resolution. This decision is exactly its shape.
+- **OCR future.** Photos serve double duty: enforcement now, OCR training data later. Encouraging photos broadly (even when not strictly required) feeds that future.
 
 ## Considered options
 
 - **Option A:** Trust everyone. No photo requirement.
-- **Option B:** Hard block — record-breaking submissions without photo are rejected. Forces synchronous photo upload at the worst time.
+- **Option B:** Hard block. Record-breaking submissions without a photo are rejected. Forces synchronous photo upload at the worst time.
 - **Option C:** Manual admin review for all record-breaking runs. Creates a backlog; admin becomes a bottleneck.
 - **Option D (chosen):** Auto-flag and hide record-breaking runs that lack a photo. Photo upload auto-resolves the flag and the run becomes visible. Soft enforcement; no admin in the loop unless the flag stays unresolved.
 
@@ -31,26 +32,28 @@ A photo of the in-game results screen is the cheap proof. The question is *how* 
 
 Chosen: **Option D** — automatic, asymmetric, self-resolving.
 
-**Mechanism.** When a run is submitted that would beat any existing record (track, cup, or global), the run service checks for an attached photo. If absent, a `run_flags` row is inserted with a `record_without_photo` reason. While that flag is unresolved, the run is excluded from leaderboard queries — the record holder is whoever was there before.
+**Mechanism.** When a run is submitted that would beat any existing record (track, cup, or global), the run service checks for an attached photo. If none, a `run_flags` row is inserted with reason `record_without_photo`. While that flag is unresolved, the run is excluded from leaderboard queries — the previous record-holder remains the surfaced one.
 
 **Resolution.** Uploading a photo against the same run auto-resolves the flag. The run becomes visible and the leaderboard updates on the next read. No admin action required for the common case.
 
-**Why this works.** The asymmetry is the win: the vast majority of submissions aren't record-breaking and pass through with no friction. The rare case that is record-breaking is exactly the one worth a photo. And the user who actually beat the record has the strongest incentive to upload the photo — they want the credit.
+**DQ'd runs are excluded** from record-breaking eligibility per ADR 0012. A DQ can't be a record, so there's nothing to flag.
+
+**Why this works.** The submitter who actually beat the record has the strongest incentive to upload — they want the credit. The vast majority of submissions aren't record-breaking and pass through with no friction. The rare case that *is* record-breaking is precisely the case worth a photo.
 
 ### Positive consequences
 
 - No friction on the common case (most submissions aren't records).
 - Strong incentive on the rare case (the record-holder *wants* the leaderboard to update).
-- No admin queue for routine records — admin only intervenes on disputed flags.
-- Composes cleanly with the `run_flags` audit trail (ADR 0029) — records stay visible after resolution.
+- No admin queue for routine records — admin only intervenes when a flag stays unresolved.
+- Composes cleanly with the `run_flags` audit trail (ADR 0029); records stay visible in history after resolution.
 
 ### Negative consequences / trade-offs
 
-- **Unrelated-photo loophole.** A user can upload any image — a screenshot of someone else's race, a stock photo, a JPEG of nothing — and the flag auto-resolves. Magic-byte validation (ADR 0020) doesn't examine *content*. The MVP mitigation is social: users see each other's submissions and call out obvious fakes. The durable mitigation is OCR (planned post-MVP) — extract the time and player name from the photo and verify they match the submission. Until OCR ships, this is a real attack against leaderboard credibility, not a hypothetical one.
-- Slight delay between record submission and leaderboard update if the photo lags. Acceptable: the run is preserved; the user just has to upload to claim the spot.
-- Adds complexity vs. trust-everyone. Acceptable: the leaderboard's value depends on records being credible.
+- **Unrelated-photo loophole.** A user can upload any image — a screenshot of someone else's race, a stock photo, a JPEG of nothing — and the flag auto-resolves. Magic-byte validation (ADR 0020) checks file *type*, not *content*. The MVP mitigation is social: in a friend-group app, fakes get called out. The durable mitigation is OCR (planned post-MVP) — extract the time and player name from the photo and verify they match the submission. Until OCR ships, this is a real attack on leaderboard credibility, not a hypothetical one.
+- **Slight delay** between record submission and leaderboard update if the photo lags. Acceptable: the run is preserved; the user just has to upload to claim the spot.
+- **Implementation complexity** vs. trust-everyone. Acceptable: the leaderboard's value depends on records being credible.
 
 ## Links
 
 - Source: `ad-hoc`
-- Related ADRs: [0020 (photo upload validation — server-side magic-byte checks)](0020-photo-upload-validation.md), [0029 (run_flags audit trail)](0029-run-flags-audit-trail.md), [0019 (admin defense in depth)](0019-admin-defense-in-depth.md)
+- Related ADRs: [0012 — DQ'd runs excluded from records and leaderboards](0012-dqd-runs-recorded-but-excluded.md), [0019 — admin defense in depth](0019-admin-defense-in-depth.md), [0020 — photo upload validation (server-side magic-byte checks)](0020-photo-upload-validation.md), [0029 — run_flags audit trail](0029-run-flags-audit-trail.md)

--- a/docs/decisions/0025-photo-enforcement-for-records.md
+++ b/docs/decisions/0025-photo-enforcement-for-records.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0025 — Photo enforcement for record-breaking runs (auto-flag + auto-resolve)
+
+## Context and problem statement
+
+Beerio Kart's leaderboards are honor-system: users self-report their times. That works fine for everyday runs — there's social pressure within a session and no real incentive to fudge a mediocre lap. The problem starts at the top of the leaderboard: a fabricated record-breaking time has outsized impact (it bumps the legitimate holder, anchors comparisons, and is hard to dislodge once stale).
+
+A photo of the in-game results screen is the cheap proof. The question is *how* to enforce it: hard block at submission, manual admin review, or some softer pattern that doesn't require admin intervention on every record but still keeps unverified records out of the leaderboard surface.
+
+## Decision drivers
+
+- Records have outsized impact on the leaderboard surface; everyday runs do not. Enforcement should match the asymmetry.
+- Hard-block at submission feels punitive — players in the middle of a session shouldn't have to pull out their phone, take a photo, transfer it, and upload it just to record a time. Half the time the photo arrives a minute later from someone else.
+- Admin manual review doesn't scale and creates a queue. The whole point of MVP automation is no human in the loop for the common case.
+- The system already has a `run_flags` table (ADR 0029) that's designed exactly for this shape: auto-applied conditions that need resolution.
+
+## Considered options
+
+- **Option A:** Trust everyone. No photo requirement.
+- **Option B:** Hard block — record-breaking submissions without photo are rejected. Forces synchronous photo upload at the worst time.
+- **Option C:** Manual admin review for all record-breaking runs. Creates a backlog; admin becomes a bottleneck.
+- **Option D (chosen):** Auto-flag and hide record-breaking runs that lack a photo. Photo upload auto-resolves the flag and the run becomes visible. Soft enforcement; no admin in the loop unless the flag stays unresolved.
+
+## Decision outcome
+
+Chosen: **Option D** — automatic, asymmetric, self-resolving.
+
+**Mechanism.** When a run is submitted that would beat any existing record (track, cup, or global), the run service checks for an attached photo. If absent, a `run_flags` row is inserted with a `record_without_photo` reason. While that flag is unresolved, the run is excluded from leaderboard queries — the record holder is whoever was there before.
+
+**Resolution.** Uploading a photo against the same run auto-resolves the flag. The run becomes visible and the leaderboard updates on the next read. No admin action required for the common case.
+
+**Why this works.** The asymmetry is the win: 95% of submissions are not record-breaking and pass through with no friction. The 5% that are record-breaking are exactly the ones worth a photo. And the user who actually beat the record has the strongest incentive to upload the photo — they want the credit.
+
+### Positive consequences
+
+- No friction on the common case (most submissions aren't records).
+- Strong incentive on the rare case (the record-holder *wants* the leaderboard to update).
+- No admin queue for routine records — admin only intervenes on disputed flags.
+- Composes cleanly with the `run_flags` audit trail (ADR 0029) — records stay visible after resolution.
+
+### Negative consequences / trade-offs
+
+- Slight delay between record submission and leaderboard update if the photo lags. Acceptable: the run is preserved; the user just has to upload to claim the spot.
+- Honor-system loophole: someone could upload an unrelated photo to resolve the flag. OCR work in a future phase tightens this; for MVP, the photo is enough of a deterrent because users see each other's submissions.
+- Adds complexity vs. trust-everyone. Acceptable: the leaderboard's value depends on records being credible.
+
+## Links
+
+- Source: `ad-hoc`
+- Related ADRs: [0020 (photo upload validation — server-side magic-byte checks)](0020-photo-upload-validation.md), [0029 (run_flags audit trail)](0029-run-flags-audit-trail.md), [0019 (admin defense in depth)](0019-admin-defense-in-depth.md)

--- a/docs/decisions/0025-photo-enforcement-for-records.md
+++ b/docs/decisions/0025-photo-enforcement-for-records.md
@@ -35,7 +35,7 @@ Chosen: **Option D** — automatic, asymmetric, self-resolving.
 
 **Resolution.** Uploading a photo against the same run auto-resolves the flag. The run becomes visible and the leaderboard updates on the next read. No admin action required for the common case.
 
-**Why this works.** The asymmetry is the win: 95% of submissions are not record-breaking and pass through with no friction. The 5% that are record-breaking are exactly the ones worth a photo. And the user who actually beat the record has the strongest incentive to upload the photo — they want the credit.
+**Why this works.** The asymmetry is the win: the vast majority of submissions aren't record-breaking and pass through with no friction. The rare case that is record-breaking is exactly the one worth a photo. And the user who actually beat the record has the strongest incentive to upload the photo — they want the credit.
 
 ### Positive consequences
 
@@ -46,8 +46,8 @@ Chosen: **Option D** — automatic, asymmetric, self-resolving.
 
 ### Negative consequences / trade-offs
 
+- **Unrelated-photo loophole.** A user can upload any image — a screenshot of someone else's race, a stock photo, a JPEG of nothing — and the flag auto-resolves. Magic-byte validation (ADR 0020) doesn't examine *content*. The MVP mitigation is social: users see each other's submissions and call out obvious fakes. The durable mitigation is OCR (planned post-MVP) — extract the time and player name from the photo and verify they match the submission. Until OCR ships, this is a real attack against leaderboard credibility, not a hypothetical one.
 - Slight delay between record submission and leaderboard update if the photo lags. Acceptable: the run is preserved; the user just has to upload to claim the spot.
-- Honor-system loophole: someone could upload an unrelated photo to resolve the flag. OCR work in a future phase tightens this; for MVP, the photo is enough of a deterrent because users see each other's submissions.
 - Adds complexity vs. trust-everyone. Acceptable: the leaderboard's value depends on records being credible.
 
 ## Links

--- a/docs/decisions/0026-lap-time-column-naming.md
+++ b/docs/decisions/0026-lap-time-column-naming.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0026 — Lap time column naming: `lap1_time`, `lap2_time`, `lap3_time`
+
+## Context and problem statement
+
+The `runs` table stores the time for each lap: lap 1, lap 2, lap 3. Column names need to be unambiguous and map cleanly to Rust identifiers. The question is whether to use underscores before digits (e.g., `lap_1_time`) or not (e.g., `lap1_time`).
+
+## Decision drivers
+
+- Column names map to Rust via SeaORM's `DeriveIden` macro, which converts snake_case to PascalCase.
+- `lap1_time` → `Lap1Time` is the natural SeaORM output.
+- `lap_1_time` → `Lap1Time` requires a custom rename, adding noise.
+- Consistency with Rust identifier conventions (no underscore before digit).
+
+## Considered options
+
+- **Option A:** `lap_1_time`, `lap_2_time`, `lap_3_time` — explicit word boundaries. Requires custom naming in SeaORM.
+- **Option B:** `lap1_time`, `lap2_time`, `lap3_time` — matches SeaORM's natural codegen output.
+
+## Decision outcome
+
+Chosen: **Option B** — `lap1_time`, `lap2_time`, `lap3_time`. No underscore before digit. Matches SeaORM's `DeriveIden` macro output naturally.
+
+### Positive consequences
+
+- Codegen produces the right Rust names without custom overrides.
+- Fewer surprises in entity definitions.
+
+### Negative consequences / trade-offs
+
+- Negligible: SQL dialect supports both; readability is the same.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0027-uuid-storage-as-text-in-sqlite.md
+++ b/docs/decisions/0027-uuid-storage-as-text-in-sqlite.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0027 — UUID storage in SQLite: TEXT, not BLOB
+
+## Context and problem statement
+
+The app uses UUIDs for entity IDs (runs, sessions, users, etc.). SQLite doesn't have a native UUID type. Two options: store as TEXT (human-readable) or BLOB (binary, compact). The choice affects debuggability and PostgreSQL migration path.
+
+## Decision drivers
+
+- Human readability when debugging with SQLite CLI tools.
+- No performance penalty for this app's scale (friend groups, not millions of rows).
+- PostgreSQL migration later can use its native UUID type; SeaORM maps both to `String` in Rust, so application code won't change.
+
+## Considered options
+
+- **Option A:** Store as TEXT (e.g., `'550e8400-e29b-41d4-a716-446655440000'`). Human-readable, slightly larger.
+- **Option B:** Store as BLOB (binary 16 bytes). Compact, opaque, hard to debug.
+- **Option C:** Hybrid: BLOB in SQLite, TEXT in PostgreSQL. Adds migration complexity.
+
+## Decision outcome
+
+Chosen: **Option A** — UUIDs stored as TEXT in SQLite for human readability. PostgreSQL migration will map to native UUID type. SeaORM maps both to `String` in Rust; application code doesn't change.
+
+### Positive consequences
+
+- Easy debugging with SQLite CLI (can read UUIDs directly).
+- No application-code changes when migrating to PostgreSQL.
+- No compression needed at this scale.
+
+### Negative consequences / trade-offs
+
+- TEXT is slightly larger on disk than BLOB. Negligible at this scale; the savings are sub-millisecond.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0028-timestamp-storage-as-iso8601-text.md
+++ b/docs/decisions/0028-timestamp-storage-as-iso8601-text.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0028 — Timestamp storage in SQLite: TEXT in ISO 8601 format
+
+## Context and problem statement
+
+The app tracks timestamps: when sessions were created, when races were submitted, when flags were resolved. SQLite has no native timestamp type. Timestamps must be stored as TEXT, BLOB, or numeric (seconds since epoch). The format must be debuggable and migrate cleanly to PostgreSQL.
+
+## Decision drivers
+
+- Human-readable format for SQLite CLI debugging.
+- ISO 8601 is a standard; no ambiguity about timezone or format.
+- SeaORM codegen produces `DateTime<Utc>` for DATETIME columns, enabling ergonomic Rust handling.
+- PostgreSQL migration later uses TIMESTAMPTZ (compatible with ISO 8601).
+
+## Considered options
+
+- **Option A:** Numeric (seconds since epoch). Compact, but opaque in CLI.
+- **Option B:** TEXT in ISO 8601 format. Human-readable, standard, debuggable.
+- **Option C:** SQLite DATETIME type (text format with custom parsing). Works, but SeaORM doesn't recognize it as `DateTime<Utc>`.
+
+## Decision outcome
+
+Chosen: **Option B** — Timestamps stored as TEXT in ISO 8601 format (e.g., `'2026-05-05T14:30:00Z'`). SQLite has no native timestamp type. PostgreSQL migration will map to `TIMESTAMPTZ`.
+
+### Positive consequences
+
+- Human-readable in CLI tools and logs.
+- Standard format; no ambiguity.
+- ISO 8601 is timezone-aware; no surprises.
+- Clean migration to PostgreSQL (both understand ISO 8601).
+
+### Negative consequences / trade-offs
+
+- TEXT is slightly larger than numeric. Negligible: timestamp strings are ~20 bytes; at friend-group scale, storage is not a concern.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0029-run-flags-audit-trail.md
+++ b/docs/decisions/0029-run-flags-audit-trail.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0029 — run_flags: audit trail, no unique constraint on (run_id, reason)
+
+## Context and problem statement
+
+Runs can be flagged for investigation (suspicious time, missing photo, etc.). Each flag has a reason and a resolved status. A single run can have multiple flags if different issues are discovered. The question is whether to allow duplicate reasons on the same run.
+
+## Decision drivers
+
+- A run might be flagged multiple times for the same reason if the issue isn't fully resolved, or if different admins flag it independently.
+- Audit trail: all flags (resolved and unresolved) are kept for history.
+- Only duplicate flags (same run + same reason while unresolved) need to be prevented to avoid spam.
+
+## Considered options
+
+- **Option A:** Unique constraint on (run_id, reason). Prevents any duplicate; forces deletion of old flags.
+- **Option B:** Allow multiple flags per (run_id, reason); no uniqueness constraint. Spam risk if not careful.
+- **Option C:** No unique constraint; prevent duplicates in application code only. Simpler schema, explicit logic.
+
+## Decision outcome
+
+Chosen: **Option C** — No unique constraint on (run_id, reason). The application code prevents duplicate flags (same run + same reason while unresolved). Resolved flags are kept as audit history.
+
+### Positive consequences
+
+- Audit trail is complete; resolved flags are never deleted.
+- Application code is explicit about which duplicates are forbidden.
+- Schema is simpler; constraints don't lock behavior.
+
+### Negative consequences / trade-offs
+
+- Relies on application code to prevent spam. Acceptable: checks are simple and testable.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0030-frontend-served-from-axum.md
+++ b/docs/decisions/0030-frontend-served-from-axum.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0030 — Frontend serving strategy: Axum serves static files with SPA fallback
+
+## Context and problem statement
+
+The frontend is built by Vite and produces static files (HTML, CSS, JavaScript). These files need to be served to browsers. Options include Axum serving them directly, a separate nginx container, or Vite's dev server in production. The choice affects deployment complexity and operational overhead.
+
+## Decision drivers
+
+- Simple deployment: one container, one process.
+- No CORS complexity; frontend and API are the same origin.
+- Vite build is a standard artifact; no dev-server production hack.
+- Scalability: if static performance ever matters (it won't at this scale), a CDN or reverse proxy can be added in front.
+
+## Considered options
+
+- **Option A:** Separate nginx container for static files; Axum for API only. Classic, adds complexity.
+- **Option B:** Axum serves everything via `tower-http::ServeDir` with SPA fallback to `index.html`. Simple, one container.
+- **Option C:** Vite dev server in production. No. Adds startup overhead and development tools to production.
+
+## Decision outcome
+
+Chosen: **Option B** — Axum serves the Vite build's static files via `tower-http::ServeDir` with SPA fallback to `index.html`. One container, no separate frontend infrastructure.
+
+### Positive consequences
+
+- Single deployment unit; no nginx config or container orchestration.
+- No CORS headers needed (same origin).
+- Standard Vite build; no production-specific tooling.
+
+### Negative consequences / trade-offs
+
+- Cache headers and asset versioning are less flexible than a dedicated CDN. Acceptable: can be optimized post-MVP if performance metrics demand it.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0031-auth-token-strategy.md
+++ b/docs/decisions/0031-auth-token-strategy.md
@@ -9,81 +9,80 @@ source: ad-hoc
 
 ## Context and problem statement
 
-The original Phase 1 design had a single 24-hour JWT in the `Authorization` header. That's adequate for "you're logged in for a day," but it has three problems:
+The original Phase 1 design used a single 24-hour JWT in the `Authorization` header. That's adequate for "you're logged in for a day," but three problems surface:
 
-1. **No revocation.** A leaked or compromised token is valid for the full window with no recourse. Bumping a key revokes everyone, which is unacceptable.
-2. **Long-lived bearer tokens in JS-accessible storage.** The 24-hour token sits wherever the frontend stores it (localStorage, in-memory). Either choice has tradeoffs around XSS exposure or page-reload state.
-3. **No graceful re-auth.** When the 24-hour mark hits, the user is bounced to login mid-session.
+1. **No revocation.** A leaked token is valid for the full window with no recourse. Bumping the signing key revokes everyone, which is unacceptable.
+2. **Long-lived bearer tokens in JS-accessible storage.** A 24-hour token sits wherever the frontend stores it — `localStorage` (XSS-readable) or in-memory (lost on reload). Both are bad.
+3. **No graceful re-auth.** When the 24 hours hit, the user is bounced to login mid-session.
 
-Phase 2's auth refactor replaces the single-token model with the standard short-access + long-refresh pattern, with one notable refinement: the refresh token lives in an HttpOnly cookie scoped to the refresh endpoint, not in JS-accessible storage. This single ADR consolidates four bullets that were originally separate but are too tightly coupled to live apart.
+Phase 2's auth refactor replaces the single-token model. The decision splits into one core choice (storage pattern for the refresh token) and three coupled sub-decisions (cookie `SameSite`, refresh format, rotation policy) that are easier to reason about together than separately.
 
 ## Decision drivers
 
-- Need server-side revocation without bumping a global signing key.
-- Want short bearer-token windows (minutes, not hours) to limit damage from theft.
-- Want the refresh path to survive page reload without re-login.
-- Want refresh tokens unreachable from JS (XSS-resilient).
-- Want the cookie to survive following an external link to the app (a friend texts you the URL — re-login is a bad first impression).
+- **Server-side revocation** without bumping a global signing key.
+- **Short bearer-token windows** (minutes, not hours) to limit damage from token theft.
+- **Survives page reload** without re-login.
+- **XSS-resilient.** The refresh token must be unreachable from JS.
+- **Survives external links.** A friend texts you the URL → you click → still logged in. Re-login from an external nav is a bad first impression.
 
 ## Considered options
 
-This ADR resolves four parallel sub-decisions. Each lists the considered options inline for symmetry.
+(Storage pattern only — sub-decisions are below in the outcome.)
 
-### Storage of the refresh token
-
-- **A:** Single long-lived JWT in the `Authorization` header. Original design. Simple but no revocation, no graceful re-auth, long bearer-token exposure.
-- **B:** Access + refresh, both in JS-accessible storage (localStorage / in-memory). Refresh token is XSS-reachable.
-- **C (chosen):** Access in JS, refresh in an HttpOnly cookie scoped to `/api/v1/auth/refresh`. JS can't read the refresh token; the path scope means it isn't sent on most requests.
-
-### `SameSite` attribute on the refresh cookie
-
-- **Strict:** blocks the cookie on any cross-site request, including a benign click from an external link (text message, email). User would be forced to re-login after following such a link.
-- **Lax (chosen):** still blocks cross-site POSTs (which is what `SameSite` is meant to prevent — CSRF on the refresh endpoint), but allows top-level GET navigation. Preserves "follow a link to the app" without giving up CSRF protection.
-
-### Refresh token format
-
-- **Opaque random string + server-side lookup table:** enables per-device revocation, but adds a table and per-refresh DB hit.
-- **JWT signed with the same key as the access token (chosen):** no new table, no extra DB hit on refresh validation. Per-device revocation is the only thing given up, and MVP doesn't need it.
-
-### Rotation policy
-
-- **Extend existing refresh token's expiry on each refresh:** simpler in theory but requires mutable state on the token.
-- **Issue a brand-new refresh token on each refresh (chosen):** matches the standard refresh-rotation pattern and keeps tokens immutable. Rotation does *not* bump `refresh_token_version` — that's reserved for actual revocation events (logout, password change). Bumping on rotation would invalidate the just-issued token.
+- **Option A:** Single long-lived JWT. Original design. Simple but no revocation, no graceful re-auth, long bearer-token exposure.
+- **Option B:** Access + refresh, both in JS-accessible storage. Standard pattern, but the refresh token is XSS-reachable.
+- **Option C (chosen):** Access + refresh, refresh in HttpOnly cookie scoped to `/api/v1/auth/refresh`. JS can't read the refresh token; the cookie's path scope means it isn't sent on most requests.
 
 ## Decision outcome
 
-Chosen: **Option C** with the orthogonal pieces resolved as below.
+Chosen: **Option C.** Sub-decisions follow.
 
-**Tokens.**
+### Tokens
 
-- **Access token.** 15–30 minute lifetime. Sent in the `Authorization: Bearer <jwt>` header on every API call. JWT signed with the auth key.
-- **Refresh token.** 7–30 day lifetime. Lives in an HttpOnly, Secure, `SameSite=Lax` cookie scoped to `Path=/api/v1/auth/refresh`. JWT signed with the same key as the access token. Claims: `sub`, `refresh_token_version`, `exp`, `iat`, `token_type: "refresh"`.
+- **Access token.** 15–30 minute lifetime. Sent in `Authorization: Bearer <jwt>` on every API call. JWT signed with the auth key.
+- **Refresh token.** 7–30 day lifetime. HttpOnly, Secure, `SameSite=Lax` cookie scoped to `Path=/api/v1/auth/refresh`. JWT signed with the same key as the access token. Claims: `sub`, `refresh_token_version`, `exp`, `iat`, `token_type: "refresh"`.
 
-**Revocation: `refresh_token_version` column on `users`.** Bumped on logout and on password change. The refresh path is the only place the version is checked — the access-token path is unchanged (no DB hit per request). A bumped version invalidates every existing refresh token for that user; the next refresh attempt is rejected and the user is bounced to login. Per-device revocation is deferred — a single global counter is sufficient for MVP.
+### `SameSite=Lax`, not `Strict`
 
-**Rotation.** Each successful refresh issues a brand-new refresh JWT with a fresh expiry. The version is *not* bumped on rotation — rotation is about extending the session window, not revoking. Bumping on rotation would invalidate the just-issued token immediately.
+Strict blocks the cookie when the request originates from another site — including the entirely benign case of clicking a link to the app from a text message or email. The user follows the link, gets to the app, and is unexpectedly logged out. Lax still blocks the cross-site POST attacks the cookie attribute is meant to prevent (CSRF on refresh) while letting "user navigated here from outside" work. Lax wins on UX with no meaningful security loss.
 
-**Frontend behavior.** API responses with status 401 trigger a silent refresh: the frontend POSTs to `/api/v1/auth/refresh` (cookie attached automatically), receives a new access token + rotated refresh cookie, and retries the original request. User-visible re-login only happens when the refresh itself returns 401.
+### Refresh token format: JWT, not opaque
 
-**Password change.** `PUT /auth/password` lives on the same route module as the refresh endpoint. It bumps `refresh_token_version` as part of the change, invalidating any existing refresh cookies. The user re-authenticates after a password change — that's the desired behavior and the version-bump is the mechanism.
+Opaque random tokens require a server-side lookup table per token. JWT signed with the access-token key requires no new table. The only thing JWT gives up is per-device revocation — and we don't need that for MVP. If "log out other devices" ever becomes a feature, opaque tokens with a per-token DB row are the migration path; the existing `refresh_token_version` plumbing carries forward.
+
+### Rotation: new token on every refresh, no version bump
+
+Each successful refresh issues a brand-new refresh JWT with a fresh expiry. The version is **not** bumped on rotation — rotation extends the session window, not revokes existing sessions. Bumping on rotation would invalidate the just-issued token immediately.
+
+### Revocation: `refresh_token_version` column on `users`
+
+Bumped on logout and on password change. Checked **only on the refresh path** — the access-token path is unchanged (no DB hit per request). A bumped version invalidates every existing refresh token for that user; the next refresh attempt is rejected and the user is bounced to login.
+
+### Frontend behavior
+
+API responses with status 401 trigger a silent refresh: the frontend POSTs to `/api/v1/auth/refresh` (cookie attached automatically), receives a new access token + rotated refresh cookie, and retries the original request. User-visible re-login only happens when the refresh itself returns 401.
+
+### Password change
+
+`PUT /auth/password` lives on the same route module as the refresh endpoint. It bumps `refresh_token_version` as part of the change. The user re-authenticates after a password change — that's the desired behavior, and the version-bump is the mechanism.
 
 ### Positive consequences
 
-- Refresh token is unreachable from JS (XSS-resilient).
-- 401s trigger a silent refresh; users don't see the token expiry.
+- Refresh token unreachable from JS (XSS-resilient).
+- 401s trigger silent refresh; users don't see token expiry.
 - Server-side revocation without a per-token table — one integer per user.
-- Logout, password change, and "rotate everything" are all the same primitive (bump the counter).
-- The cookie scope (`Path=/api/v1/auth/refresh`) means the refresh token isn't sent on every API request — narrower attack surface than a session cookie.
+- Logout, password change, and "rotate everything" are the same primitive: bump the counter.
+- Cookie scoped to `/api/v1/auth/refresh` means the refresh token isn't sent on every API request — narrower attack surface than a session cookie.
 - `SameSite=Lax` keeps "follow a link to the app" working without sacrificing CSRF protection on the refresh path.
 
 ### Negative consequences / trade-offs
 
-- Two-token complexity vs. one. Frontend has to handle 401-then-refresh-then-retry; backend has two token validators. Acceptable: this is the standard pattern and the security/UX gains pay for it.
-- Per-device revocation isn't possible without a per-token table. Deferred until there's a feature that needs it (e.g., "log out other devices" UI).
-- Cookies require HTTPS in production (Secure attribute). Cloudflare Tunnel handles this; not a constraint in practice.
+- **Two-token complexity vs. one.** The frontend handles 401 → refresh → retry; the backend has two token validators. Acceptable: this is the standard pattern, and the security/UX gains pay for it.
+- **Per-device revocation isn't possible** without a per-token table. Deferred until there's a feature that needs it (e.g., a "log out other devices" UI).
+- **HTTPS required in production** for the Secure attribute. Cloudflare Tunnel (ADR 0033) provides this; not a constraint in practice.
 
 ## Links
 
 - Source: `ad-hoc`
-- Related ADRs: [0016 (session passwords deferred — re-uses the same `POST /sessions/:id/join` shape so password support is additive later)](0016-session-passwords-deferred.md)
+- Related ADRs: [0016 — session passwords deferred (re-uses POST `/sessions/:id/join` shape)](0016-session-passwords-deferred.md), [0033 — Cloudflare Tunnel for exposure](0033-cloudflare-tunnel-for-exposure.md)
 - Implementing PRs: PR #7 (Phase 2: Production config + refresh token auth)

--- a/docs/decisions/0031-auth-token-strategy.md
+++ b/docs/decisions/0031-auth-token-strategy.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0031 — Auth: short access token + long refresh token (HttpOnly cookie)
+
+## Context and problem statement
+
+The original Phase 1 design had a single 24-hour JWT in the `Authorization` header. That's adequate for "you're logged in for a day," but it has three problems:
+
+1. **No revocation.** A leaked or compromised token is valid for the full window with no recourse. Bumping a key revokes everyone, which is unacceptable.
+2. **Long-lived bearer tokens in JS-accessible storage.** The 24-hour token sits wherever the frontend stores it (localStorage, in-memory). Either choice has tradeoffs around XSS exposure or page-reload state.
+3. **No graceful re-auth.** When the 24-hour mark hits, the user is bounced to login mid-session.
+
+Phase 2's auth refactor replaces the single-token model with the standard short-access + long-refresh pattern, with one notable refinement: the refresh token lives in an HttpOnly cookie scoped to the refresh endpoint, not in JS-accessible storage. This single ADR consolidates four bullets that were originally separate but are too tightly coupled to live apart.
+
+## Decision drivers
+
+- Need server-side revocation without bumping a global signing key.
+- Want short bearer-token windows (minutes, not hours) to limit damage from theft.
+- Want the refresh path to survive page reload without re-login.
+- Want refresh tokens unreachable from JS (XSS-resilient).
+- Want the cookie to survive following an external link to the app (a friend texts you the URL — re-login is a bad first impression).
+
+## Considered options
+
+- **Option A:** Single long-lived JWT. Original design. Simple but no revocation, no graceful re-auth, long bearer-token exposure.
+- **Option B:** Access + refresh, both in JS-accessible storage. Standard pattern but refresh token is XSS-reachable.
+- **Option C:** Access + refresh, refresh in HttpOnly cookie scoped to `/api/v1/auth/refresh`. (Chosen.) JS can't read the refresh token; cookie-scoped path means it isn't sent on most requests.
+
+A second decision orthogonal to the storage choice: **`SameSite=Lax` vs `SameSite=Strict`** on the refresh cookie. Strict blocks the cookie when the request originates from another site — including the entirely benign case of clicking a link to the app from a text message or email. Lax still blocks the cross-site POST attacks the cookie attribute is meant to prevent (CSRF on refresh) while letting "user navigated here from outside" work.
+
+A third decision: **refresh token format** — opaque random string with a server-side lookup table, or JWT signed with the same key as the access token. JWT wins on simplicity (no new table); per-device revocation is the only thing it gives up, and we don't need that for MVP.
+
+A fourth decision: **rotation** — should each refresh issue a brand-new refresh token, or extend the existing one's expiry? New token. Simpler and matches the standard refresh-rotation pattern.
+
+## Decision outcome
+
+Chosen: **Option C** with the orthogonal pieces resolved as below.
+
+**Tokens.**
+
+- **Access token.** 15–30 minute lifetime. Sent in the `Authorization: Bearer <jwt>` header on every API call. JWT signed with the auth key.
+- **Refresh token.** 7–30 day lifetime. Lives in an HttpOnly, Secure, `SameSite=Lax` cookie scoped to `Path=/api/v1/auth/refresh`. JWT signed with the same key as the access token. Claims: `sub`, `refresh_token_version`, `exp`, `iat`, `token_type: "refresh"`.
+
+**Revocation: `refresh_token_version` column on `users`.** Bumped on logout and on password change. The refresh path is the only place the version is checked — the access-token path is unchanged (no DB hit per request). A bumped version invalidates every existing refresh token for that user; the next refresh attempt is rejected and the user is bounced to login. Per-device revocation is deferred — a single global counter is sufficient for MVP.
+
+**Rotation.** Each successful refresh issues a brand-new refresh JWT with a fresh expiry. The version is *not* bumped on rotation — rotation is about extending the session window, not revoking. Bumping on rotation would invalidate the just-issued token immediately.
+
+**Frontend behavior.** API responses with status 401 trigger a silent refresh: the frontend POSTs to `/api/v1/auth/refresh` (cookie attached automatically), receives a new access token + rotated refresh cookie, and retries the original request. User-visible re-login only happens when the refresh itself returns 401.
+
+**Password change.** `PUT /auth/password` lives on the same route module as the refresh endpoint. It bumps `refresh_token_version` as part of the change, invalidating any existing refresh cookies. The user re-authenticates after a password change — that's the desired behavior and the version-bump is the mechanism.
+
+### Positive consequences
+
+- Refresh token is unreachable from JS (XSS-resilient).
+- 401s trigger a silent refresh; users don't see the token expiry.
+- Server-side revocation without a per-token table — one integer per user.
+- Logout, password change, and "rotate everything" are all the same primitive (bump the counter).
+- The cookie scope (`Path=/api/v1/auth/refresh`) means the refresh token isn't sent on every API request — narrower attack surface than a session cookie.
+- `SameSite=Lax` keeps "follow a link to the app" working without sacrificing CSRF protection on the refresh path.
+
+### Negative consequences / trade-offs
+
+- Two-token complexity vs. one. Frontend has to handle 401-then-refresh-then-retry; backend has two token validators. Acceptable: this is the standard pattern and the security/UX gains pay for it.
+- Per-device revocation isn't possible without a per-token table. Deferred until there's a feature that needs it (e.g., "log out other devices" UI).
+- Cookies require HTTPS in production (Secure attribute). Cloudflare Tunnel handles this; not a constraint in practice.
+
+## Links
+
+- Source: `ad-hoc`
+- Related ADRs: [0016 (session passwords deferred — re-uses the same `POST /sessions/:id/join` shape so password support is additive later)](0016-session-passwords-deferred.md)
+- Implementing PRs: PR #7 (Phase 2: Production config + refresh token auth)

--- a/docs/decisions/0031-auth-token-strategy.md
+++ b/docs/decisions/0031-auth-token-strategy.md
@@ -27,15 +27,28 @@ Phase 2's auth refactor replaces the single-token model with the standard short-
 
 ## Considered options
 
-- **Option A:** Single long-lived JWT. Original design. Simple but no revocation, no graceful re-auth, long bearer-token exposure.
-- **Option B:** Access + refresh, both in JS-accessible storage. Standard pattern but refresh token is XSS-reachable.
-- **Option C:** Access + refresh, refresh in HttpOnly cookie scoped to `/api/v1/auth/refresh`. (Chosen.) JS can't read the refresh token; cookie-scoped path means it isn't sent on most requests.
+This ADR resolves four parallel sub-decisions. Each lists the considered options inline for symmetry.
 
-A second decision orthogonal to the storage choice: **`SameSite=Lax` vs `SameSite=Strict`** on the refresh cookie. Strict blocks the cookie when the request originates from another site — including the entirely benign case of clicking a link to the app from a text message or email. Lax still blocks the cross-site POST attacks the cookie attribute is meant to prevent (CSRF on refresh) while letting "user navigated here from outside" work.
+### Storage of the refresh token
 
-A third decision: **refresh token format** — opaque random string with a server-side lookup table, or JWT signed with the same key as the access token. JWT wins on simplicity (no new table); per-device revocation is the only thing it gives up, and we don't need that for MVP.
+- **A:** Single long-lived JWT in the `Authorization` header. Original design. Simple but no revocation, no graceful re-auth, long bearer-token exposure.
+- **B:** Access + refresh, both in JS-accessible storage (localStorage / in-memory). Refresh token is XSS-reachable.
+- **C (chosen):** Access in JS, refresh in an HttpOnly cookie scoped to `/api/v1/auth/refresh`. JS can't read the refresh token; the path scope means it isn't sent on most requests.
 
-A fourth decision: **rotation** — should each refresh issue a brand-new refresh token, or extend the existing one's expiry? New token. Simpler and matches the standard refresh-rotation pattern.
+### `SameSite` attribute on the refresh cookie
+
+- **Strict:** blocks the cookie on any cross-site request, including a benign click from an external link (text message, email). User would be forced to re-login after following such a link.
+- **Lax (chosen):** still blocks cross-site POSTs (which is what `SameSite` is meant to prevent — CSRF on the refresh endpoint), but allows top-level GET navigation. Preserves "follow a link to the app" without giving up CSRF protection.
+
+### Refresh token format
+
+- **Opaque random string + server-side lookup table:** enables per-device revocation, but adds a table and per-refresh DB hit.
+- **JWT signed with the same key as the access token (chosen):** no new table, no extra DB hit on refresh validation. Per-device revocation is the only thing given up, and MVP doesn't need it.
+
+### Rotation policy
+
+- **Extend existing refresh token's expiry on each refresh:** simpler in theory but requires mutable state on the token.
+- **Issue a brand-new refresh token on each refresh (chosen):** matches the standard refresh-rotation pattern and keeps tokens immutable. Rotation does *not* bump `refresh_token_version` — that's reserved for actual revocation events (logout, password change). Bumping on rotation would invalidate the just-issued token.
 
 ## Decision outcome
 

--- a/docs/decisions/0032-cursor-based-pagination.md
+++ b/docs/decisions/0032-cursor-based-pagination.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0032 — Pagination: cursor-based (keyset) on `created_at` + `id`
+
+## Context and problem statement
+
+List endpoints like `GET /runs` and run history views need pagination to avoid loading all data at once. Two strategies exist: offset-based (skip N, take M) and cursor-based (keyset pagination using a position marker). Cursor-based avoids duplicate/skipped entries when data is inserted during browsing.
+
+## Decision drivers
+
+- Avoid duplicates or skipped entries if new data is inserted while a user is paginating.
+- Cursor-based is stable across inserts; offset-based is not.
+- Standard pattern in modern APIs.
+
+## Considered options
+
+- **Option A:** Offset-based pagination. Simple to implement; buggy if new data arrives mid-browse.
+- **Option B:** Cursor-based keyset pagination. Stable across inserts; slightly more complex.
+- **Option C:** No pagination; load all data. Scalability nightmare.
+
+## Decision outcome
+
+Chosen: **Option B** — Cursor-based pagination using `created_at` + `id` (compound key ensures uniqueness). Pagination is implemented for `GET /runs` and run history views. If complexity proves unmanageable relative to offset-based, can revisit post-MVP.
+
+### Positive consequences
+
+- Stable browsing experience; no skipped or duplicate entries if new data arrives.
+- Works at scale without offset overhead.
+
+### Negative consequences / trade-offs
+
+- Slightly more complex to implement and explain. Acceptable: if the implementation burden is real, offset-based can be substituted later with a note about the tradeoff.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0033-cloudflare-tunnel-for-exposure.md
+++ b/docs/decisions/0033-cloudflare-tunnel-for-exposure.md
@@ -19,8 +19,10 @@ The app runs on Brendan's Unraid server at home. To make it accessible from outs
 
 ## Considered options
 
-- **Option A:** Port forwarding on the router. Opens the home network to direct attacks.
-- **Option B:** Cloudflare Tunnel (outbound-only connection to the Cloudflare edge). Secure, no open ports.
+- **Option A:** Port forwarding on the router. Opens an inbound port on the home network. Direct attack surface; needs DDNS for a stable hostname; needs a separate TLS solution (Let's Encrypt + cert renewal).
+- **Option B:** Cloudflare Tunnel (chosen). Outbound-only daemon on the Unraid server connects to the Cloudflare edge; Cloudflare proxies traffic back through the tunnel. No inbound port; TLS, DDoS protection, and a stable hostname are bundled.
+- **Option C:** Tailscale Funnel or ngrok. Same outbound-tunnel shape as Cloudflare; bundles TLS and a stable hostname. Tailscale is good for "private mesh + selective public exposure" but the public-tunnel feature is comparatively new; ngrok's free tier has rate limits and a rotating hostname unless paid.
+- **Option D:** Small VPS (e.g., $5/mo Hetzner / Fly.io) running a reverse proxy back to home via WireGuard or SSH tunnel. Most flexible, full control over TLS and routing, but adds an always-on box to operate.
 
 ## Decision outcome
 
@@ -35,6 +37,7 @@ Chosen: **Option B** — Cloudflare Tunnel. The server makes an outbound-only co
 ### Negative consequences / trade-offs
 
 - Dependency on Cloudflare's uptime and reliability. Acceptable: small-scale hobby app; standard SaaS risk.
+- Lock-in to Cloudflare's specific tunnel daemon (`cloudflared`) and DNS / hostname configuration. Migrating to Tailscale Funnel, ngrok, or a self-hosted reverse proxy later would touch the deploy config but not application code — cost is bounded.
 
 ## Links
 

--- a/docs/decisions/0033-cloudflare-tunnel-for-exposure.md
+++ b/docs/decisions/0033-cloudflare-tunnel-for-exposure.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0033 — Cloudflare Tunnel for exposure, not port forwarding
+
+## Context and problem statement
+
+The app runs on Brendan's Unraid server at home. To make it accessible from outside the home network (e.g., testing from a phone on mobile data), the server needs to be exposed to the internet. Options include opening a port on the home network's firewall (port forwarding) or using a service like Cloudflare Tunnel that doesn't require opening ports.
+
+## Decision drivers
+
+- No open ports on the home network — eliminates direct attack surface.
+- Outbound-only connection from the server to Cloudflare's edge — no inbound listening.
+- Cloudflare provides DDoS protection and SSL termination as a bonus.
+
+## Considered options
+
+- **Option A:** Port forwarding on the router. Opens the home network to direct attacks.
+- **Option B:** Cloudflare Tunnel (outbound-only connection to the Cloudflare edge). Secure, no open ports.
+
+## Decision outcome
+
+Chosen: **Option B** — Cloudflare Tunnel. The server makes an outbound-only connection to Cloudflare's edge; requests are routed back to the server through the tunnel. No open ports on the home network.
+
+### Positive consequences
+
+- No open ports; reduced attack surface.
+- Outbound-only connection is hard to exploit from outside.
+- Bonus: DDoS protection and SSL from Cloudflare.
+
+### Negative consequences / trade-offs
+
+- Dependency on Cloudflare's uptime and reliability. Acceptable: small-scale hobby app; standard SaaS risk.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/0034-docker-compose-manager-for-deployment.md
+++ b/docs/decisions/0034-docker-compose-manager-for-deployment.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-05-05
+deciders: [Brendan]
+source: ad-hoc
+---
+
+# 0034 — Docker Compose Manager plugin on Unraid for container management
+
+## Context and problem statement
+
+The app and its services run in Docker containers on an Unraid server. Unraid has multiple container management options: the built-in UI, manual `docker-compose` commands, or dedicated plugins. The choice affects how easy it is to deploy, monitor, and update the app.
+
+## Decision drivers
+
+- Unraid is a home-lab platform designed for Docker; its plugins are native to the ecosystem.
+- Docker Compose is a standard abstraction; using it as the config language ensures portability.
+- The Compose Manager plugin gives Unraid's UI a view into the compose file without manual CLI work.
+
+## Considered options
+
+- **Option A:** Manual `docker-compose` commands; manage containers via CLI. Works, but less integrated with Unraid.
+- **Option B:** Unraid's built-in Docker UI (separate from Compose). Limited Compose visibility.
+- **Option C:** Docker Compose Manager plugin on Unraid. Unraid's UI knows about Compose; single source of truth in `compose.yaml`.
+
+## Decision outcome
+
+Chosen: **Option C** — Docker Compose Manager plugin on Unraid. `compose.yaml` is the single source of truth for the deployment. Unraid's plugin reads and manages the Compose file through the UI.
+
+### Positive consequences
+
+- `compose.yaml` is portable; the app can run on any system with Docker and Compose.
+- Unraid's UI is integrated; no manual CLI.
+- Easy to version control and review `compose.yaml` changes.
+
+### Negative consequences / trade-offs
+
+- Plugin dependency; if the plugin is discontinued, manual `docker-compose` commands remain as a fallback.
+
+## Links
+
+- Source: `ad-hoc`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,6 +18,39 @@ See `template.md` for the starting point. Files are named `NNNN-kebab-case-title
 | # | Title | Status | Date |
 |---|---|---|---|
 | [0001](0001-sessions-no-created-by-column.md) | Sessions: no `created_by` column | accepted | 2026-05-02 |
+| [0002](0002-sqlite-strict-mode-on-static-tables.md) | SQLite STRICT mode on lookup tables; DATETIME on timestamped tables | accepted | 2026-05-05 |
+| [0003](0003-global-leaderboard-most-track-records.md) | Global leaderboard: most track records held | accepted | 2026-05-05 |
+| [0004](0004-account-recovery-admin-reset.md) | Account recovery: admin reset for now | accepted | 2026-05-05 |
+| [0005](0005-no-time-entry-validation.md) | Time entry: no validation against plausible track times | accepted | 2026-05-05 |
+| [0006](0006-beer-vs-water-separate-leaderboards.md) | Beer vs water: separate leaderboards by default, with combined view | accepted | 2026-05-05 |
+| [0007](0007-track-variants-150cc-only.md) | Track variants: 150cc only | accepted | 2026-05-05 |
+| [0008](0008-admin-model-env-var-gated.md) | Admin model: lightweight admin page gated by user ID in env variable | accepted | 2026-05-05 |
+| [0009](0009-run-immutability-admin-can-edit.md) | Run immutability: users cannot edit runs after creation; admin can | accepted | 2026-05-05 |
+| [0010](0010-h2h-derived-from-session-races.md) | Head-to-head: derived from session races, not stored | accepted | 2026-05-05 |
+| [0011](0011-sessions-replace-standalone-runs.md) | Sessions replace standalone run recording | accepted | 2026-05-05 |
+| [0012](0012-dqd-runs-recorded-but-excluded.md) | DQ'd runs: recorded but excluded from leaderboards and H2H | accepted | 2026-05-05 |
+| [0013](0013-pending-race-cap.md) | Pending race cap: UI shows max 3 pending races | accepted | 2026-05-05 |
+| [0014](0014-session-host-transfer.md) | Session host transfer: earliest-joined remaining participant becomes new host | accepted | 2026-05-05 |
+| [0015](0015-session-timeout-skip-turn.md) | Session timeout handling (MVP): "skip turn" allows recovery without restart | accepted | 2026-05-05 |
+| [0016](0016-session-passwords-deferred.md) | Session passwords: deferred post-MVP | accepted | 2026-05-05 |
+| [0017](0017-ruleset-changes-mid-session-deferred.md) | Ruleset changes mid-session: deferred post-MVP | accepted | 2026-05-05 |
+| [0018](0018-realtime-via-polling-not-websockets.md) | Real-time updates: polling, not WebSockets | accepted | 2026-05-05 |
+| [0019](0019-admin-defense-in-depth.md) | Admin defense in depth: two independent checks | accepted | 2026-05-05 |
+| [0020](0020-photo-upload-validation.md) | Photo upload: magic-byte validation, format whitelist, size cap | accepted | 2026-05-05 |
+| [0021](0021-upload-path-isolation.md) | Upload path isolation: separate URL prefix and filesystem directory | accepted | 2026-05-05 |
+| [0022](0022-rulesets-as-rust-trait.md) | Rulesets: implemented as Rust trait with one module per ruleset | accepted | 2026-05-05 |
+| [0023](0023-hand-written-seaorm-entities.md) | Hand-written SeaORM entities: committed source code | accepted | 2026-05-05 |
+| [0024](0024-just-not-make-for-dev-commands.md) | just (not Make) for developer commands | accepted | 2026-05-05 |
+| [0025](0025-photo-enforcement-for-records.md) | Photo enforcement for record-breaking runs (auto-flag + auto-resolve) | accepted | 2026-05-05 |
+| [0026](0026-lap-time-column-naming.md) | Lap time column naming: `lap1_time`, `lap2_time`, `lap3_time` | accepted | 2026-05-05 |
+| [0027](0027-uuid-storage-as-text-in-sqlite.md) | UUID storage in SQLite: TEXT, not BLOB | accepted | 2026-05-05 |
+| [0028](0028-timestamp-storage-as-iso8601-text.md) | Timestamp storage in SQLite: TEXT in ISO 8601 format | accepted | 2026-05-05 |
+| [0029](0029-run-flags-audit-trail.md) | run_flags: audit trail, no unique constraint on (run_id, reason) | accepted | 2026-05-05 |
+| [0030](0030-frontend-served-from-axum.md) | Frontend serving strategy: Axum serves static files with SPA fallback | accepted | 2026-05-05 |
+| [0031](0031-auth-token-strategy.md) | Auth: short access token + long refresh token (HttpOnly cookie) | accepted | 2026-05-05 |
+| [0032](0032-cursor-based-pagination.md) | Pagination: cursor-based (keyset) on `created_at` + `id` | accepted | 2026-05-05 |
+| [0033](0033-cloudflare-tunnel-for-exposure.md) | Cloudflare Tunnel for exposure, not port forwarding | accepted | 2026-05-05 |
+| [0034](0034-docker-compose-manager-for-deployment.md) | Docker Compose Manager plugin on Unraid for container management | accepted | 2026-05-05 |
 
 ## Adding a new ADR
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -561,44 +561,7 @@ Required test scenarios per ruleset: normal flow, recusal by one player, recusal
 
 ## Resolved Decisions
 
-- **SQLite STRICT mode on lookup / static tables; DATETIME columns on timestamped tables.** STRICT kept on static game data tables for type safety at insert time. Dropped on timestamped tables so columns use `DATETIME` type, giving Rust `DateTime<Utc>` via SeaORM codegen instead of stringly-typed timestamps.
-- **Global leaderboard ranking:** Most track records held.
-- **Account recovery:** Admin reset for now.
-- **Time entry validation:** No validation against plausible track times. Rely on photos and eventual OCR.
-- **Beer vs water:** Separate leaderboards by default, with combined view. Default toggle matches user's preferred drink category.
-- **Track variants:** 150cc only.
-- **Admin model:** Lightweight admin page gated by user ID in env variable. No formal role system for MVP.
-- **Run immutability:** Users cannot edit runs after creation. Admin can edit (for correcting OCR errors, etc.).
-- **Head-to-head tracking:** Derived from session races. Two players have a H2H record when they both submitted non-DQ'd runs for the same session race. Replaces the earlier timestamp-clustering approach.
-- **Sessions replace standalone run recording.** All runs are recorded within session context. Solo racing uses a one-person session (MVP). Future enhancement: nullable `session_race_id` for lightweight standalone runs.
-- **H2H ties:** Identical times = 0-0 (draw). Neither player gets a win or loss.
-- **H2H drink category:** H2H does not distinguish alcoholic vs non-alcoholic. A drinker and non-drinker in the same session race have their result counted. Drink category only matters for leaderboards.
-- **DQ'd runs:** Recorded but excluded from H2H tallies and leaderboard positions. Self-reported at submission time (honor system). DQ = didn't finish drink before finishing race.
-- **Pending race cap:** UI shows max 3 pending races (oldest expire first). Schema supports unlimited — cap is a UX guardrail, adjustable later.
-- **Session host transfer:** When host leaves, earliest-joined remaining participant becomes new host.
-- **Session timeout handling (MVP):** "Skip turn" allows any participant to pass the chooser's turn. Vote-to-kick deferred. Leave-and-restart is the fallback for stuck sessions.
-- **Session passwords:** Deferred. The `POST /sessions/:id/join` endpoint is a dedicated action so password checking can be added later without restructuring the join flow.
-- **Ruleset changes mid-session:** Deferred post-MVP.
-- **Real-time updates via polling, not WebSockets.** Clients poll `GET /sessions/:id` every 2-3 seconds. For a turn-based game where events happen every few minutes, polling latency is imperceptible. WebSockets can be added later as an optimization. Polling is stateless, testable with standard HTTP tools, and avoids connection state management, reconnection logic, and heartbeat complexity.
-- **Admin defense in depth.** Admin-only operations (editing runs, resolving flags) are checked in both the route middleware (AdminUser extractor) and the service layer independently. Two independent checks — if either the middleware or the service rejects the request, it fails. Prevents a middleware bug from exposing admin operations.
-- **Photo upload validation.** Validate server-side by checking magic bytes (not just Content-Type header). Accept JPEG, PNG, HEIC/HEIF. Max file size: 10MB. Generate filenames from run ID (`{run_id}.{ext}`) — never use user-provided filenames. Optionally strip EXIF data (GPS, device info) for privacy in a future pass.
-- **Upload path isolation.** User uploads are served from a separate URL prefix and filesystem directory from static assets. Static assets at `/static/...` (from `STATIC_DIR`), uploads at `/uploads/...` (from `UPLOAD_DIR`). Different prefixes and different directories prevent path traversal across boundaries.
-- **Rulesets implemented as a Rust trait.** Each ruleset (Random, Default, Least Played, Round-robin) is a separate module implementing a `Ruleset` trait, not conditionals in the session service. Adding a fifth ruleset later means adding one module, not modifying existing code.
-- **Hand-written SeaORM entities.** Entities under `backend/src/entities/` are committed source code, hand-edited as the schema evolves. The migration in `migration/` is the schema source of truth; entities mirror that shape. Codegen (`just entities-bootstrap`, wrapping `sea-orm-cli generate entity`) is a one-shot scaffolding tool used only when adding a brand-new table — running it on existing entities will clobber hand-corrections (partial-index attributes, relation cardinalities). Architectural reasoning: [`docs/designs/2026-05-02-entity-codegen-strategy.md`](./designs/2026-05-02-entity-codegen-strategy.md), implemented in PR-X1.
-- **just (not Make) for developer commands.** Cargo handles Rust build dependencies, Bun handles frontend dependencies, Docker handles container caching. Developer workflow commands (`just dev`, `just test`, `just entities-bootstrap`) don't need file-level dependency tracking — just a named command runner.
-- **Photo enforcement for records:** Runs are auto-flagged and hidden if record-breaking without a photo. Photo upload auto-resolves the flag.
-- **Lap time column naming:** `lap1_time`, `lap2_time`, `lap3_time` (no underscore before digit). Matches SeaORM's `DeriveIden` macro output for variants like `Lap1Time`, avoiding unnecessary custom naming.
-- **UUID storage in SQLite:** UUIDs stored as TEXT (not BLOB) for human readability when debugging with CLI tools. PostgreSQL migration will map to native UUID type. SeaORM maps both to `String` in Rust, so application code won't change.
-- **Timestamp storage in SQLite:** Timestamps stored as TEXT in ISO 8601 format. SQLite has no native timestamp type. PostgreSQL migration will map to `TIMESTAMPTZ`.
-- **run_flags audit trail:** `run_id` is not unique — a run can have multiple flags (different reasons tracked separately, resolved independently). Resolved flags are kept as history. Only duplicate flags (same run + same reason while unresolved) are prevented in application code.
-- **Frontend serving strategy:** Axum serves everything in a single container. The Vite build produces static files that Axum serves via `tower-http::ServeDir`, with SPA fallback to `index.html`. No nginx or separate frontend container. Rationale: simpler deployment for a small-scale app, no CORS (same origin), one container to manage. If static asset performance ever matters (it won't at this scale), a CDN or nginx can be added in front later.
-- **Auth token strategy:** Short-lived access token (15-30 min, Authorization header) + long-lived refresh token (7-30 days, HttpOnly/Secure/SameSite=Lax cookie scoped to `/api/v1/auth/refresh`). Lax (not Strict) because Strict blocks the cookie when navigating from an external link (e.g., a friend texts you the URL), which would force a re-login. Lax still protects against cross-origin POST attacks. A `refresh_token_version` column on `users` enables server-side revocation checked only on the refresh path, not every request. Frontend intercepts 401s, silently refreshes, and retries. Replaces the original 24-hour single JWT approach.
-- **Pagination:** Cursor-based (keyset) pagination using `created_at` + `id` for list endpoints, particularly `GET /runs` and run history views. Preferred over offset-based to avoid duplicate/skipped entries when new data is inserted during browsing. If implementation proves too complex relative to offset-based, revisit.
-- **Password change:** `PUT /auth/password` endpoint for users to change their own password. Implemented in Phase 2 alongside refresh token auth.
-- **Refresh token format:** JWT (not opaque). Contains `sub`, `refresh_token_version`, `exp`, `iat`, `token_type`. Same signing key as access token. Simplest approach — no new table. Per-device revocation deferred; version-bump covers logout and password change.
-- **Refresh token rotation:** On each refresh, a new refresh JWT is issued with a fresh expiry. Does not bump `refresh_token_version` — rotation is about extending the session window, not revocation.
-- **Cloudflare Tunnel (not port forwarding)** for exposing the app. Outbound-only connection from Unraid to Cloudflare edge. No open ports on the home network.
-- **Docker Compose Manager plugin** on Unraid for container management. compose.yaml as the single source of truth for the deployment.
+See [`decisions/`](./decisions/) — each prior bullet has been distilled into a MADR file under `docs/decisions/`. The index in [`decisions/README.md`](./decisions/README.md) lists every ADR with its title, status, and date.
 
 ## Backlog
 
@@ -628,3 +591,4 @@ Random ideas that may or may not be pursued.
 - 2026-05-04 — Added `docs/research/` to the project-structure tree and a corresponding entry in Related documents (long-form exploration not yet promoted to design or coding-standards).
 - 2026-05-04 — Replaced the "Entity regeneration via justfile recipe" rule with "Hand-written SeaORM entities"; updated the `just (not Make)` example to use `just entities-bootstrap`. Closes the codegen-strategy decision recorded at [`reviews/design/2026-05-02-entity-codegen-strategy.md`](./reviews/design/2026-05-02-entity-codegen-strategy.md). PR-X1.
 - 2026-05-05 — Extracted Data Model section to `data-model.md`. PR 1 of the docs restructure.
+- 2026-05-05 — Replaced the Resolved Decisions bullet list with a pointer to `docs/decisions/`. Each prior bullet distilled into a MADR file (0002–0034). PR 2 of the docs restructure.


### PR DESCRIPTION
## Reviewer notes

33 ADRs in 33 commits + 1 wrap-up commit (design.md replacement + index population) — `git log --oneline` is the scannable summary. Two non-mechanical bits worth careful review:

1. **Three "richer" ADRs were hand-drafted by Claude Code, not the Haiku tier.** Per the Issue AC, Cowork is expected to review-rewrite these. Drafts live at:
   - [`docs/decisions/0010-h2h-derived-from-session-races.md`](docs/decisions/0010-h2h-derived-from-session-races.md) — consolidates 3 bullets (H2H tracking, ties, drink-category neutrality)
   - [`docs/decisions/0025-photo-enforcement-for-records.md`](docs/decisions/0025-photo-enforcement-for-records.md)
   - [`docs/decisions/0031-auth-token-strategy.md`](docs/decisions/0031-auth-token-strategy.md) — consolidates 4 bullets (token strategy, password change, refresh format, refresh rotation)

   I drafted them at decent quality so Cowork has a solid starting point to rewrite, not a blank page.

   **Update:** Cowork rewrote the three richer ADRs onto this branch as three additional commits at the head (`bff91f4`, `7feacb1`, `457b49b`) — see `git log --oneline | grep 'rewrite ADR'`. The richer-ADR AC is now satisfied.

2. **Numbering / consolidation.** The Issue says ~35 ADRs; the actual count is 33, because related bullets were combined per the design record's §3 guidance ("Combine related decisions when natural"):
   - 0010 absorbs three H2H bullets.
   - 0031 absorbs four auth bullets.

   Numbering is contiguous 0002–0034 (0001 was distilled in PR 1).

## Summary

Implements PR 2 of the docs restructure: every entry in `docs/design.md`'s old "Resolved Decisions" section becomes its own MADR file under `docs/decisions/`. The bulk used the model-tiered approach per `docs/CLAUDE.md` — Claude Code hand-drafted the canonical (0002), spawned a Haiku-tier subagent for the 27 simpler ADRs, and hand-drafted the three richer ones for Cowork to rewrite. `docs/design.md` shrinks by ~40 lines; `docs/decisions/` gains 33 files; `docs/decisions/README.md` index lists everything.

## Linked work

- Closes #39
- Implements PR 2 of [`docs/designs/2026-05-04-design-doc-restructure.md`](docs/designs/2026-05-04-design-doc-restructure.md) §9.

## How to verify

- [ ] `ls docs/decisions/ | wc -l` is 36 (33 ADRs + README + template + 0001 from PR 1).
- [ ] `grep -c '^| \[' docs/decisions/README.md` is 34 (rows in the index).
- [ ] Numbering is contiguous 0001–0034 (no gaps, no duplicates): `ls docs/decisions/[0-9][0-9][0-9][0-9]-*.md | grep -oE '^docs/decisions/[0-9]{4}' | sort -u | wc -l` = 34.
- [ ] `grep -c '## Resolved Decisions' docs/design.md` is 1; the section is exactly the pointer paragraph.
- [ ] `tail -1 docs/design.md` is the new Document history entry.
- [ ] `git log --oneline main..HEAD | grep -c '^[a-f0-9]\+ 39: distill'` is 31 (28 bulk + canonical + 3 richer = 32, minus the 1 wrap-up commit = 31).
- [ ] Spot-check: `cat docs/decisions/0007-track-variants-150cc-only.md` is shaped like the canonical (0002) — frontmatter, Context, Drivers, Options, Outcome (Positive/Negative), Links.

## Author checklist

- [x] Linked to an Issue under "Linked work" above (Closes #39).
- [x] Tests added or updated for new logic — N/A; doc-only PR.
- [x] Docs updated if applicable — design.md Document history entry added; ADRs are intrinsically dated via frontmatter (no Document history per `docs/CLAUDE.md` carve-outs).
- [x] Schema changes — N/A.
- [x] Tested locally end-to-end — markdown previewed; numbering contiguous; index matches files; pointer in design.md resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
