### PR TITLE
34: roadmap split + Star backlog Issues

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -473,91 +473,9 @@ beerio-kart/
     └── uploads/                  # User-uploaded run photos (gitignored)
 ```
 
-## Build Plan (Phases)
+## Build Plan
 
-### Phase 1: Foundation
-- [x] Initialize Rust project with Axum
-- [x] Initialize React project with Vite + Bun + Tailwind
-- [x] Set up SeaORM with SQLite and migrations (all tables including run_flags)
-- [x] Seed MK8 Deluxe data (tracks, cups, characters, bodies, wheels, gliders)
-- [x] Basic auth (register/login with argon2 + JWT)
-- [x] Dockerfiles + compose.yaml
-
-### Phase 2: Deployment
-- [x] Validate single-container Dockerfile on Unraid (multi-stage build already exists from Phase 1)
-- [x] Validate compose.yaml on Unraid (already exists from Phase 1, single service + volumes)
-- [x] Configure Cloudflare tunnel to route domain to the app on Unraid
-- [x] Set Cloudflare encryption mode to **Full (strict)** — Flexible encrypts browser-to-Cloudflare but forwards plaintext to the origin server, which means passwords travel unencrypted on the last hop
-- [x] Verify HTTPS works end-to-end through Cloudflare
-- [x] Test basic auth flow from phone over real network
-- [x] Add .env / config for production vs development settings
-- [x] Upgrade auth to refresh token flow (short-lived access token + HttpOnly refresh cookie + `refresh_token_version` on users)
-
-Note: Deploying early (before core features) keeps the deployment simple and catches infrastructure issues before application complexity grows. The Dockerfile and compose.yaml were created in Phase 1 for local development — Phase 2 validates they work on the actual Unraid server behind Cloudflare.
-
-### Phase 3: Sessions & Run Recording
-- [ ] Session schema: sessions, session_participants, session_races tables + migrations
-- [ ] Add `session_race_id` and `disqualified` columns to runs table (migration)
-- [ ] Session polling endpoint (`GET /sessions/:id` returns full session state; clients poll every 2-3 seconds)
-- [ ] Session lifecycle: create, join, leave, auto-close on inactivity (1 hour)
-- [ ] Host transfer on leave (earliest-joined remaining participant)
-- [ ] Random ruleset (first ruleset — track chosen at random without replacement)
-- [ ] Run entry within session context (time, drink, race setup, DQ option)
-- [ ] Pending race tracking (max 3 in UI, submit in order, skip option)
-- [ ] 5-minute grace period for disconnects before pending races expire
-- [ ] "Skip turn" — any participant can pass the chooser's turn
-- [ ] Drink type selector with inline creation
-- [ ] Previous/preferred defaulting for drink and race setup
-- [ ] Photo upload (separate endpoint)
-- [ ] Auto-flagging for record-breaking runs without photos (DQ'd runs excluded)
-- [ ] Home screen: active sessions list + "Start a Session" primary action + recent runs
-- [ ] Background task: Tokio task to close stale sessions (no activity for 1 hour, check every ~5 min)
-- [ ] User profile endpoints (GET /users, GET /users/:id, PUT /users/:id for preferred setup and drink type)
-- [ ] Drink types API (create, list, get)
-- [ ] Sessions API (create, join, leave, next-track, choose-track, skip-turn, list races)
-- [x] Pre-seeded data read endpoints (characters, bodies, wheels, gliders, cups, tracks)
-- [ ] Runs API (create within session, list, delete, photo upload)
-- [ ] Password change endpoint (`PUT /auth/password`)
-- [ ] justfile with recipes: `dev`, `test`, `entities`, `build`
-
-Note: Solo racing uses a one-person session. Future enhancement: streamline the solo experience by making `session_race_id` nullable on runs and offering a lightweight entry flow without session overhead.
-
-### Phase 4: Session Rulesets
-- [ ] Default ruleset (least leaderboard points chooses; recusal; fallback to random)
-- [ ] Least Played ruleset (track with fewest runs chosen; drink category config at session creation)
-- [ ] Round-robin ruleset ("Can Choose" / "Can't Choose" groups; recusal; reset when empty)
-- [ ] Ruleset selection UI at session creation (brief inline explanations)
-
-Future consideration: allow ruleset changes mid-session (deferred post-MVP).
-
-Required test scenarios per ruleset: normal flow, recusal by one player, recusal by all players, player joins mid-session, player leaves mid-session, host leaves mid-session. Each ruleset needs all six scenarios covered.
-
-### Phase 5: Stats & Leaderboards
-- [ ] Personal stats page (PBs, averages, run count, most-played track, best track)
-- [ ] Session history in profile (date, participants, race count, personal W-L per session)
-- [ ] Full run history with detail view
-- [ ] Per-track time history with chart
-- [ ] Track leaderboard (alcoholic / non-alcoholic / combined toggle; DQ'd runs excluded)
-- [ ] Cup-level leaderboard
-- [ ] Global leaderboard (most track records held)
-- [ ] User rank pinned at bottom of leaderboards
-
-### Phase 6: Social & Head-to-Head
-- [ ] "Players you've competed with" (derived from shared session races)
-- [ ] Head-to-head comparison view (wins/losses derived from session race data; DQ'd runs excluded; ties = 0-0)
-- [ ] Win/loss records (H2H does not distinguish alcoholic vs non-alcoholic — drink category only matters for leaderboards)
-- [ ] Profile page with improvement trends
-- [ ] Flagging a run (user-initiated, with preset reasons + notes + visibility choice)
-- [ ] Admin page (lightweight, env-variable-gated)
-- [ ] Admin: review flagged runs, resolve, edit, or delete
-
-### Phase 7: Camera/OCR (Future)
-- [ ] Photo upload with each run (verification + training data)
-- [ ] Use phone camera to photograph TV screen showing race time
-- [ ] Extract time using OCR (likely browser-side Tesseract.js or similar)
-- [ ] Auto-populate time field from photo
-- [ ] Extract race setup from end-of-race screen
-- [ ] Retire preferred race setup from user profiles once OCR is reliable
+See [`roadmap.md`](./roadmap.md) for the cup-by-cup narrative — goals, scope, deferred work, and success criteria per work-chunk. Status of individual work items lives on the [project board](https://github.com/users/brendanbyrne/projects/3); active-cup work is tracked there as Issues, future-cup work as scope bullets in roadmap.md until each cup goes active.
 
 ## Resolved Decisions
 
@@ -592,3 +510,4 @@ Random ideas that may or may not be pursued.
 - 2026-05-04 — Replaced the "Entity regeneration via justfile recipe" rule with "Hand-written SeaORM entities"; updated the `just (not Make)` example to use `just entities-bootstrap`. Closes the codegen-strategy decision recorded at [`reviews/design/2026-05-02-entity-codegen-strategy.md`](./reviews/design/2026-05-02-entity-codegen-strategy.md). PR-X1.
 - 2026-05-05 — Extracted Data Model section to `data-model.md`. PR 1 of the docs restructure.
 - 2026-05-05 — Replaced the Resolved Decisions bullet list with a pointer to `docs/decisions/`. Each prior bullet distilled into a MADR file (0002–0034). PR 2 of the docs restructure.
+- 2026-05-06 — Replaced the Build Plan section with a one-paragraph pointer to `roadmap.md` (created in this PR). Phase narratives moved to roadmap.md per cup; the 20 unchecked Phase 3 / Milestone Star bullets were filed as GitHub Issues (#46, #47, #49, #50, #51, #54, #56, #58, #59, #61, #62, #63, #64, #65, #66, #67, #70, #71, #72, #73) under Milestone Star. PR 3 of the docs restructure.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,203 @@
+# Beerio Kart roadmap
+
+Where Beerio Kart is going at the cup-by-cup level. Status of individual work items lives on the [project board](https://github.com/users/brendanbyrne/projects/3); this file is the narrative.
+
+## How this works
+
+- **Cups** are GitHub milestones, named after Mario Kart 8 Deluxe cups (Mushroom, Flower, Star, Special, Shell, Banana, Leaf, Lightning, then Crossing/Bell/Egg/Triforce, then the eight Booster Course Pass cups). Cups are claimed in chronological start order — the Nth major work-chunk gets the Nth cup. No semantic mapping; cup names are arbitrary chronological labels.
+- **Issues** under a milestone are the working checklist. One Issue per discrete unit of work; the project board shows their status (Backlog → Ready → In Progress → Done).
+- **This file** is the narrative — each cup gets a section describing the goal, scope, deferred work, and success criteria. When a cup closes, its section keeps a brief retrospective and the cup keeps its name forever.
+- **Future-cup Scope sections double as the future-work record.** Cups not yet active list their work as bullets here, not as GitHub Issues. When a cup becomes the next active work-chunk, its bullets transcribe to Issues at that time and the Scope list in this file gets a "see Milestone X for current status" pointer. This keeps the GitHub Backlog scoped to "things we're committed to right now," not "everything we'd ever want to do."
+
+For the underlying conventions, see [`workflow.md`](./workflow.md) § Milestone lifecycle and [`designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §12.
+
+## Cup mapping
+
+| Cup | Work chunk | Status | Closed |
+|-----|------------|--------|--------|
+| Mushroom | Foundation (was Phase 1) | Closed | 2026-03-31 |
+| Flower | Deployment (was Phase 2) | Closed | 2026-04-02 |
+| Star | Sessions & Run Recording (was Phase 3) | Open, in progress | — |
+| Special | Documentation overhaul (PRs 1–6 of the docs-restructure design record) | Open, in progress | — |
+| Shell | Session Rulesets (was Phase 4) | Future | — |
+| Banana | Stats & Leaderboards (was Phase 5) | Future | — |
+| Leaf | Social & Head-to-Head (was Phase 6) | Future | — |
+| Lightning | (next thing — TBD) | Reserved | — |
+
+OCR work (was Phase 7) is **not** yet milestoned — too speculative to commit to a cup. It gets a cup when it's next-up.
+
+---
+
+## Mushroom — Foundation
+
+**Status:** Closed 2026-03-31.
+
+Initial scaffolding — Rust + Axum backend, React + Vite + Tailwind frontend with Bun, SeaORM with SQLite and migrations for all base tables, MK8 Deluxe seed data (tracks, cups, characters, bodies, wheels, gliders), basic auth (argon2 + JWT), Dockerfile + `compose.yaml`. The cup that proved the stack works end-to-end. Everything since builds on this foundation.
+
+[Milestone Mushroom](https://github.com/brendanbyrne/beerio-kart/milestone/1)
+
+---
+
+## Flower — Deployment
+
+**Status:** Closed 2026-04-02.
+
+Single-container Docker on Unraid, Cloudflare Tunnel + Full-strict TLS (per ADR 0033), refresh-token auth (short access token + HttpOnly refresh cookie per ADR 0031), prod/dev config split, password change endpoint. Brought the app online in production. After Flower the app could be reached from any phone over HTTPS with secure auth.
+
+[Milestone Flower](https://github.com/brendanbyrne/beerio-kart/milestone/2)
+
+---
+
+## Star — Sessions & Run Recording
+
+**Status:** Open, in progress.
+
+**Goal.** The core gameplay loop: friends gather, start a session, race tracks together, submit times, see results. Sessions hold a sequence of races; runs belong to session races; pending races get tracked when someone disconnects mid-session.
+
+**Scope.**
+
+- Session lifecycle: create, join, leave, auto-close after inactivity, host transfer on leave.
+- Session races: track choice (Random ruleset for MVP), `skip turn` to pass a stalled chooser.
+- Run entry within session context: time, drink type, race setup, DQ flag, optional photo.
+- Pending race tracking: 3-deep UI cap, submit-in-order, skip option, 5-minute grace on disconnect.
+- Photo upload (separate endpoint) and auto-flagging for record-breaking runs without photos (per ADR 0025).
+- Supporting APIs: users, drink types, runs, sessions, pre-seeded data reads.
+- Background task: stale session cleanup (Tokio).
+- Home screen: active sessions list + "Start a Session" primary action + recent runs.
+- Build chore: `justfile` recipes for `dev`, `test`, `entities`, `build`.
+
+**Deferred to later cups.**
+
+- All non-Random rulesets (Default, Least Played, Round-robin) → Shell.
+- Stats / leaderboards / personal history → Banana.
+- Rivals lists, H2H comparisons, admin page, flagging UI → Leaf.
+
+**Success criteria.** A friend group can start a session, race, submit times, and see the session's race history. Random is the only available ruleset. Photos verify record-breaking runs. The H2H derivation (per ADR 0010) functions correctly when reads land in Banana.
+
+[Milestone Star](https://github.com/brendanbyrne/beerio-kart/milestone/3)
+
+---
+
+## Special — Documentation overhaul
+
+**Status:** Open, in progress.
+
+**Goal.** Restructure `docs/` from a few large files into a coherent multi-doc structure: ADRs in `decisions/`, design records in `designs/`, narrative in `roadmap.md` and `design.md`, an operational `workflow.md`, and CLAUDE.md files at the right scopes. Settled in [`designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md).
+
+**Scope.** PRs 1–6 of the docs-restructure design record:
+
+- PR 1 — foundation (workflow.md, ADR scaffolding, Issue/PR templates, link-check workflow, `reviews/` migration, data-model extraction). Merged.
+- PR 2 — Resolved Decisions section → 33 ADRs in `decisions/`. Merged.
+- PR 3 — this file + spawn the Star backlog as Issues. (You are reading the result of this PR's first deliverable.)
+- PR 4 — merge `design.md`'s API Surface section into `api-contract.md`; move User Workflows + UI Screens into a new `workflows.md`.
+- PR 5 — final `design.md` trim to ~250 lines + repo-root `README.md` + cross-reference cleanup.
+- PR 6 (optional) — nested `backend/CLAUDE.md` and `frontend/CLAUDE.md`.
+
+**Deferred.** Periodic maintenance and follow-up cleanups (e.g., the `lychee` flip-back from `fail: false` → `fail: true` after PR 5) live in their own follow-up Issues, not Special's scope.
+
+**Success criteria.** New contributors find what they need in under five minutes via the index in `docs/README.md`. Design records are durable; ADRs are searchable by topic; the working checklist lives on the project board, not in markdown.
+
+[Milestone Special](https://github.com/brendanbyrne/beerio-kart/milestone/4)
+
+---
+
+## Shell — Session Rulesets
+
+**Status:** Future.
+
+**Goal.** Three additional rulesets beyond Star's Random, plus the ruleset selection UI at session creation.
+
+**Scope.**
+
+- Default ruleset — lowest-leaderboard-points player chooses, with recusal; falls back to random when everyone recuses. Tiebreaker: oldest account creation time.
+- Least Played ruleset — track with fewest runs in the chosen drink category. Drink-category config picked at session creation; defaults to the host's preferred drink category.
+- Round-robin ruleset — "Can Choose" / "Can't Choose" groups; recusal moves you to "Can't Choose"; resets when "Can Choose" is empty.
+- Ruleset selection UI at session creation, with brief inline explanations of each.
+
+Each ruleset is its own Rust trait impl per ADR 0022. **Six test scenarios per ruleset** (normal flow, recusal by one, recusal by all, mid-session join, mid-session leave, host leave) — 24 effective items behind the four deliverables.
+
+**Deferred.** Mid-session ruleset changes (deferred per ADR 0017).
+
+**Success criteria.** All four rulesets pass the six-scenario test matrix. Ruleset selection is a one-tap choice at session creation with brief inline explanations.
+
+[Milestone Shell](https://github.com/brendanbyrne/beerio-kart/milestone/5)
+
+---
+
+## Banana — Stats & Leaderboards
+
+**Status:** Future.
+
+**Goal.** Read-only views over accumulated run data: personal stats, per-track time-series with charts, session history in profile, track / cup / global leaderboards with the drink-category toggle (alcoholic / non-alcoholic / combined), user-rank pinned at the bottom.
+
+**Scope.**
+
+- Personal stats page — PBs, averages, run count, most-played track, best track.
+- Session history in profile — date, participants, race count, personal W-L per session. Tap into a session for race-by-race breakdown.
+- Full run history with detail view, paginated per ADR 0032.
+- Per-track time-series chart of all runs.
+- Track leaderboard — alcoholic / non-alcoholic / combined toggle (per ADR 0006); DQ'd runs excluded (per ADR 0012); user's preferred drink category sets the default toggle position.
+- Cup-level leaderboard — same toggle.
+- Global leaderboard — most track records held (per ADR 0003).
+- User rank pinned at the bottom of leaderboards when not in the top N.
+
+**Success criteria.** A user can find their PB on any track in two taps. Leaderboards refresh as runs come in. The drink-category toggle feels natural, not buried.
+
+[Milestone Banana](https://github.com/brendanbyrne/beerio-kart/milestone/6)
+
+---
+
+## Leaf — Social & Head-to-Head
+
+**Status:** Future.
+
+**Goal.** The social layer: rivals lists, H2H comparison views, profile pages with improvement trends, run flagging (user-initiated), and the admin page (env-variable-gated) for resolving flags.
+
+**Scope.**
+
+- "Players you've competed with" — derived from shared session races (no separate table per ADR 0010).
+- Head-to-head comparison view — wins / losses / ties derived per ADR 0010. DQ'd runs excluded; ties count as 0-0 draws.
+- Win/loss records — H2H does not distinguish alcoholic vs non-alcoholic (drink category matters for leaderboards only).
+- Profile page with improvement trends.
+- Flagging a run — user-initiated, preset reasons + freeform note + visibility choice (`hide_while_pending` per ADR 0029). User can only flag their own runs, and only if a photo is attached.
+- Admin page — lightweight, env-variable-gated (per ADR 0008 / 0019).
+- Admin actions on flagged runs — resolve, edit-and-resolve (admin-only exception to immutability per ADR 0009), or delete.
+
+**Success criteria.** From any player's profile, see your H2H record against them in one tap. Flagged runs appear in admin's queue with all the context needed to resolve.
+
+[Milestone Leaf](https://github.com/brendanbyrne/beerio-kart/milestone/7)
+
+---
+
+## Lightning — Reserved
+
+The next major work-chunk after Leaf claims this cup. No specific assignment yet. OCR (see below) is the most likely candidate.
+
+---
+
+## OCR — no cup assigned yet
+
+The eventual goal: photograph the in-game results screen → automatic time extraction. Reduces manual-entry friction, increases verification quality (closes the unrelated-photo loophole flagged in ADR 0025), and retires the preferred-race-setup field on profiles.
+
+**Scope (when this becomes a cup).**
+
+- Photo capture with each run for verification + OCR training data (some of this lands incidentally in Star's auto-flag mechanism).
+- Use phone camera to photograph the TV screen showing race time.
+- Extract time via OCR — `docs/research/ocr-strategy.md` covers the candidate-tools survey. Likely browser-side (Tesseract.js or similar).
+- Auto-populate the time field from the photo.
+- Extract race setup from the end-of-race screen.
+- Retire the preferred-race-setup fields on user profiles once OCR is reliable as the default path.
+
+When OCR becomes the next active work-chunk, it claims a cup name (likely Lightning per chronological order) and the bullets above transcribe to Issues at that time. Until then, this section is the canonical record.
+
+---
+
+## Future cups not yet allocated
+
+The remaining pool: Crossing, Bell, Egg, Triforce (MK8 Deluxe additions); Golden Dash, Lucky Cat, Turnip, Propeller, Rock, Moon, Fruit, Boomerang (Booster Course Pass). 20 cups in total — enough for any plausible Beerio Kart lifetime. Cups get claimed when their work-chunk starts.
+
+---
+
+## Document history
+
+- 2026-05-06 — Initial creation as part of PR 3 of the documentation restructure. Sourced from `docs/design.md`'s Build Plan section (which gets a pointer paragraph in the same PR) and the cup-mapping table from `docs/designs/2026-05-04-design-doc-restructure.md` §12.2.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -195,9 +195,3 @@ When OCR becomes the next active work-chunk, it claims a cup name (likely Lightn
 ## Future cups not yet allocated
 
 The remaining pool: Crossing, Bell, Egg, Triforce (MK8 Deluxe additions); Golden Dash, Lucky Cat, Turnip, Propeller, Rock, Moon, Fruit, Boomerang (Booster Course Pass). 20 cups in total — enough for any plausible Beerio Kart lifetime. Cups get claimed when their work-chunk starts.
-
----
-
-## Document history
-
-- 2026-05-06 — Initial creation as part of PR 3 of the documentation restructure. Sourced from `docs/design.md`'s Build Plan section (which gets a pointer paragraph in the same PR) and the cup-mapping table from `docs/designs/2026-05-04-design-doc-restructure.md` §12.2.


### PR DESCRIPTION
## Reviewer notes

PR 3 of the docs restructure. Two non-mechanical bits worth review:

1. **`roadmap.md` content.** Cowork-drafted; reviewer should sanity-check that the future-cup Scope sections (Shell, Banana, Leaf, OCR) faithfully cover what was in `design.md`'s old Phase 4–7. The Star section should match what's filed as Issues.
2. **`design.md` Build Plan replacement.** The diff drops ~85 lines (full phase listings) and adds 3. Verify nothing referenced the dropped lines from elsewhere in `design.md` or other docs.

The 20 Star backlog Issues (#46–#73, listed in the new `design.md` Document history entry) were filed by Cowork via MCP before this PR opened. They are NOT created by this PR — only the doc moves are.

Side commit on `main` (`0d74965`) ahead of this PR: `docs/workflow.md` is now the canonical home for the gh token scopes / `INSUFFICIENT_SCOPES` recovery — `.claude/CLAUDE.md` § GitHub access trimmed to a one-line pointer. Unrelated to PR 3's content; handled separately on `main` per the doc-only carve-out.

## Summary

Implements PR 3 of the docs restructure: creates `docs/roadmap.md` from the cup-name convention; replaces `docs/design.md`'s Build Plan section with a one-paragraph pointer; documents the 20 Star backlog Issues filed under Milestone Star.

## Linked work

- Closes #34
- Implements PR 3 of [`docs/designs/2026-05-04-design-doc-restructure.md`](docs/designs/2026-05-04-design-doc-restructure.md) §9 + §13.

## How to verify

- [ ] `head -1 docs/roadmap.md` is `# Beerio Kart roadmap`.
- [ ] `grep -c '^## Build Plan$' docs/design.md` is 1; the section is exactly the pointer paragraph.
- [ ] `ls docs/drafts/` shows only `.gitkeep` (both `WIP_pr3-*` files removed).
- [ ] `tail -1 docs/design.md` is the new Document history entry.
- [ ] `git log --oneline 34/roadmap-split ^main | wc -l` is 2 (one commit per Step).
- [ ] All 20 referenced Issue numbers exist on GitHub under Milestone Star: `gh issue list -m "Star: Sessions & Run Recording" --state all --json number --jq '[.[].number] | sort'` includes 46, 47, 49, 50, 51, 54, 56, 58, 59, 61, 62, 63, 64, 65, 66, 67, 70, 71, 72, 73.

## Author checklist

- [x] Linked to an Issue under "Linked work" above (Closes #34).
- [x] Tests added or updated for new logic — N/A; doc-only PR.
- [x] Docs updated if applicable — `docs/design.md` Document history entry added; `roadmap.md` is carved out of the Document history rule per `docs/CLAUDE.md` (it's task-tracking, not narrative-rules).
- [x] Schema changes — N/A.
- [x] Tested locally end-to-end — markdown previewed; cross-references checked; head/tail of both files match expectations.

## Note on commit count vs. handoff suggestion

The handoff suggested three commits including a third for "remove the Cowork-internal Haiku batch draft (Issues filed via MCP)". That third commit isn't here because both WIP drafts (`WIP_pr3-roadmap.md`, `WIP_pr3-star-issues.md`) were untracked when I picked up the work — they were never committed to git, so removing them is a local-disk operation with no commit equivalent. Mentioned in the first commit's body so the cleanup is recorded somewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)