### PR TITLE
ci: SHA-pin third-party actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"
     groups:
       actions:
         patterns:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,20 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: backend
 
@@ -40,7 +43,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: backend/lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: backend
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       # Two-pass retry: most runs end at attempt 1. Attempt 2 fires only
@@ -35,7 +35,7 @@ jobs:
       - name: Run lychee (attempt 1)
         id: lychee1
         continue-on-error: true
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --verbose --no-progress --max-retries 4 --retry-wait-time 3 --timeout 30 --exclude-path docs/drafts --exclude-path docs/handoffs './**/*.md'
           fail: true
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lychee (attempt 2 if attempt 1 failed)
         if: steps.lychee1.outcome == 'failure'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --verbose --no-progress --max-retries 4 --retry-wait-time 3 --timeout 30 --exclude-path docs/drafts --exclude-path docs/handoffs './**/*.md'
           fail: true


### PR DESCRIPTION
## Summary

Replaces every `uses:` floating tag with the commit SHA it currently resolves to, with the human-readable version preserved as a trailing comment. Adds `.github/dependabot.yml` so Dependabot watches for new releases and opens a PR each week to bump the SHAs. Without Dependabot, SHA pins go stale and stop receiving security fixes — the two changes are a package, not separable.

### Why pin

Floating tags (`@v4`, `@stable`, `@v2`) are mutable: the action maintainer can repoint them at any commit, including malicious code if their account is compromised. This is not theoretical — `tj-actions/changed-files` was hijacked in March 2025 and leaked secrets from thousands of repos. Pinning to a 40-char SHA makes the reference immutable; the only way it changes is via an explicit PR (which Dependabot generates and you review).

Recommended by [GitHub's hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard's `Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies).

### Per-action notes

Two actions used non-standard tag patterns where the tag *is* the input parameter (`@stable`, `@cargo-llvm-cov`). Dependabot can't reason about those well, and pinning a branch ref's SHA is brittle. I switched both to canonical versioned tags with the input passed explicitly:

| Action | Before | After |
|---|---|---|
| `dtolnay/rust-toolchain` | `@stable` (branch) | `@e97e2d8…  # v1` + `toolchain: stable` |
| `taiki-e/install-action` | `@cargo-llvm-cov` (shortcut) | `@cca35ed…  # v2.77.1` + `tool: cargo-llvm-cov` |

The behavior is identical; the references are now Dependabot-trackable.

### Dependabot grouping

Six tracked actions × weekly schedule would mean up to six PRs/week. The `groups: actions: patterns: ["*"]` block bundles them into a single weekly PR. If you'd rather see them individually (to roll back one without the others), drop the `groups` block.

### Conflict with [#85](https://github.com/brendanbyrne/beerio-kart/pull/85)

This PR is branched from `main`, not from #85, per the project's squash-merge convention (stacking would silently lose this PR's content when #85 squashes). After #85 merges, this PR will conflict on the `uses:` lines — the resolution is mechanical (keep both: the SHA pin **and** the `persist-credentials: false` block on `actions/checkout`). I'm happy to rebase once #85 lands; just ping me.

### Out of scope (intentionally)

`package-ecosystem: cargo` and `package-ecosystem: bun` (or `npm`) for the backend and frontend dependency trees. Those are bigger decisions about dep-bump cadence — open as a separate question once you've seen how the GH Actions cadence feels.

## Test plan

- [ ] **Re-run both workflows on this PR.** This PR touches `.github/workflows/*.yml` and `.github/dependabot.yml` but no `.md`, so the `paths:` filter on `link-check` will skip. Force a run by editing any markdown file (or just push a trivial md edit on this branch). Coverage runs unconditionally on PR.
- [ ] **Confirm coverage workflow still passes.** All four pinned actions need to actually load and run: checkout, rust-toolchain, install-action, rust-cache, codecov-action. A typo in any SHA would surface as `Unable to resolve action`.
- [ ] **Confirm link-check workflow still passes.** Same check for the lychee pin.
- [ ] **Confirm Dependabot picks up the config.** After merge, visit the repo's "Insights → Dependency graph → Dependabot" tab. The `github-actions` ecosystem should appear there. (No PR will fire immediately — Dependabot waits for its weekly schedule, but the config is detected within a few minutes.)
- [ ] **Optional sanity check via local YAML parse.** `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` — should produce no output if the file is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)