### PR TITLE
89: clean up stale reviews/design and reviews/pr references

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -149,7 +149,7 @@ Notes on the API:
 
 After posting, verify with `gh api repos/<owner>/<repo>/pulls/<number>/reviews/<review-id>/comments --jq '.[] | {path, position, body: (.body[0:80])}'` — `position` (legacy diff-position field) being non-null confirms the inline anchored correctly even when `line` returns null.
 
-**Confirm with the user before posting.** Posting publishes findings to anyone who can see the PR. Once approved, post via the single review POST as the default mechanism — no other tiers, no markdown file in `reviews/pr/`. The `reviews/pr/` directory was retired by `docs/designs/2026-05-04-design-doc-restructure.md` § 8.8: PR review feedback now lives entirely on GitHub.
+**Confirm with the user before posting.** Posting publishes findings to anyone who can see the PR. Once approved, post via the single review POST as the default mechanism — no other tiers, no markdown file output. PR review feedback lives entirely on GitHub per `docs/designs/2026-05-04-design-doc-restructure.md` § 8.8.
 
 ## What to look for
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -38,7 +38,7 @@ Integration tests live in [`tests/`](./tests); unit tests live inline as `#[cfg(
 | `src/routes/` | HTTP handlers (one file per resource) |
 | `src/services/` | Business logic (called from routes) |
 | `src/middleware/` | Auth, admin checks |
-| `src/entities/` | SeaORM-generated entity types (do not hand-edit) |
+| `src/entities/` | Hand-written SeaORM entity types (per ADR 0023) |
 | `src/domain/` | Hand-written domain types (IDs, enums, validated newtypes) |
 | [`migration/`](./migration) | Schema migrations (workspace member crate) |
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,7 +54,7 @@ Before opening a PR that touches the backend, skim these:
 - **[`../docs/api-contract.md`](../docs/api-contract.md)** — Wire-format decisions (error codes, ETag polling, idempotency keys, time format).
 - **[`../docs/compliance-plan.md`](../docs/compliance-plan.md)** — Sequenced PRs to bring the existing code to the standard. If you're picking work, look here.
 
-If a PR introduces a pattern not covered by the standards, propose an addition in a `reviews/design/` checkbox session before merging.
+If a PR introduces a pattern not covered by the standards, propose an addition in a design record under [`../docs/designs/`](../docs/designs) before merging.
 
 ## Justfile recipes
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,11 +35,11 @@ Integration tests live in [`tests/`](./tests); unit tests live inline as `#[cfg(
 | [`src/main.rs`](./src/main.rs) | Server bootstrap, routing, middleware, shutdown |
 | [`src/config.rs`](./src/config.rs) | Environment / config loading |
 | [`src/error.rs`](./src/error.rs) | Unified `AppError` and `IntoResponse` |
-| `src/routes/` | HTTP handlers (one file per resource) |
-| `src/services/` | Business logic (called from routes) |
-| `src/middleware/` | Auth, admin checks |
-| `src/entities/` | Hand-written SeaORM entity types (per ADR 0023) |
-| `src/domain/` | Hand-written domain types (IDs, enums, validated newtypes) |
+| [`src/routes/`](./src/routes) | HTTP handlers (one file per resource) |
+| [`src/services/`](./src/services) | Business logic (called from routes) |
+| [`src/middleware/`](./src/middleware) | Auth, admin checks |
+| [`src/entities/`](./src/entities) | Hand-written SeaORM entity types (per ADR 0023) |
+| [`src/domain/`](./src/domain) | Hand-written domain types (IDs, enums, validated newtypes) |
 | [`migration/`](./migration) | Schema migrations (workspace member crate) |
 
 ## Required reading

--- a/backend/tests/schema_drift.rs
+++ b/backend/tests/schema_drift.rs
@@ -2,7 +2,7 @@
 //! `backend/src/entities/` can load from a freshly-migrated database.
 //!
 //! Implements PR-X2 / § 7 of
-//! `reviews/design/2026-05-02-entity-codegen-strategy.md`. Now that entities
+//! `docs/designs/2026-05-02-entity-codegen-strategy.md`. Now that entities
 //! are committed source (per `coding-standards/seaorm.md` § 6), codegen no
 //! longer acts as an implicit drift-checker between migration and entity.
 //! This test replaces that signal with a single CI-time guarantee: for every

--- a/docs/compliance-plan.md
+++ b/docs/compliance-plan.md
@@ -370,7 +370,7 @@ The largest phase. Each PR is independently reviewable; sequence keeps blast rad
 - **Scope:**
   - Update `.claude/` (or wherever the code-review skill is configured) to read `docs/coding-standards/README.md` first when starting a review.
   - The skill should identify which area files (`rust.md`, `seaorm.md`, `tokio.md`) the PR diff touches and load only those.
-  - Findings get written to `reviews/pr/` (existing convention).
+  - Findings get posted as GitHub PR review comments (line-anchored where possible) per [`docs/designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §8.8.
 - **Standards refs:** Workflow improvement; not a code rule.
 - **Effort:** S–M.
 - **Dependencies:** Doc split lands (already done).
@@ -464,3 +464,4 @@ Some PRs (B1, B3, E3, X1) have no dependencies and can land in parallel with A1/
 - 2026-05-04 — Marked PR-B3 sign-off complete (merged 2026-05-04 as PR #27).
 - 2026-05-05 — Renamed `Phase A`–`Phase J` to `Stream A`–`Stream J` throughout to free the `Phase` namespace for build phases only, per the cup-name milestone convention adopted in the design record's 2026-05-05 amendment ([`docs/designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §12.5 #2).
 - 2026-05-08 — Repaired two broken `reviews/design/` markdown links in document history entries (lines 461, 465). Old `../reviews/design/...` paths now point at `./designs/...` per the PR 1 migration. Closes part of Issue #42. PR 5 of the docs restructure.
+- 2026-05-08 — Updated PR-I1 scope: "Findings get written to `reviews/pr/`" → "Findings get posted as GitHub PR review comments per [`docs/designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §8.8." `reviews/pr/` was retired in the docs restructure; live-prose references should match the new convention. Closes part of [#89](https://github.com/brendanbyrne/beerio-kart/issues/89).


### PR DESCRIPTION
## Reviewer notes

The Issue body listed three live-prose sites; while sweeping I found a fourth (`.claude/skills/code-review/SKILL.md:152`) with the same shape — live operational prose pointing at the retired `reviews/pr/` path. Included it for consistency since the AC's grep test expected zero live-prose hits.

Document history entry added only to `docs/compliance-plan.md` — the other three edited files are out of scope of the doc-history rule (`.claude/skills/`, `backend/README.md`, and a Rust source file).

The remaining `git grep -E 'reviews/(design|pr)/'` hits all live in either `docs/designs/` (intentional design-record narrative — explicitly allowed by AC) or in `Document history` entries inside `docs/coding-standards/seaorm.md`, `docs/compliance-plan.md`, `docs/research/ci-options.md`. History entries are durable narrative by convention and are not "live prose" — preserving them is correct.

**Added scope (out-of-Issue but folded in):** Two fixes to the `backend/README.md` Layout table, same shape of staleness as the `reviews/` references (doc lagging behind reality), and the file was already open in this PR:

1. The `src/entities/` row described entities as "SeaORM-generated entity types (do not hand-edit)" — the literal inverse of ADR 0023's accepted decision to commit hand-written entities.
2. The five `src/<subdir>/` rows (`routes/`, `services/`, `middleware/`, `entities/`, `domain/`) were unlinked, while every other navigable target in the table (`src/main.rs`, `src/config.rs`, `src/error.rs`, `migration/`) was a markdown link. The unlinked-ness was a freeze-in-place from when the directories were skeletal — they all have real content now. Linked all five for consistency.

## Summary

The `reviews/design/` and `reviews/pr/` directories were retired in PR 1 of the docs restructure ([`docs/designs/2026-05-04-design-doc-restructure.md`](../blob/main/docs/designs/2026-05-04-design-doc-restructure.md) §8.8). Four live-prose sites still pointed at the retired paths; this PR rewrites all four to reference the current conventions (design records under `docs/designs/`, PR-review feedback on GitHub).

## Linked work

- Closes #89
- Per [`docs/designs/2026-05-04-design-doc-restructure.md`](../blob/main/docs/designs/2026-05-04-design-doc-restructure.md) §8.8

## How to verify

- [ ] **Live-prose grep returns no hits** (only design-record narrative in `docs/designs/` and history entries):

  ```bash
  git grep -nE 'reviews/(design|pr)/' | grep -v 'docs/designs/' | grep -vE '^[^:]+:[0-9]+:- 2026-'
  # → empty
  ```

- [ ] **Each rewritten site reads sensibly in context:**
  - [`backend/README.md:57`](../blob/89/cleanup-stale-reviews-refs/backend/README.md#L57)
  - [`backend/tests/schema_drift.rs:5`](../blob/89/cleanup-stale-reviews-refs/backend/tests/schema_drift.rs#L5)
  - [`docs/compliance-plan.md:373`](../blob/89/cleanup-stale-reviews-refs/docs/compliance-plan.md#L373)
  - [`.claude/skills/code-review/SKILL.md:152`](../blob/89/cleanup-stale-reviews-refs/.claude/skills/code-review/SKILL.md#L152)

- [ ] **`docs/designs/2026-05-02-entity-codegen-strategy.md` exists** at the new path (the schema_drift.rs doc-comment now points there):

  ```bash
  ls docs/designs/2026-05-02-entity-codegen-strategy.md
  ```

- [ ] **Build + tests still pass** (the schema_drift.rs change is doc-comment only, no logic):

  ```bash
  cd backend && cargo build && cargo test --test schema_drift
  ```

## Author checklist

- [x] Linked to Issue #89.
- [x] Tests added or updated — N/A, doc-comment + prose changes only.
- [x] Docs updated: `docs/compliance-plan.md` got a Document history entry.
- [x] Schema changes — N/A.
- [x] Tested locally — verification grep returns empty; cargo build/test untouched (no logic changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
