### PR TITLE
audit: record §1.5 leave_session BadRequest divergence

### DIFF
--- a/docs/designs/2026-04-15-rust-audit.md
+++ b/docs/designs/2026-04-15-rust-audit.md
@@ -139,6 +139,8 @@ Examples where the HTTP status feels off:
 
 Re-classify the above under this rule. "Session closed" errors become 409.
 
+**Divergence noted (2026-05-09):** `leave_session` kept `BadRequest` for "Not currently in this session" rather than re-classifying to `Conflict`. Reasoning is captured inline at [`backend/src/services/sessions.rs:859-863`](../../backend/src/services/sessions.rs#L859-L863): `require_active_participant` returns `Forbidden` (an authorization guard), but trying to leave a session you aren't in is bad input from the client (wrong session named) rather than a state clash on the server. `Conflict` would imply "valid input but clashes with server state," which doesn't fit. The other call sites in the list above were re-classified per the rule.
+
 - [x] Approved
 - [ ] Needs discussion
 - [ ] Skip
@@ -670,3 +672,10 @@ If most of this is approved, I'd suggest splitting into three PRs for digestibil
 **PR 1: "Low-level primitives"** — Sections 1.2 (enums), 2.1 (load_active_session), 2.2 (require_participant), 2.3 (touch_session), 2.6 (test helpers), 1.4 (timestamp helpers). Pure additions; existing call sites unchanged. Foundation for the others.
 
 **PR 2: "Apply primitives, collapse duplication"** — Rewrite `join_session`, `leave_session`, `next_track`, `skip_turn`, `create_run`, `delete_run` to use the primitives from PR 1. Apply 2.4 (FK helpers), 2.5 (pick_random_track), 3.1 (decompose get_session_detail), 3.2 (decompose create_run), 3.3 (
+
+---
+
+## Document history
+
+- 2026-05-05 — Audit content (authored 2026-04-15) migrated into `docs/designs/` as part of PR 1 (docs restructure foundation, commit `31f90bd`).
+- 2026-05-09 — Added §1.5 "Divergence noted" subsection recording that `leave_session::BadRequest` is a deliberate departure from the rule, with a cross-reference to the inline rationale at [`backend/src/services/sessions.rs:859-863`](../../backend/src/services/sessions.rs#L859-L863). Per Issue [#81](https://github.com/brendanbyrne/beerio-kart/issues/81).

--- a/docs/designs/2026-04-15-rust-audit.md
+++ b/docs/designs/2026-04-15-rust-audit.md
@@ -139,7 +139,7 @@ Examples where the HTTP status feels off:
 
 Re-classify the above under this rule. "Session closed" errors become 409.
 
-**Divergence noted (2026-05-09):** `leave_session` kept `BadRequest` for "Not currently in this session" rather than re-classifying to `Conflict`. Reasoning is captured inline at [`backend/src/services/sessions.rs:859-863`](../../backend/src/services/sessions.rs#L859-L863): `require_active_participant` returns `Forbidden` (an authorization guard), but trying to leave a session you aren't in is bad input from the client (wrong session named) rather than a state clash on the server. `Conflict` would imply "valid input but clashes with server state," which doesn't fit. The other call sites in the list above were re-classified per the rule.
+**Divergence noted (2026-05-09):** `leave_session` kept `BadRequest` for "Not currently in this session" rather than re-classifying to `Conflict` or `NotFound`. Reasoning is captured inline at [`backend/src/services/sessions.rs:859-863`](../../backend/src/services/sessions.rs#L859-L863): `require_active_participant` returns `Forbidden` (an authorization guard), but trying to leave a session you aren't in is bad input from the client (wrong session named) rather than a state clash on the server. `Conflict` would imply "valid input but clashes with server state," which doesn't fit. `NotFound` would also be ambiguous — the session resource exists; only the participation doesn't. The other call sites in the list above were re-classified per the rule.
 
 - [x] Approved
 - [ ] Needs discussion


### PR DESCRIPTION
## Summary

- Adds a "Divergence noted (2026-05-09)" subsection to `docs/designs/2026-04-15-rust-audit.md` §1.5, recording that `leave_session::BadRequest` is a deliberate departure from the recommended `Conflict` reclassification.
- Cross-references the inline rationale at [`backend/src/services/sessions.rs:859-863`](../blob/main/backend/src/services/sessions.rs#L859-L863): naming a session you aren't in is bad client input, not server-state conflict.
- Adds the missing `## Document history` section to the audit doc (per `docs/CLAUDE.md` history rule for `docs/designs/*` records).

Closes #81.

## Test plan

Doc-only change. To verify:

- [ ] Open [`docs/designs/2026-04-15-rust-audit.md`](../blob/main/docs/designs/2026-04-15-rust-audit.md) on the PR branch.
- [ ] Scroll to §1.5 (around line 140). Confirm the new **Divergence noted (2026-05-09)** paragraph reads cleanly between the "Re-classify the above..." sentence and the sign-off checkbox block.
- [ ] Click the `backend/src/services/sessions.rs:859-863` link in that paragraph; confirm it lands on the inline comment block above the `BadRequest` mapping in `leave_session`.
- [ ] Scroll to the bottom of the file. Confirm the new `## Document history` section appears after the `Implementation Strategy` section, with two dated bullets (2026-05-05 initial migration, 2026-05-09 this change).
- [ ] Run `git diff main..HEAD -- docs/designs/2026-04-15-rust-audit.md`; confirm only the §1.5 paragraph and the trailing Document history section are changed (no other lines touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)