### PR TITLE
audit: extract validate_run_request from create_run (§3.2)

### DIFF
--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -157,7 +157,7 @@ pub async fn create_run(
     body: CreateRunRequest,
 ) -> Result<RunDetail, AppError> {
     let session_race = validate_run_request(db, user_id, &body).await?;
-    let run_id = insert_run(db, user_id, &body, &session_race).await?;
+    let run_id = insert_run(db, user_id, body, &session_race).await?;
     get_run(db, &run_id).await
 }
 
@@ -277,7 +277,7 @@ async fn validate_run_request(
 async fn insert_run(
     db: &DatabaseConnection,
     user_id: &UserId,
-    body: &CreateRunRequest,
+    body: CreateRunRequest,
     session_race: &session_races::Model,
 ) -> Result<RunId, AppError> {
     let now = Utc::now().naive_utc();
@@ -288,7 +288,7 @@ async fn insert_run(
     runs::ActiveModel {
         id: Set(run_id.as_str().to_string()),
         user_id: Set(user_id.as_str().to_string()),
-        session_race_id: Set(body.session_race_id.clone()),
+        session_race_id: Set(body.session_race_id),
         track_id: Set(session_race.track_id),
         character_id: Set(body.character_id),
         body_id: Set(body.body_id),
@@ -298,7 +298,7 @@ async fn insert_run(
         lap1_time: Set(body.lap1_time),
         lap2_time: Set(body.lap2_time),
         lap3_time: Set(body.lap3_time),
-        drink_type_id: Set(body.drink_type_id.clone()),
+        drink_type_id: Set(body.drink_type_id),
         disqualified: Set(body.disqualified),
         photo_path: Set(None),
         created_at: Set(now),

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -148,15 +148,40 @@ fn validate_time_fields(body: &CreateRunRequest) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Create a run for a session race. Validates all inputs before inserting.
+/// Create a run for a session race. Top-level orchestrator: validate, insert,
+/// fetch. The validation surface and the transactional insert each live in
+/// their own helper below.
 pub async fn create_run(
     db: &DatabaseConnection,
     user_id: &UserId,
     body: CreateRunRequest,
 ) -> Result<RunDetail, AppError> {
-    validate_time_fields(&body)?;
+    let session_race = validate_run_request(db, user_id, &body).await?;
+    let run_id = insert_run(db, user_id, &body, &session_race).await?;
+    get_run(db, &run_id).await
+}
 
-    // Validate session_race exists and belongs to an active session
+/// Run every gate that must pass before a run can be inserted. Returns the
+/// loaded `session_race` so the caller doesn't re-fetch it.
+///
+/// Gates run in this order:
+/// 1. Time-field arithmetic (lap times sum to track time, all within range).
+/// 2. `session_race` exists.
+/// 3. The session is still active.
+/// 4. The user is an active participant in that session.
+/// 5. The user hasn't already submitted a run for this race.
+/// 6. The user hasn't explicitly skipped this race (mutual exclusion with
+///    submit, per docs/design.md "Pending Race Tracking" → "Submission rules").
+/// 7. The user has no older pending race blocking this submission
+///    (ordered-submit guard, same source).
+/// 8. All FK references (character/body/wheel/glider/drink_type) exist.
+async fn validate_run_request(
+    db: &DatabaseConnection,
+    user_id: &UserId,
+    body: &CreateRunRequest,
+) -> Result<session_races::Model, AppError> {
+    validate_time_fields(body)?;
+
     let session_race = session_races::Entity::find_by_id(&body.session_race_id)
         .one(db)
         .await?
@@ -243,6 +268,18 @@ pub async fn create_run(
     helpers::require_exists::<drink_types::Entity, _>(db, body.drink_type_id.clone(), "drink_type")
         .await?;
 
+    Ok(session_race)
+}
+
+/// Insert the run row and bump the session's last_activity_at, atomically.
+/// Returns the new run's ID. Caller is expected to have already validated
+/// the request via `validate_run_request`.
+async fn insert_run(
+    db: &DatabaseConnection,
+    user_id: &UserId,
+    body: &CreateRunRequest,
+    session_race: &session_races::Model,
+) -> Result<RunId, AppError> {
     let now = Utc::now().naive_utc();
     let run_id = RunId::new(Uuid::new_v4().to_string());
 
@@ -261,7 +298,7 @@ pub async fn create_run(
         lap1_time: Set(body.lap1_time),
         lap2_time: Set(body.lap2_time),
         lap3_time: Set(body.lap3_time),
-        drink_type_id: Set(body.drink_type_id),
+        drink_type_id: Set(body.drink_type_id.clone()),
         disqualified: Set(body.disqualified),
         photo_path: Set(None),
         created_at: Set(now),
@@ -270,11 +307,12 @@ pub async fn create_run(
     .insert(&txn)
     .await?;
 
+    let session_id = SessionId::new(session_race.session_id.clone());
     helpers::touch_session(&txn, &session_id).await?;
 
     txn.commit().await?;
 
-    get_run(db, &run_id).await
+    Ok(run_id)
 }
 
 /// Fetch a single run by ID with JOINed username and drink_type_name.

--- a/docs/designs/2026-04-15-rust-audit.md
+++ b/docs/designs/2026-04-15-rust-audit.md
@@ -463,6 +463,8 @@ async fn validate_run_request(
 
 Then `create_run` becomes ~30 lines: validate → insert → touch_session → return.
 
+**Adoption status (2026-05-09):** Extracted `validate_run_request` and `insert_run` from `create_run`. The orchestrator is now 4 lines (validate → insert → fetch). The validation interior was kept cohesive (one helper, not seven) — fragmenting each gate into its own function would hide the validation surface behind names and add parameter-threading noise without buying reuse, since none of the gates have a second caller. Note that the audit's predicted ~30 lines doesn't match reality because two pending-races validation gates were added post-audit (skip mutual-exclusion and ordered-submit guard); `validate_run_request` covers all gates, including the post-audit ones. Per Issue [#83](https://github.com/brendanbyrne/beerio-kart/issues/83).
+
 - [x] Approved
 - [ ] Needs discussion
 - [ ] Skip
@@ -682,3 +684,4 @@ If most of this is approved, I'd suggest splitting into three PRs for digestibil
 - 2026-05-05 — Audit content (authored 2026-04-15) migrated into `docs/designs/` as part of PR 1 (docs restructure foundation, commit `31f90bd`).
 - 2026-05-09 — Added §1.5 "Divergence noted" subsection recording that `leave_session::BadRequest` is a deliberate departure from the rule, with a cross-reference to the inline rationale at [`backend/src/services/sessions.rs:859-863`](../../backend/src/services/sessions.rs#L859-L863). Per Issue [#81](https://github.com/brendanbyrne/beerio-kart/issues/81).
 - 2026-05-09 — Recorded §4.2 adoption status: the four ID newtypes (`UserId`, `SessionId`, `RunId`, `SessionRaceId`) are now plumbed through service signatures, middleware (`AuthUser` / `AdminUser`), route adapters, response DTOs, and test helpers. Per Issue [#82](https://github.com/brendanbyrne/beerio-kart/issues/82).
+- 2026-05-09 — Recorded §3.2 adoption status: `create_run` decomposed into a 4-line orchestrator over `validate_run_request` and `insert_run`. Per Issue [#83](https://github.com/brendanbyrne/beerio-kart/issues/83).


### PR DESCRIPTION
## Summary

Per audit §3.2 (Approved), decompose `services/runs.rs::create_run`. Closes #83.

- `create_run` becomes a 4-line orchestrator: `validate_run_request` → `insert_run` → `get_run`.
- `validate_run_request` runs every gate that must pass before insert: time-field math, session_race lookup, active-session and active-participant checks, duplicate-run check, skip mutual-exclusion check, ordered-submit guard, FK existence checks. Returns the loaded `session_race` so the caller doesn't re-fetch.
- `insert_run` handles the transactional row insert plus `touch_session`. Returns the new run UUID.
- Audit §3.2 updated with adoption status.

The validation interior is **kept cohesive in one helper**, not fragmented per-gate. Splitting each gate into its own function would hide the validation surface behind names and add parameter-threading noise (`db`, `user_id`, `body`, `session_race` on every signature) without buying reuse — every gate has exactly one caller. The current inline-with-comments form documents the validation surface in one screen.

The audit's prediction of ~30 lines for `create_run` reflected pre-pending-races scope. Two gates were added post-audit (skip mutual-exclusion at lines ~190-210 and ordered-submit guard at lines ~212-234 of the pre-extraction code). `validate_run_request` covers all gates, including the post-audit ones.

This is **Option 2** from #83 (extract), not Option 1 (close-with-rationale).

## Test plan

Automated:

- [ ] `cd backend && cargo build --all-targets` — clean.
- [ ] `cd backend && cargo clippy --all-targets -- -D warnings` — clean.
- [ ] `cd backend && cargo test` — 234 tests pass (158 lib + 27 + 21 + 8 + 1 + 19 integration). Test code unchanged.

Behavioral check (the refactor must not change observable behavior):

1. Start backend: `cd backend && cargo run`. Wait for "Listening on" line.
2. Register two users `u1` and `u2` via `POST /auth/register` (capture the access token for each as `T1` and `T2`).
3. Create a session as `u1`: `curl -s -X POST http://127.0.0.1:3000/sessions -H "Authorization: Bearer $T1" -H 'Content-Type: application/json' -d '{"ruleset":"random"}'` — capture `session_id` (`S`) and the first `current_race.id` (`R1`).
4. Have `u2` join the session: `curl -s -X POST http://127.0.0.1:3000/sessions/$S/join -H "Authorization: Bearer $T2"` → expect 204.
5. **Submit a valid run as `u1`** for `R1` (use `lap1+lap2+lap3 == track_time`, valid character/body/wheel/glider/drink IDs from `/game-data` and `/drink-types`): `curl -s -X POST http://127.0.0.1:3000/runs ...` → expect 201 with the full `RunDetail`.
6. **Duplicate-submission gate:** repeat the same POST with the same `session_race_id` → expect 409 `"Already submitted a run for this race"`.
7. **Closed-session gate:** as `u1`, leave the session (`POST /sessions/$S/leave`); the session closes since both participants leave. Then attempt to submit a run for `R1` with a fresh user → expect 409 `"Cannot submit run for a closed session"` (after they re-fetch a token, etc.; or skip — easier to just verify gate 6 covers this path on a fresh closed session).
8. **Order-of-submit gate:** in a fresh session, advance to race 2 via `POST /sessions/$S/next-track`, then attempt to submit a run for race 2 without submitting/skipping race 1 → expect 409 `"Must submit or skip pending race #1 first"`.
9. **Skip mutual-exclusion gate:** in a fresh session at race 1, `POST /sessions/$S/races/$R1/skip` (204), then attempt to submit a run for `R1` → expect 409 `"Cannot submit a run for a skipped race"`.
10. **Time-validation gate:** submit a run where `lap1+lap2+lap3 != track_time` → expect 400 `"Lap times must add up to total time (off by Nms)"`.
11. **FK gate:** submit a run with `character_id: 99999` → expect 400 `"Invalid character_id"`.

Each numbered case exercises one gate inside `validate_run_request`. The expected status codes and error messages are the same as on `main` — the test suite (`tests/runs_pending_races.rs`, `tests/api_integration.rs`, etc.) covers most of these and is passing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)