### PR TITLE
94: migrate AppError to thiserror

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -63,6 +63,7 @@ jsonwebtoken = "9"
 sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.6", features = ["trace", "fs"] }
 tracing = "0.1"

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -4,6 +4,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
+use thiserror::Error;
 use tracing::error;
 
 #[derive(Serialize)]
@@ -16,21 +17,35 @@ struct ErrorBody {
 /// Implements Axum's `IntoResponse`, so handlers can return
 /// `Result<impl IntoResponse, AppError>` and use `?` directly
 /// instead of writing match arms for every fallible call.
-#[derive(Debug)]
+#[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum AppError {
     /// 400 — validation failures, malformed input
+    #[error("{0}")]
     BadRequest(String),
     /// 401 — wrong credentials, expired/missing token
+    #[error("{0}")]
     Unauthorized(String),
     /// 403 — action not permitted for this user
+    #[error("{0}")]
     Forbidden(String),
     /// 404 — resource not found
+    #[error("{0}")]
     NotFound(String),
     /// 409 — state conflict (e.g. closed session) or uniqueness violation (e.g. duplicate username)
+    #[error("{0}")]
     Conflict(String),
     /// 500 — unexpected internal failures (DB, crypto, etc.)
     /// The String is a log-only message; the user sees "Internal server error".
+    #[error("{0}")]
     Internal(String),
+    /// 500 — JWT encode/decode failure. User-visible response is "Internal server error";
+    /// the wrapped error is logged via the source chain at the response boundary.
+    #[error("Token error")]
+    Token(#[from] jsonwebtoken::errors::Error),
+    /// 500 — password hashing/verification failure. Same response semantics as `Token`.
+    #[error("Password hashing error")]
+    Hash(#[from] argon2::password_hash::Error),
 }
 
 impl IntoResponse for AppError {
@@ -41,8 +56,8 @@ impl IntoResponse for AppError {
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
-            AppError::Internal(log_msg) => {
-                error!("{log_msg}");
+            AppError::Internal(_) | AppError::Token(_) | AppError::Hash(_) => {
+                error!("{}", format_error_chain(&self));
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Internal server error".to_string(),
@@ -60,7 +75,22 @@ impl IntoResponse for AppError {
     }
 }
 
+fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source = err.source();
+    while let Some(e) = source {
+        parts.push(e.to_string());
+        source = e.source();
+    }
+    parts.join(": ")
+}
+
 // ── From impls for common error types ──────────────────────────────
+//
+// The `Token` and `Hash` variants get their `From` impls from `#[from]` on the
+// variant. `DbErr` needs hand-written discrimination — different `DbErr`
+// variants map to different `AppError` variants (404 / 409 / 400 / 500), which
+// `#[from]` can't express.
 
 impl From<sea_orm::DbErr> for AppError {
     fn from(e: sea_orm::DbErr) -> Self {
@@ -76,20 +106,10 @@ impl From<sea_orm::DbErr> for AppError {
     }
 }
 
-impl From<jsonwebtoken::errors::Error> for AppError {
-    fn from(e: jsonwebtoken::errors::Error) -> Self {
-        AppError::Internal(format!("Token error: {e}"))
-    }
-}
-
-impl From<argon2::password_hash::Error> for AppError {
-    fn from(e: argon2::password_hash::Error) -> Self {
-        AppError::Internal(format!("Password hashing error: {e}"))
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use sea_orm::{ActiveModelTrait, DbErr, Set};
 
     use super::*;
@@ -179,5 +199,50 @@ mod tests {
             AppError::BadRequest(_) => {}
             other => panic!("expected BadRequest, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_jwt_error_maps_to_token_variant_with_source() {
+        let jwt_err =
+            jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken);
+        let app_err: AppError = jwt_err.into();
+        match &app_err {
+            AppError::Token(_) => {}
+            other => panic!("expected Token, got {other:?}"),
+        }
+        // The wrapped error must be reachable via the source chain so the
+        // `IntoResponse` log gets the underlying jwt detail, not just "Token error".
+        assert!(
+            app_err.source().is_some(),
+            "Token variant should expose its source"
+        );
+    }
+
+    #[test]
+    fn test_argon2_error_maps_to_hash_variant_with_source() {
+        let app_err: AppError = argon2::password_hash::Error::Password.into();
+        match &app_err {
+            AppError::Hash(_) => {}
+            other => panic!("expected Hash, got {other:?}"),
+        }
+        assert!(
+            app_err.source().is_some(),
+            "Hash variant should expose its source"
+        );
+    }
+
+    #[test]
+    fn test_format_error_chain_joins_sources() {
+        let jwt_err =
+            jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken);
+        let app_err: AppError = jwt_err.into();
+        let chain = format_error_chain(&app_err);
+        // First segment is the variant's Display ("Token error"); the second is
+        // the wrapped jwt error's Display, joined by ": ".
+        assert!(chain.starts_with("Token error: "), "got: {chain}");
+        assert!(
+            chain.contains("InvalidToken") || chain.contains("invalid"),
+            "got: {chain}"
+        );
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -76,13 +76,10 @@ impl IntoResponse for AppError {
 }
 
 fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
-    let mut parts = vec![err.to_string()];
-    let mut source = err.source();
-    while let Some(e) = source {
-        parts.push(e.to_string());
-        source = e.source();
-    }
-    parts.join(": ")
+    std::iter::successors(Some(err), |e| e.source())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(": ")
 }
 
 // ── From impls for common error types ──────────────────────────────

--- a/docs/compliance-plan.md
+++ b/docs/compliance-plan.md
@@ -112,6 +112,22 @@ These are real bugs the standard would prevent in new code, surfaced during rese
 - **Verification:** All existing tests pass; error responses look identical to clients.
 - **Sign-off:** [ ]
 
+### PR-C2: Reshape `AppError::Internal` to attach call-site context
+
+- **Scope:**
+  - Pick one of the two shapes from `rust.md` § 1: `Internal { source: Box<dyn std::error::Error + Send + Sync + 'static>, context: &'static str }`, or `Internal(#[from] anyhow::Error)` with `.context(...)` at service boundaries.
+  - Update `From<sea_orm::DbErr>` so the `Internal` fallback carries context; this likely means turning `From` into named constructors like `AppError::internal_db("loading user", e)` since `From` impls can't know context.
+  - `IntoResponse` already walks `error.source()` (landed in PR-C1), so a structural source-bearing variant Just Works on the log side; verify the chain reads naturally.
+  - Update existing tests for the new `Internal` shape (`test_unrecognized_dberr_maps_to_internal` will need a small adjustment).
+  - Update [`docs/design.md`](./design.md) § Observability → Error response pattern to reflect the new variant shape and the context-attachment rule.
+- **Standards refs:** `rust.md` § 1 (third bullet on attaching context to `Internal`).
+- **Effort:** M. Mostly mechanical, but the call-site rewrites are widespread (every service that produces `Internal` from a `?` via `From<DbErr>`).
+- **Dependencies:** PR-C1 (#105) — the thiserror foundation must be in place. Compatible with #84 (driver-string sanitization in `From<DbErr>`); whichever lands first, the other rebases.
+- **Risk:** Medium. Touches many call sites. Mostly mechanical, but enough breadth that bundling with another phase isn't appealing.
+- **Verification:** All existing tests pass with the test signature update. Spot-check that `Internal` log lines from a real failing endpoint now read like `"Internal: loading user: Database error: <DbErr>"` rather than just `"Database error: <DbErr>"`.
+- **Tracking:** Issue [#106](https://github.com/brendanbyrne/beerio-kart/issues/106).
+- **Sign-off:** [ ]
+
 ---
 
 ## Stream D — Type-driven design
@@ -465,3 +481,4 @@ Some PRs (B1, B3, E3, X1) have no dependencies and can land in parallel with A1/
 - 2026-05-05 — Renamed `Phase A`–`Phase J` to `Stream A`–`Stream J` throughout to free the `Phase` namespace for build phases only, per the cup-name milestone convention adopted in the design record's 2026-05-05 amendment ([`docs/designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §12.5 #2).
 - 2026-05-08 — Repaired two broken `reviews/design/` markdown links in document history entries (lines 461, 465). Old `../reviews/design/...` paths now point at `./designs/...` per the PR 1 migration. Closes part of Issue #42. PR 5 of the docs restructure.
 - 2026-05-08 — Updated PR-I1 scope: "Findings get written to `reviews/pr/`" → "Findings get posted as GitHub PR review comments per [`docs/designs/2026-05-04-design-doc-restructure.md`](./designs/2026-05-04-design-doc-restructure.md) §8.8." `reviews/pr/` was retired in the docs restructure; live-prose references should match the new convention. Closes part of [#89](https://github.com/brendanbyrne/beerio-kart/issues/89).
+- 2026-05-09 — Added PR-C2 (`AppError::Internal` reshape to carry call-site context per `rust.md` § 1). Surfaced and scoped-out during PR #105 review; tracked here so the gap doesn't get rediscovered and re-dismissed each PR. Issue [#106](https://github.com/brendanbyrne/beerio-kart/issues/106) tracks the work.

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,11 +82,14 @@ All route handlers return `Result<impl IntoResponse, AppError>` where `AppError`
 | `NotFound(msg)` | 404 | The provided `msg` |
 | `Conflict(msg)` | 409 | The provided `msg` |
 | `Internal(log_msg)` | 500 | Generic `"Internal server error"` |
+| `Token(jwt_err)` | 500 | Generic `"Internal server error"` |
+| `Hash(hash_err)` | 500 | Generic `"Internal server error"` |
 
 **Key behaviors:**
-- `Internal` logs the real error via `tracing::error!` but returns a generic message to the client — internal details are never exposed.
-- `From` impls for `jsonwebtoken::errors::Error` and `argon2::password_hash::Error` map library errors to `Internal`, so `?` works directly on token operations and password hashing.
+- The 500-class variants (`Internal`, `Token`, `Hash`) log the real error chain via `tracing::error!` (walking `error.source()`) but return a generic message to the client — internal details are never exposed.
+- `Token` and `Hash` are typed wrappers (with `#[from]`) around `jsonwebtoken::errors::Error` and `argon2::password_hash::Error` respectively, so `?` works directly on token operations and password hashing. The wrapped error is reachable via `error.source()` so the boundary log captures the underlying detail.
 - `From<sea_orm::DbErr>` is variant-aware: `RecordNotFound` → `NotFound` (404), `SqlErr::UniqueConstraintViolation` → `Conflict` (409), `SqlErr::ForeignKeyConstraintViolation` → `BadRequest` (400), everything else → `Internal` (500). This preserves error semantics that a blanket-Internal mapping would otherwise hide.
+- `AppError` is `#[non_exhaustive]`: the compiler enforces a wildcard arm in any external matcher so adding a future variant (e.g., `Timeout`, `RateLimited`) doesn't break callers.
 - Client-facing errors (`BadRequest`, `Unauthorized`, etc.) are always constructed explicitly — they require human judgment about the appropriate status code and message.
 
 **Response format:** All errors return JSON: `{ "error": "<message>" }`
@@ -155,6 +158,7 @@ See [`decisions/`](./decisions/) — each prior bullet has been distilled into a
 - 2026-05-05 — Extracted Data Model section to `data-model.md`. PR 1 of the docs restructure.
 - 2026-05-05 — Replaced the Resolved Decisions bullet list with a pointer to `docs/decisions/`. Each prior bullet distilled into a MADR file (0002–0034). PR 2 of the docs restructure.
 - 2026-05-06 — Replaced the Build Plan section with a one-paragraph pointer to `roadmap.md` (created in this PR). Phase narratives moved to roadmap.md per cup; the 20 unchecked Phase 3 / Milestone Star bullets were filed as GitHub Issues (#46, #47, #49, #50, #51, #54, #56, #58, #59, #61, #62, #63, #64, #65, #66, #67, #70, #71, #72, #73) under Milestone Star. PR 3 of the docs restructure.
+- 2026-05-09 — Updated the AppError variants table and Key behaviors bullets to reflect the thiserror migration: added `Token` and `Hash` rows; clarified that the 500-class log path now walks `error.source()` for the full chain; noted `#[non_exhaustive]`. PR #105.
 - 2026-05-06 — Removed the `## Backlog` section. The three random ideas (player invite emails, username change, send-emails / account recovery) moved to `docs/roadmap.md` § Random ideas. The fourth (concurrent `next_track` race condition) was filed as Issue #75 under Milestone Star with `enhancement` label.
 - 2026-05-06 — Replaced § "API Surface" with a pointer to `api-contract.md` § 1. Replaced § "User Workflows" and § "UI Screens" with pointers to `user-workflows.md`. Two minor editorial changes carried in the moves (Workflow 1.4 "Phase 3" → "Milestone Star"; § 2 preamble adds Pixel 9 Pro reference). PR 4 of the docs restructure.
 - 2026-05-08 — Removed the Project Structure section entirely (heading + body, ~99 lines of repo tree). The tree now lives only in the rebuilt repo-root `README.md`. Diverges from PR 4's stub-pointer pattern (User Workflows / API Surface / UI Screens kept their headings) — design.md is for architecture, repo tree is bootstrap content. PR 5 of the docs restructure.


### PR DESCRIPTION
## Reviewer notes

The hand-written `From<DbErr>` stays — it does variant discrimination (RecordNotFound→404, UNIQUE→409, FK→400, otherwise→500) that `#[from]` can't express. Issue scope says "replace hand-rolled From impls with thiserror attributes (#[from])", but that only applies to the trivially-mapping ones. `seaorm.md` § 7 explicitly recommends the discriminating `From<DbErr>` shape, so I kept it. #84 is the planned follow-up that sanitizes the driver-string leakage in the Conflict/BadRequest paths from this same impl.

The two trivially-mapping `From` impls (`jsonwebtoken::errors::Error`, `argon2::password_hash::Error`) become `Token` / `Hash` variants with `#[from]`. The wire shape doesn't change — both still surface to clients as 500 `{ "error": "Internal server error" }` — but now the underlying error is reachable via `error.source()`, which is what the new `IntoResponse` chain-walking logging consumes.

## Summary

- Derive `thiserror::Error, Debug` on `AppError`; mark `#[non_exhaustive]`.
- Per-variant `#[error("{0}")]` replaces the hand-rolled Display path; new `Token` and `Hash` variants with `#[from]` replace the trivially-mapping `From` impls.
- `IntoResponse` walks `error.source()` and logs the full chain (single line, joined by `": "`) for the three 500-class variants. Status codes and JSON body shape match the prior implementation exactly.

## Linked work

- Closes #94
- Per `docs/coding-standards/rust.md` § 1 and `docs/compliance-plan.md` § PR-C1.
- Follow-up: #84 sanitizes driver-string leakage from `From<DbErr>` (separate PR per the Iter 1 sequence).
- Follow-up: #106 reshapes `AppError::Internal` to attach call-site context (PR-C2, surfaced in this PR's review).

## How to verify

- [x] **Build is clean:**
  ```bash
  cd backend && cargo build && cargo clippy --all-targets
  ```
  Expect no warnings, no errors.

- [x] **All tests pass, including the new error-variant tests:**
  ```bash
  cd backend && cargo test
  ```
  Expect every test suite green. The new `error::tests::test_jwt_error_maps_to_token_variant_with_source`, `test_argon2_error_maps_to_hash_variant_with_source`, and `test_format_error_chain_joins_sources` should be in the list.

- [x] **Existing variant mappings still work (regression check):**
  ```bash
  cd backend && cargo test --lib error::
  ```
  Expect the four pre-existing `DbErr`-mapping tests (RecordNotFound→404, Custom→Internal, UNIQUE→Conflict, FK→BadRequest) and the three new variant tests to all pass — 7 tests total in `error::tests::`.

- [x] **End-to-end error response shape unchanged.** Start the dev server:
  ```bash
  cd backend && cargo run
  ```
  In another shell, exercise three error variants. Each `curl` is one logical command — line-continuation backslashes are bare `\` (not `\\`); the JSON body is single-quoted so its inner double-quotes are literal. Note that **all `GET /api/v1/<resource>/<id>` endpoints are auth-protected** (each handler takes an `AuthUser` extractor), so the 404 smoke needs a token.
  ```bash
  # 401 — missing Authorization header (any auth-protected GET works; cups is convenient)
  curl -s -i http://localhost:3000/api/v1/cups/99999

  # 409 — duplicate username (register the same name twice). Save the access_token
  # from the first call for the 404 step below.
  curl -s -X POST http://localhost:3000/api/v1/auth/register \
    -H 'content-type: application/json' \
    -d '{"username":"thiserror_smoke","password":"correct horse battery staple"}'
  curl -s -i -X POST http://localhost:3000/api/v1/auth/register \
    -H 'content-type: application/json' \
    -d '{"username":"thiserror_smoke","password":"correct horse battery staple"}'

  # 404 — unknown cup id, with a real bearer token so auth doesn't fire first
  TOKEN=$(curl -s -X POST http://localhost:3000/api/v1/auth/login \
    -H 'content-type: application/json' \
    -d '{"username":"thiserror_smoke","password":"correct horse battery staple"}' \
    | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
  curl -s -i http://localhost:3000/api/v1/cups/99999 -H "Authorization: Bearer $TOKEN"
  ```
  Expect:
  - 401 response: `{"error":"Missing Authorization header"}` with status `401 Unauthorized`.
  - 409 response: `{"error":"Username already taken"}` with status `409 Conflict`.
  - 404 response: `{"error":"Cup 99999 not found"}` with status `404 Not Found`.

  All three confirm the JSON body shape (`{"error": "<msg>"}`) and per-variant status code are unchanged from the pre-thiserror implementation.

- [x] **`Internal` source-chain logging works.** No clean way to provoke a `Token` or `Hash` 500 from a real client without breaking auth state, but the unit test `test_format_error_chain_joins_sources` exercises the chain-formatting code directly and asserts the output starts with `"Token error: "` and contains the inner jwt error description. Spot-check by reading the test.

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated for new logic (3 new unit tests cover the new variants and chain-formatting).
- [x] Docs updated if applicable — `docs/design.md` § Observability → Error response pattern updated (added Token/Hash rows + `#[non_exhaustive]` note + chain-walking note + Document history entry); `docs/compliance-plan.md` Stream C now lists PR-C2 (#106) for the deferred `Internal` reshape.
- [x] Schema changes — N/A.
- [x] Tested locally end-to-end (cargo test green; build/clippy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
