### PR TITLE
101: remove unwrap_used/expect_used allows from non-test code

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use anyhow::Context;
+
 /// Shared application configuration loaded from environment variables.
 ///
 /// Wrapped in `Arc` and stored in Axum's state so all handlers can access it
@@ -23,12 +25,11 @@ pub struct AppConfig {
 impl AppConfig {
     /// Load configuration from environment variables.
     ///
-    /// Panics if `JWT_SECRET` is not set — this is intentional. Running without
-    /// a signing key would silently produce unsigned or weak tokens.
-    #[allow(clippy::expect_used)] // Startup config; panic-on-missing is the right behavior.
-    pub fn from_env() -> Arc<Self> {
+    /// Errors if `JWT_SECRET` is not set — running without a signing key would
+    /// silently produce unsigned or weak tokens.
+    pub fn from_env() -> anyhow::Result<Arc<Self>> {
         let jwt_secret = std::env::var("JWT_SECRET")
-            .expect("JWT_SECRET must be set — it's the signing key for auth tokens");
+            .context("JWT_SECRET must be set — it's the signing key for auth tokens")?;
 
         let jwt_access_expiry_minutes = std::env::var("JWT_ACCESS_EXPIRY_MINUTES")
             .ok()
@@ -47,12 +48,12 @@ impl AppConfig {
             .and_then(|v| v.parse().ok())
             .unwrap_or(true);
 
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             jwt_secret,
             jwt_access_expiry_minutes,
             jwt_refresh_expiry_days,
             admin_user_id,
             cookie_secure,
-        })
+        }))
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,11 +1,8 @@
-// Startup code — panic-on-misconfiguration is intentional (CLAUDE.md "what
-// doesn't need tests" carve-out for one-time startup code).
-#![allow(clippy::expect_used, clippy::unwrap_used)]
-
 mod seed;
 
 use std::{sync::Arc, time::Duration};
 
+use anyhow::Context;
 use axum::{
     Json, Router,
     routing::{get, post, put},
@@ -26,7 +23,7 @@ struct HelloResponse {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     // Load .env file if present (non-fatal if missing)
     dotenvy::dotenv().ok();
 
@@ -42,25 +39,25 @@ async fn main() {
     let database_url = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "sqlite:../data/db/beerio-kart.db?mode=rwc".to_string());
 
-    // Load config from env vars (panics if JWT_SECRET is missing)
-    let config = AppConfig::from_env();
+    // Load config from env vars (errors if JWT_SECRET is missing)
+    let config = AppConfig::from_env()?;
 
     // Build the SQLx pool with per-connection PRAGMAs (foreign_keys, busy_timeout,
     // synchronous, journal_mode), then wrap as a SeaORM DatabaseConnection. See
     // src/db.rs for the rationale and seaorm.md § 8 for the rule.
     let db = db::connect(&database_url)
         .await
-        .expect("Failed to connect to database");
+        .context("Connecting to database")?;
 
     // Run all pending migrations. On a fresh database this creates every table.
     Migrator::up(&db, None)
         .await
-        .expect("Failed to run database migrations");
+        .context("Running database migrations")?;
 
     // Seed static game data (characters, tracks, cups, etc.) from JSON files.
     // Only inserts into empty tables — safe to call on every startup.
     tracing::info!("Seeding static data...");
-    seed::run(&db).await.expect("Failed to seed database");
+    seed::run(&db).await.context("Seeding database")?;
     tracing::info!("Seeding complete");
 
     let state = AppState {
@@ -175,9 +172,15 @@ async fn main() {
         }
     });
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
+        .await
+        .context("Binding TCP listener on 0.0.0.0:3000")?;
     tracing::info!("Listening on http://localhost:3000");
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app)
+        .await
+        .context("HTTP server returned an error")?;
+
+    Ok(())
 }
 
 async fn hello() -> Json<HelloResponse> {

--- a/backend/src/seed.rs
+++ b/backend/src/seed.rs
@@ -33,7 +33,7 @@ struct SeedTrack {
 
 /// Load seed data into empty tables. Skips tables that already have rows.
 /// All inserts for a given table happen inside a single transaction.
-pub async fn run(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(db: &DatabaseConnection) -> anyhow::Result<()> {
     seed_simple_table::<cups::Entity, cups::ActiveModel>(
         db,
         "cups",
@@ -84,7 +84,7 @@ async fn seed_simple_table<E, A>(
     db: &DatabaseConnection,
     table_name: &str,
     json_data: &str,
-) -> Result<(), Box<dyn std::error::Error>>
+) -> anyhow::Result<()>
 where
     E: EntityTrait,
     A: ActiveModelBehavior<Entity = E> + From<SimpleActiveModel> + Send,
@@ -142,7 +142,7 @@ macro_rules! impl_simple_seed {
 
 impl_simple_seed!(characters, bodies, wheels, gliders, cups);
 
-async fn seed_tracks(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+async fn seed_tracks(db: &DatabaseConnection) -> anyhow::Result<()> {
     let existing = tracks::Entity::find().one(db).await?;
     if existing.is_some() {
         tracing::debug!("tracks: already seeded, skipping");
@@ -164,11 +164,12 @@ async fn seed_tracks(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::
 
     for track in &items {
         if !cup_ids.contains(&track.cup_id) {
-            return Err(format!(
+            return Err(anyhow::anyhow!(
                 "Track '{}' (id={}) references cup_id={} which doesn't exist",
-                track.name, track.id, track.cup_id
-            )
-            .into());
+                track.name,
+                track.id,
+                track.cup_id
+            ));
         }
     }
 
@@ -196,7 +197,7 @@ struct SeedDrinkType {
     alcoholic: bool,
 }
 
-async fn seed_drink_types(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+async fn seed_drink_types(db: &DatabaseConnection) -> anyhow::Result<()> {
     let existing = drink_types::Entity::find().one(db).await?;
     if existing.is_some() {
         tracing::debug!("drink_types: already seeded, skipping");

--- a/docs/coding-standards/rust.md
+++ b/docs/coding-standards/rust.md
@@ -339,7 +339,7 @@ The project targets edition 2024 (Rust 1.85+). Edition 2024 is the latest stable
 
 - **Rule:** `unwrap()` policy:
   - **Tests, `build.rs`, examples:** unrestricted.
-  - **`main.rs` startup:** `expect("static config invariant: ...")` is fine — failure aborts startup, which is the desired behavior for misconfiguration.
+  - **`main.rs` startup:** prefer `fn main() -> anyhow::Result<()>` with `?` and `.context("...")` over `.expect(...)`/`.unwrap()`. Both abort on misconfiguration, but the anyhow form yields an error chain via `Display`/`source()` (richer than a panic message) and stays clippy-clean without per-file `#[allow(clippy::expect_used)]`. This is the binary-glue half of § 1's `anyhow` (binary) / `thiserror` (library) split. `expect("static config invariant: ...")` remains acceptable for genuinely-infallible call sites where wiring through `Result` would be all noise (rare in practice).
   - **Handlers, services, library code:** banned. Use `?` or explicit `match`.
   - **Source:** <https://burntsushi.net/unwrap/>
 
@@ -527,3 +527,4 @@ Anyone modifying Rust code in this repo should have read at least the first thre
 - 2026-05-04 — Clarified § 8 unwrap/expect rule for test modules vs integration test files: lib code uses `cfg_attr(test, allow(...))`, files under `tests/` use bare `#![allow(...)]` since `cfg(test)` is unconditionally true there. Surfaced during PR-A1 (#24) review.
 - 2026-05-08 — Repaired the broken Rust stdlib doc URL on the `NonZeroI32` rule: `struct.NonZeroI32.html` → `type.NonZeroI32.html` (the type became a type alias for `NonZero<i32>` in Rust 1.79, so the old struct page no longer exists). PR 5 of the docs restructure (plan deviation — surfaced when lychee `fail: true` flipped on).
 - 2026-05-09 — Added § 1 rule on capital-first error messages with no trailing punctuation. Codifies the convention already in force across the 30+ `AppError::{BadRequest,Unauthorized,Forbidden,NotFound,Conflict}` call sites and extends it to anyhow contexts and `anyhow!` synthetic messages (a deliberate divergence from anyhow's lowercase-context docs convention). Surfaced during PR #107 (PR-C2) review.
+- 2026-05-10 — Updated § 11's `main.rs` startup sub-rule to prefer `fn main() -> anyhow::Result<()>` + `?` + `.context(...)` over `.expect(...)`/`.unwrap()`. The previous wording predated PR-A1's lint config and PR-C2's anyhow foundation; with both in place, the anyhow form is clippy-clean without per-file allows and yields a richer error chain. `expect(...)` retained as the rare-case fallback for genuinely-infallible sites. Surfaced during PR #108 (PR-H1+ a) review; tracking Issue [#109](https://github.com/brendanbyrne/beerio-kart/issues/109).


### PR DESCRIPTION
Closes #101, closes #109. First PR in the PR-H1+ lint cleanup sequence.

## Summary
- `main()` now returns `anyhow::Result<()>`; `.expect()`/`.unwrap()` on startup operations replaced with `.context(...)?`.
- `AppConfig::from_env()` now returns `anyhow::Result<Arc<Self>>` instead of `Arc<Self>` with an internal `.expect()` on `JWT_SECRET`.
- `seed::run` (and its private helpers) widened from `Result<(), Box<dyn Error>>` to `anyhow::Result<()>` so the `.context()` chain composes through the call site.
- All `#[allow(clippy::unwrap_used)]` / `#[allow(clippy::expect_used)]` removed from non-test code. Remaining allows are the documented test-code exceptions per `rust.md` § 8: `lib.rs`'s `cfg_attr(test, ...)` gate and the bare `#![allow(...)]` at the top of each `tests/*.rs` file.

Why anyhow at the top: `main` is binary glue, which is exactly anyhow's lane per `rust.md` § 1. The error chain is preserved, and `.context(...)` strings follow the capital-first / no-trailing-punctuation convention codified for the C2 reshape.

## Verification
```
cd backend
cargo clippy --all-targets   # clean
cargo test                    # 19 + integration suites pass
```

Manual smoke tests:
1. **Missing JWT_SECRET reports a clear chain.** From a shell where `JWT_SECRET` is unset:
   ```
   cd backend && cargo run
   ```
   Expect the binary to exit non-zero with an error chain that surfaces `JWT_SECRET must be set — it's the signing key for auth tokens` followed by `environment variable not found` (exact wording from `std::env::VarError`).

2. **Happy path still boots.** With a normal `.env` (containing `JWT_SECRET`):
   ```
   cd backend && cargo run
   ```
   Expect the usual startup logs (`Seeding static data...`, `Seeding complete`, `Listening on http://localhost:3000`) and the server to come up healthy on `:3000`.

3. **Bad DATABASE_URL surfaces a context'd chain.** Set `DATABASE_URL=sqlite:/this/path/cannot/exist.db?mode=rw` and run as above; expect the error chain to lead with `Connecting to database`.

4. **No leftover non-test allows.**
   ```
   grep -rn 'clippy::unwrap_used\|clippy::expect_used' backend/src
   ```
   Should match only `backend/src/lib.rs`'s `cfg_attr(test, ...)` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
