### PR TITLE
102: verify needless_pass_by_value / large_types_passed_by_value clean

### DIFF
--- a/docs/compliance-plan.md
+++ b/docs/compliance-plan.md
@@ -485,3 +485,5 @@ Some PRs (B1, B3, E3, X1) have no dependencies and can land in parallel with A1/
 - 2026-05-10 — Marked PR-A2 sign-off complete (audit completed 2026-04-15; deliverable is [`docs/designs/2026-04-15-rust-audit.md`](./designs/2026-04-15-rust-audit.md)).
 - 2026-05-10 — Marked PR-C1 sign-off complete (merged 2026-05-10 as PR #105).
 - 2026-05-10 — Marked PR-C2 sign-off complete (merged 2026-05-10 as PR #107).
+- 2026-05-10 — PR-H1+ (a) Issue [#101](https://github.com/brendanbyrne/beerio-kart/issues/101) closed via PR #108 (`unwrap_used`/`expect_used` allows removed from non-test code; `main()` now returns `anyhow::Result<()>`).
+- 2026-05-10 — PR-H1+ (b) Issue [#102](https://github.com/brendanbyrne/beerio-kart/issues/102) verified clean without code changes. PR-A1 (#24) never added module-level allows for `clippy::needless_pass_by_value` or `clippy::large_types_passed_by_value` (verified by `gh pr diff 24` and `grep -rn "allow.*clippy" backend/src`); both lints are already covered as warnings via the workspace `pedantic = "warn"` setting and the codebase has zero violations against either. Issue body's premise about removing PR-A1-introduced allows was stale.


### PR DESCRIPTION
Closes #102. Second PR in the PR-H1+ lint cleanup sequence.

## Summary

Issue #102's premise was stale. PR-A1 (#24) never added module-level allows for `clippy::needless_pass_by_value` or `clippy::large_types_passed_by_value`. Both lints are already covered as warnings via the workspace `pedantic = \"warn\"` setting in `backend/Cargo.toml`, and the codebase has zero violations against either.

This PR records that verification result as a `docs/compliance-plan.md` Document history entry. No backend code changes.

## Verification trail

```
# 1. PR-A1 didn't add allows for these lints:
gh pr diff 24 | grep "needless_pass_by_value\|large_types_passed_by_value"
# (no output)

# 2. No allows anywhere in backend src:
grep -rn "allow.*clippy" backend/src
# Only match: backend/src/lib.rs:2  →  cfg_attr(test, allow(unwrap_used, expect_used, panic))

# 3. Force-enabling produces no warnings:
cd backend && cargo clippy --all-targets -- \
  -W clippy::needless_pass_by_value \
  -W clippy::large_types_passed_by_value
# (no output)
```

## Manual reproduction

```
cd backend
cargo clippy --all-targets        # clean
cargo clippy --all-targets -- -W clippy::needless_pass_by_value -W clippy::large_types_passed_by_value  # clean
grep -rn 'allow.*clippy' backend/src  # only the test cfg_attr line
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)