### PR TITLE
100: clear pedantic batch 1 (10 lints, ~33 sites)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,7 +12,6 @@ nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 # Tame the noisy pedantic ones:
 module_name_repetitions = "allow"
-must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 cast_precision_loss = "allow"
@@ -24,18 +23,9 @@ cargo_common_metadata = "allow"
 multiple_crate_versions = "allow"
 # Phase H scaffolding — clear each in a follow-up PR per rust.md § 8:
 doc_markdown = "allow"
-use_self = "allow"
 needless_raw_string_hashes = "allow"
 too_long_first_doc_paragraph = "allow"
-missing_const_for_fn = "allow"
-single_match_else = "allow"
-redundant_closure_for_method_calls = "allow"
-redundant_clone = "allow"
-map_unwrap_or = "allow"
-manual_let_else = "allow"
-items_after_statements = "allow"
 too_many_lines = "allow"
-used_underscore_binding = "allow"
 # High-value extras:
 dbg_macro = "deny"
 print_stdout = "deny"

--- a/backend/src/domain/enums.rs
+++ b/backend/src/domain/enums.rs
@@ -17,7 +17,8 @@ pub enum SessionStatus {
 }
 
 impl SessionStatus {
-    pub fn as_str(&self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Active => "active",
             Self::Closed => "closed",
@@ -54,7 +55,8 @@ pub enum Ruleset {
 }
 
 impl Ruleset {
-    pub fn as_str(&self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Random => "random",
         }

--- a/backend/src/domain/ids.rs
+++ b/backend/src/domain/ids.rs
@@ -102,7 +102,7 @@ mod tests {
         let id = UserId::new("abc");
         assert_eq!(id.as_str(), "abc");
         assert_eq!(id.to_string(), "abc");
-        assert_eq!(id.clone().into_string(), "abc".to_string());
+        assert_eq!(id.into_string(), "abc".to_string());
     }
 
     #[test]

--- a/backend/src/drink_type_id.rs
+++ b/backend/src/drink_type_id.rs
@@ -8,6 +8,7 @@ const DRINK_TYPE_NAMESPACE: Uuid = Uuid::from_bytes([
 
 /// Compute a deterministic UUID for a drink type name (case-insensitive).
 /// `uuid_v5(DRINK_TYPE_NAMESPACE, UPPERCASE(name))`
+#[must_use]
 pub fn drink_type_uuid(name: &str) -> String {
     Uuid::new_v5(&DRINK_TYPE_NAMESPACE, name.to_uppercase().as_bytes()).to_string()
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -59,12 +59,12 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, user_message) = match &self {
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
-            AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
-            AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
-            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
-            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
-            AppError::Internal(_) | AppError::Token(_) | AppError::Hash(_) => {
+            Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            Self::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
+            Self::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
+            Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            Self::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            Self::Internal(_) | Self::Token(_) | Self::Hash(_) => {
                 error!("{}", format_error_chain(&self));
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -101,11 +101,11 @@ impl From<sea_orm::DbErr> for AppError {
     fn from(e: sea_orm::DbErr) -> Self {
         use sea_orm::{DbErr, SqlErr};
         match &e {
-            DbErr::RecordNotFound(msg) => AppError::NotFound(msg.clone()),
+            DbErr::RecordNotFound(msg) => Self::NotFound(msg.clone()),
             _ => match e.sql_err() {
-                Some(SqlErr::UniqueConstraintViolation(m)) => AppError::Conflict(m),
-                Some(SqlErr::ForeignKeyConstraintViolation(m)) => AppError::BadRequest(m),
-                _ => AppError::Internal(anyhow::Error::new(e).context("Database error")),
+                Some(SqlErr::UniqueConstraintViolation(m)) => Self::Conflict(m),
+                Some(SqlErr::ForeignKeyConstraintViolation(m)) => Self::BadRequest(m),
+                _ => Self::Internal(anyhow::Error::new(e).context("Database error")),
             },
         }
     }

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -51,7 +51,7 @@ impl FromRequestParts<crate::AppState> for AuthUser {
             return Err(AppError::Unauthorized("Invalid token type".to_string()));
         }
 
-        Ok(AuthUser {
+        Ok(Self {
             user_id: UserId::new(claims.sub),
             username: claims.username,
         })
@@ -90,7 +90,7 @@ impl FromRequestParts<crate::AppState> for AdminUser {
             return Err(AppError::Forbidden("Admin access required".to_string()));
         }
 
-        Ok(AdminUser {
+        Ok(Self {
             user_id: auth_user.user_id,
             username: auth_user.username,
         })

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -77,7 +77,7 @@ fn extract_refresh_cookie(headers: &HeaderMap) -> Option<String> {
         .split(';')
         .find_map(|pair| {
             let pair = pair.trim();
-            pair.strip_prefix("refresh_token=").map(|v| v.to_string())
+            pair.strip_prefix("refresh_token=").map(ToString::to_string)
         })
 }
 
@@ -167,26 +167,23 @@ pub async fn login(
 ) -> Result<impl IntoResponse, AppError> {
     let username = body.username.trim();
 
-    let user = match users::Entity::find()
+    let Some(user) = users::Entity::find()
         .filter(users::Column::Username.eq(username))
         .one(&state.db)
         .await?
-    {
-        Some(u) => u,
-        None => {
-            // Hash a dummy password so the timing is similar to the "wrong password"
-            // path. Prevents username enumeration via response-time analysis.
-            let _ = auth_service::verify_password(
-                &state.argon2_limit,
-                "dummy".to_string(),
-                "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    .to_string(),
-            )
-            .await;
-            return Err(AppError::Unauthorized(
-                "Invalid username or password".into(),
-            ));
-        }
+    else {
+        // Hash a dummy password so the timing is similar to the "wrong password"
+        // path. Prevents username enumeration via response-time analysis.
+        let _ = auth_service::verify_password(
+            &state.argon2_limit,
+            "dummy".to_string(),
+            "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                .to_string(),
+        )
+        .await;
+        return Err(AppError::Unauthorized(
+            "Invalid username or password".into(),
+        ));
     };
 
     // Verify password (offloaded to the blocking pool, capped by argon2_limit)

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -163,6 +163,7 @@ pub fn validate_refresh_token(
 }
 
 /// Build the `Set-Cookie` header value for a refresh token.
+#[must_use]
 pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &AppConfig) -> String {
     let secure = if config.cookie_secure { "Secure; " } else { "" };
     format!(
@@ -171,6 +172,7 @@ pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &AppConfig) -> 
 }
 
 /// Build a `Set-Cookie` header value that clears the refresh token cookie.
+#[must_use]
 pub fn clear_refresh_cookie(config: &AppConfig) -> String {
     refresh_cookie("", 0, config)
 }

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -499,6 +499,7 @@ pub async fn get_run_defaults(
 mod tests {
     use super::*;
     use crate::{
+        entities::sessions as sessions_entity,
         services::sessions,
         test_helpers::{create_user, seed_game_data, setup_db},
     };
@@ -806,7 +807,6 @@ mod tests {
             .ok();
 
         // Force-close in case leave order was wrong
-        use crate::entities::sessions as sessions_entity;
         let s = sessions_entity::Entity::find_by_id(&session_id)
             .one(&db)
             .await

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -677,7 +677,7 @@ pub async fn get_session_detail(
     // 1-indexed and gapless: `next_track` appends monotonically, and
     // `skip_turn` replaces in-place (preserves race_number). No deletion
     // path exists. Under this invariant, last().race_number == COUNT(*).
-    let race_number = races.last().map(|r| r.race_number as usize).unwrap_or(1);
+    let race_number = races.last().map_or(1, |r| r.race_number as usize);
 
     Ok(SessionDetail {
         id: SessionId::new(session.id),

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -84,7 +84,7 @@ fn extract_refresh_cookie(response: &axum_test::TestResponse) -> Option<String> 
         .split(';')
         .next()?
         .strip_prefix("refresh_token=")
-        .map(|s| s.to_string())
+        .map(ToString::to_string)
 }
 
 // ── Existing tests (updated for new response format) ────────────────

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -32,7 +32,7 @@ fn make_config(admin_user_id: Option<&str>) -> Arc<AppConfig> {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,
-        admin_user_id: admin_user_id.map(|s| s.to_string()),
+        admin_user_id: admin_user_id.map(ToString::to_string),
         cookie_secure: false,
     })
 }

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -15,12 +15,12 @@ use beerio_kart::{
     ARGON2_MAX_CONCURRENT, AppState,
     config::AppConfig,
     drink_type_id::drink_type_uuid,
-    entities::{bodies, characters, cups, drink_types, gliders, tracks, wheels},
+    entities::{bodies, characters, cups, drink_types, gliders, sessions, tracks, wheels},
     routes,
 };
 use chrono::Utc;
 use migration::{Migrator, MigratorTrait};
-use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, EntityTrait, Set};
 use serde_json::{Value, json};
 use tokio::sync::Semaphore;
 use uuid::Uuid;
@@ -207,7 +207,7 @@ async fn register_and_get_token(server: &TestServer, username: &str) -> (String,
 async fn test_full_session_lifecycle() {
     let (server, _db) = setup_test_app().await;
     let (token_host, _host_id) = register_and_get_token(&server, "host").await;
-    let (token_user2, _user2_id) = register_and_get_token(&server, "user2").await;
+    let (token_user2, user2_id) = register_and_get_token(&server, "user2").await;
 
     // 1. Create session
     let res = server
@@ -254,7 +254,7 @@ async fn test_full_session_lifecycle() {
         .add_header(AUTH_HEADER, auth_value(&token_user2))
         .await;
     let detail: Value = res.json();
-    assert_eq!(detail["host_id"], _user2_id);
+    assert_eq!(detail["host_id"], user2_id);
     assert_eq!(detail["status"], "active");
 
     // 5. Last participant leaves — session closes
@@ -480,8 +480,6 @@ async fn test_stale_session_cleanup() {
 
     // Manually set last_activity_at to 2 hours ago
     let two_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).naive_utc();
-    use beerio_kart::entities::sessions;
-    use sea_orm::EntityTrait;
     let session_model = sessions::Entity::find_by_id(&session_id)
         .one(&db)
         .await


### PR DESCRIPTION
Closes #100. Third PR in the PR-H1+ lint cleanup sequence.

## Summary

Removes the workspace allows for **ten pedantic lints** in `backend/Cargo.toml` and fixes the underlying sites. All fixes are mechanical — `Self` in impl blocks, `#[must_use]` / `const fn` annotations, `ToString::to_string` in lieu of `|s| s.to_string()` closures, `let ... else` in lieu of `match-Option-else`, plus one binding rename.

| Lint | Sites | Files |
|---|---|---|
| `use_self` | 15 | `src/error.rs`, `src/middleware/auth.rs` |
| `must_use_candidate` | 5 | `src/domain/enums.rs`, `src/drink_type_id.rs`, `src/services/auth.rs` |
| `missing_const_for_fn` | 2 | `src/domain/enums.rs` |
| `redundant_closure_for_method_calls` | 3 | `src/routes/auth.rs`, `tests/auth_integration.rs`, `tests/auth_middleware.rs` |
| `items_after_statements` | 3 | `src/services/runs.rs`, `tests/session_integration.rs` |
| `manual_let_else` (subsumes `single_match_else`) | 1 | `src/routes/auth.rs` |
| `map_unwrap_or` | 1 | `src/services/sessions.rs` |
| `redundant_clone` | 1 | `src/domain/ids.rs` |
| `used_underscore_binding` | 1 | `tests/session_integration.rs` |

Net diff: 13 files, +43 / -53.

## Deferred (out of this batch)

Per Issue #100's "If the actual list is large, defer the rest to (d)":

- **`module_name_repetitions`** — ~13 sites. Many require type renames (e.g., `AppError` variants, `AuthUser`/`AdminUser`) or per-item allows with rationale comments. Not mechanical.
- **`cast_possible_wrap`, `cast_possible_truncation`, `cast_sign_loss`, `cast_precision_loss`** — each cast site needs individual review (lossless `as` vs. `try_into`/`u32::from` etc.). Not mechanical.

→ batch (d), Issue #103.

Per Issue #100's "the larger doc-comment audit is G3 (separate Issue, not yet filed)":

- **`missing_errors_doc`** (72 sites), **`missing_panics_doc`** (9), **`doc_markdown`** (62), **`too_long_first_doc_paragraph`** (6) — all queued for PR-G3 (doc-comment audit, not in PR-H1+).

The workspace `Cargo.toml` retains explicit `= "allow"` lines for all of the above so they don't surface as warnings until the appropriate PR picks them up.

## Verification

```
cd backend
cargo clippy --all-targets   # clean
cargo test                    # 19 + integration suites pass
```

Manual reproduction:

1. **The cleared lints stay clean.** From `backend/`:
   ```
   cargo clippy --all-targets -- \
     -W clippy::use_self \
     -W clippy::must_use_candidate \
     -W clippy::missing_const_for_fn \
     -W clippy::redundant_closure_for_method_calls \
     -W clippy::items_after_statements \
     -W clippy::manual_let_else \
     -W clippy::single_match_else \
     -W clippy::map_unwrap_or \
     -W clippy::redundant_clone \
     -W clippy::used_underscore_binding
   ```
   Should be silent.

2. **The deferred allows are still in place.** `grep '"allow"' backend/Cargo.toml` lists `module_name_repetitions`, `missing_errors_doc`, `missing_panics_doc`, the four `cast_*` lints, `doc_markdown`, `too_long_first_doc_paragraph`, plus the leave-alone-forever ones (`cargo_common_metadata`, `multiple_crate_versions`, `needless_raw_string_hashes`, `too_many_lines`).

3. **The `_user2_id` rename is correct.** `tests/session_integration.rs:210` previously declared `_user2_id` (underscore-prefixed = "intentionally unused") but line 257 actually used it. Renamed to `user2_id`. The other `_user2_id` at `tests/session_integration.rs:789` *is* unused; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)