### PR TITLE
103: clear pedantic batch 2 (module_name_repetitions + cast_*)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -60,7 +60,7 @@ When we exit prelaunch (decided when we have real user data we don't want to los
 
 ## Errors
 
-All route handlers return `Result<impl IntoResponse, AppError>` where `AppError` (`src/error.rs`) is a unified error type that implements Axum's `IntoResponse`. This enables `?` propagation. See [`docs/design.md`](../docs/design.md) § Observability → Error response pattern for the full table of variants and the `From<sea_orm::DbErr>` mapping.
+All route handlers return `Result<impl IntoResponse, error::Error>` where `error::Error` (`src/error.rs`) is a unified error type that implements Axum's `IntoResponse`. This enables `?` propagation. See [`docs/design.md`](../docs/design.md) § Observability → Error response pattern for the full table of variants and the `From<sea_orm::DbErr>` mapping.
 
 Open follow-up: [#84](https://github.com/brendanbyrne/beerio-kart/issues/84) tracks sanitizing driver-string leakage from `From<DbErr>` (Conflict/BadRequest paths leak schema details). Worth reading before touching `error.rs`.
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,13 +11,8 @@ pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 # Tame the noisy pedantic ones:
-module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
-cast_precision_loss = "allow"
-cast_possible_truncation = "allow"
-cast_possible_wrap = "allow"
-cast_sign_loss = "allow"
 # `cargo` group — relevant for crates.io publishing, not an internal binary:
 cargo_common_metadata = "allow"
 multiple_crate_versions = "allow"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -7,22 +7,24 @@ use anyhow::Context;
 /// Wrapped in `Arc` and stored in Axum's state so all handlers can access it
 /// without cloning the inner data on every request.
 #[derive(Clone, Debug)]
-pub struct AppConfig {
+pub struct Config {
     pub jwt_secret: String,
     /// How long access tokens are valid (minutes). Short-lived because they
-    /// can't be revoked — if one leaks, it expires quickly.
-    pub jwt_access_expiry_minutes: u64,
+    /// can't be revoked — if one leaks, it expires quickly. Stored as `i64`
+    /// because `chrono::TimeDelta::minutes` takes `i64`.
+    pub jwt_access_expiry_minutes: i64,
     /// How long refresh tokens are valid (days). Longer-lived because they're
     /// stored in an HttpOnly cookie (no JavaScript access) and can be revoked
-    /// by bumping `refresh_token_version` in the database.
-    pub jwt_refresh_expiry_days: u64,
+    /// by bumping `refresh_token_version` in the database. Stored as `i64`
+    /// because `chrono::TimeDelta::days` takes `i64`.
+    pub jwt_refresh_expiry_days: i64,
     pub admin_user_id: Option<String>,
     /// Controls the `Secure` flag on the refresh cookie. Must be `false` for
     /// local `http://localhost` development, `true` in production behind HTTPS.
     pub cookie_secure: bool,
 }
 
-impl AppConfig {
+impl Config {
     /// Load configuration from environment variables.
     ///
     /// Errors if `JWT_SECRET` is not set — running without a signing key would

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -33,14 +33,19 @@ impl Config {
         let jwt_secret = std::env::var("JWT_SECRET")
             .context("JWT_SECRET must be set — it's the signing key for auth tokens")?;
 
+        // Token expiry fields are i64 to match chrono::TimeDelta's argument
+        // type. A zero or negative expiry would mint already-expired tokens,
+        // so reject those at load time rather than silently shipping them.
         let jwt_access_expiry_minutes = std::env::var("JWT_ACCESS_EXPIRY_MINUTES")
             .ok()
-            .and_then(|v| v.parse().ok())
+            .and_then(|v| v.parse::<i64>().ok())
+            .filter(|&v| v > 0)
             .unwrap_or(15);
 
         let jwt_refresh_expiry_days = std::env::var("JWT_REFRESH_EXPIRY_DAYS")
             .ok()
-            .and_then(|v| v.parse().ok())
+            .and_then(|v| v.parse::<i64>().ok())
+            .filter(|&v| v > 0)
             .unwrap_or(7);
 
         let admin_user_id = std::env::var("ADMIN_USER_ID").ok();

--- a/backend/src/domain/enums.rs
+++ b/backend/src/domain/enums.rs
@@ -2,7 +2,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::AppError;
+use crate::error::Error;
 
 /// Lifecycle state of a session.
 ///
@@ -33,13 +33,13 @@ impl fmt::Display for SessionStatus {
 }
 
 impl FromStr for SessionStatus {
-    type Err = AppError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "active" => Ok(Self::Active),
             "closed" => Ok(Self::Closed),
-            other => Err(AppError::Internal(anyhow::anyhow!(
+            other => Err(Error::Internal(anyhow::anyhow!(
                 "Unknown session status: {other}"
             ))),
         }
@@ -70,12 +70,12 @@ impl fmt::Display for Ruleset {
 }
 
 impl FromStr for Ruleset {
-    type Err = AppError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "random" => Ok(Self::Random),
-            other => Err(AppError::BadRequest(format!("Invalid ruleset: '{other}'"))),
+            other => Err(Error::BadRequest(format!("Invalid ruleset: '{other}'"))),
         }
     }
 }
@@ -100,7 +100,7 @@ mod tests {
     fn session_status_unknown_is_internal_error() {
         let err = SessionStatus::from_str("nonsense").unwrap_err();
         match &err {
-            AppError::Internal(inner) => assert!(inner.to_string().contains("nonsense")),
+            Error::Internal(inner) => assert!(inner.to_string().contains("nonsense")),
             other => panic!("expected Internal, got {other:?}"),
         }
     }
@@ -133,7 +133,7 @@ mod tests {
         // deliberately different from SessionStatus, which is read from the DB.
         let err = Ruleset::from_str("spiral").unwrap_err();
         match err {
-            AppError::BadRequest(msg) => assert!(msg.contains("spiral")),
+            Error::BadRequest(msg) => assert!(msg.contains("spiral")),
             other => panic!("expected BadRequest, got {other:?}"),
         }
     }

--- a/backend/src/domain/race_setup.rs
+++ b/backend/src/domain/race_setup.rs
@@ -1,4 +1,4 @@
-use crate::error::AppError;
+use crate::error::Error;
 
 /// A fully-specified race setup update (all four IDs required together).
 ///
@@ -7,25 +7,25 @@ use crate::error::AppError;
 /// without wheels (etc.) is meaningless. This type encodes that invariant at
 /// compile time so call sites can't read only some of the fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RaceSetupUpdate {
+pub struct Update {
     pub character_id: i32,
     pub body_id: i32,
     pub wheel_id: i32,
     pub glider_id: i32,
 }
 
-impl RaceSetupUpdate {
+impl Update {
     /// Parse a race-setup update from four optional fields.
     ///
     /// - All four `None` → `Ok(None)` (caller is not updating race setup).
-    /// - All four `Some` → `Ok(Some(RaceSetupUpdate))`.
+    /// - All four `Some` → `Ok(Some(Update))`.
     /// - Any mix        → `Err(BadRequest)`.
     pub fn try_from_optional(
         character_id: Option<i32>,
         body_id: Option<i32>,
         wheel_id: Option<i32>,
         glider_id: Option<i32>,
-    ) -> Result<Option<Self>, AppError> {
+    ) -> Result<Option<Self>, Error> {
         match (character_id, body_id, wheel_id, glider_id) {
             (None, None, None, None) => Ok(None),
             (Some(character_id), Some(body_id), Some(wheel_id), Some(glider_id)) => {
@@ -36,7 +36,7 @@ impl RaceSetupUpdate {
                     glider_id,
                 }))
             }
-            _ => Err(AppError::BadRequest(
+            _ => Err(Error::BadRequest(
                 "Race setup must be provided all together (character, body, wheel, glider) or not at all".into(),
             )),
         }
@@ -49,18 +49,18 @@ mod tests {
 
     #[test]
     fn all_none_returns_ok_none() {
-        let result = RaceSetupUpdate::try_from_optional(None, None, None, None).unwrap();
+        let result = Update::try_from_optional(None, None, None, None).unwrap();
         assert_eq!(result, None);
     }
 
     #[test]
     fn all_some_returns_ok_some() {
-        let result = RaceSetupUpdate::try_from_optional(Some(1), Some(2), Some(3), Some(4))
+        let result = Update::try_from_optional(Some(1), Some(2), Some(3), Some(4))
             .unwrap()
             .unwrap();
         assert_eq!(
             result,
-            RaceSetupUpdate {
+            Update {
                 character_id: 1,
                 body_id: 2,
                 wheel_id: 3,
@@ -69,9 +69,9 @@ mod tests {
         );
     }
 
-    fn assert_bad_request(result: Result<Option<RaceSetupUpdate>, AppError>) {
+    fn assert_bad_request(result: Result<Option<Update>, Error>) {
         match result {
-            Err(AppError::BadRequest(msg)) => {
+            Err(Error::BadRequest(msg)) => {
                 assert!(msg.contains("all together"), "msg was: {msg}");
             }
             other => panic!("expected BadRequest, got {other:?}"),
@@ -80,31 +80,16 @@ mod tests {
 
     #[test]
     fn single_some_is_bad_request() {
-        assert_bad_request(RaceSetupUpdate::try_from_optional(
-            Some(1),
-            None,
-            None,
-            None,
-        ));
+        assert_bad_request(Update::try_from_optional(Some(1), None, None, None));
     }
 
     #[test]
     fn three_some_one_none_is_bad_request() {
-        assert_bad_request(RaceSetupUpdate::try_from_optional(
-            Some(1),
-            Some(2),
-            Some(3),
-            None,
-        ));
+        assert_bad_request(Update::try_from_optional(Some(1), Some(2), Some(3), None));
     }
 
     #[test]
     fn interior_none_is_bad_request() {
-        assert_bad_request(RaceSetupUpdate::try_from_optional(
-            Some(1),
-            None,
-            Some(3),
-            Some(4),
-        ));
+        assert_bad_request(Update::try_from_optional(Some(1), None, Some(3), Some(4)));
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -15,11 +15,11 @@ struct ErrorBody {
 /// Unified error type for all route handlers.
 ///
 /// Implements Axum's `IntoResponse`, so handlers can return
-/// `Result<impl IntoResponse, AppError>` and use `?` directly
+/// `Result<impl IntoResponse, Error>` and use `?` directly
 /// instead of writing match arms for every fallible call.
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum AppError {
+pub enum Error {
     /// 400 — validation failures, malformed input
     #[error("{0}")]
     BadRequest(String),
@@ -56,7 +56,7 @@ pub enum AppError {
     Hash(#[from] argon2::password_hash::Error),
 }
 
-impl IntoResponse for AppError {
+impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let (status, user_message) = match &self {
             Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
@@ -94,10 +94,10 @@ fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
 //
 // The `Token` and `Hash` variants get their `From` impls from `#[from]` on the
 // variant. `DbErr` needs hand-written discrimination — different `DbErr`
-// variants map to different `AppError` variants (404 / 409 / 400 / 500), which
+// variants map to different `Error` variants (404 / 409 / 400 / 500), which
 // `#[from]` can't express.
 
-impl From<sea_orm::DbErr> for AppError {
+impl From<sea_orm::DbErr> for Error {
     fn from(e: sea_orm::DbErr) -> Self {
         use sea_orm::{DbErr, SqlErr};
         match &e {
@@ -125,9 +125,9 @@ mod tests {
 
     #[test]
     fn test_record_not_found_maps_to_not_found() {
-        let err: AppError = DbErr::RecordNotFound("user not found".to_string()).into();
+        let err: Error = DbErr::RecordNotFound("user not found".to_string()).into();
         match err {
-            AppError::NotFound(msg) => assert_eq!(msg, "user not found"),
+            Error::NotFound(msg) => assert_eq!(msg, "user not found"),
             other => panic!("expected NotFound, got {other:?}"),
         }
     }
@@ -135,9 +135,9 @@ mod tests {
     #[test]
     fn test_unrecognized_dberr_maps_to_internal() {
         // DbErr::Custom does not produce a SqlErr, so it should fall through to Internal.
-        let err: AppError = DbErr::Custom("something went wrong".to_string()).into();
+        let err: Error = DbErr::Custom("something went wrong".to_string()).into();
         match &err {
-            AppError::Internal(_) => {}
+            Error::Internal(_) => {}
             other => panic!("expected Internal, got {other:?}"),
         }
         // The static "Database error" context is the topmost layer, the original
@@ -173,9 +173,9 @@ mod tests {
         .await;
 
         let dberr = result.expect_err("duplicate username should fail");
-        let app_err: AppError = dberr.into();
+        let app_err: Error = dberr.into();
         match app_err {
-            AppError::Conflict(_) => {}
+            Error::Conflict(_) => {}
             other => panic!("expected Conflict, got {other:?}"),
         }
     }
@@ -204,9 +204,9 @@ mod tests {
         .await;
 
         let dberr = result.expect_err("missing FK should fail");
-        let app_err: AppError = dberr.into();
+        let app_err: Error = dberr.into();
         match app_err {
-            AppError::BadRequest(_) => {}
+            Error::BadRequest(_) => {}
             other => panic!("expected BadRequest, got {other:?}"),
         }
     }
@@ -215,9 +215,9 @@ mod tests {
     fn test_jwt_error_maps_to_token_variant_with_source() {
         let jwt_err =
             jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken);
-        let app_err: AppError = jwt_err.into();
+        let app_err: Error = jwt_err.into();
         match &app_err {
-            AppError::Token(_) => {}
+            Error::Token(_) => {}
             other => panic!("expected Token, got {other:?}"),
         }
         // The wrapped error must be reachable via the source chain so the
@@ -230,9 +230,9 @@ mod tests {
 
     #[test]
     fn test_argon2_error_maps_to_hash_variant_with_source() {
-        let app_err: AppError = argon2::password_hash::Error::Password.into();
+        let app_err: Error = argon2::password_hash::Error::Password.into();
         match &app_err {
-            AppError::Hash(_) => {}
+            Error::Hash(_) => {}
             other => panic!("expected Hash, got {other:?}"),
         }
         assert!(
@@ -245,7 +245,7 @@ mod tests {
     fn test_format_error_chain_joins_sources() {
         let jwt_err =
             jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken);
-        let app_err: AppError = jwt_err.into();
+        let app_err: Error = jwt_err.into();
         let chain = format_error_chain(&app_err);
         // First segment is the variant's Display ("Token error"); the second is
         // the wrapped jwt error's Display, joined by ": ".
@@ -260,9 +260,9 @@ mod tests {
     fn test_internal_synthetic_anyhow_round_trips() {
         // Synthetic Internal — no underlying error, just a runtime-formatted
         // message via anyhow::anyhow!. The chain should contain the message.
-        let app_err: AppError = anyhow::anyhow!("Invariant violation: {}", "stale state").into();
+        let app_err: Error = anyhow::anyhow!("Invariant violation: {}", "stale state").into();
         match &app_err {
-            AppError::Internal(_) => {}
+            Error::Internal(_) => {}
             other => panic!("expected Internal, got {other:?}"),
         }
         let chain = format_error_chain(&app_err);
@@ -278,7 +278,7 @@ mod tests {
         // The chain walk should show the static context first, then the source's
         // Display. This is the shape produced by the From<DbErr> fallback.
         let inner = std::io::Error::other("disk gone");
-        let app_err: AppError = anyhow::Error::new(inner).context("Writing snapshot").into();
+        let app_err: Error = anyhow::Error::new(inner).context("Writing snapshot").into();
         let chain = format_error_chain(&app_err);
         assert!(chain.contains("Writing snapshot"), "got: {chain}");
         assert!(chain.contains("disk gone"), "got: {chain}");

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -17,7 +17,7 @@ pub mod test_helpers;
 
 use std::sync::Arc;
 
-use config::AppConfig;
+use config::Config;
 use sea_orm::DatabaseConnection;
 use tokio::sync::Semaphore;
 
@@ -32,12 +32,12 @@ pub const ARGON2_MAX_CONCURRENT: usize = 16;
 
 /// Shared application state available to all Axum handlers via `State<AppState>`.
 ///
-/// `AppState` is cheaply cloneable — `DatabaseConnection`, `Arc<AppConfig>`,
+/// `AppState` is cheaply cloneable — `DatabaseConnection`, `Arc<Config>`,
 /// and `Arc<Semaphore>` are all reference-counted internally.
 #[derive(Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
-    pub config: Arc<AppConfig>,
+    pub config: Arc<Config>,
     /// Caps concurrent Argon2 hash/verify operations across all handlers.
     /// See `services::auth::{hash_password, verify_password}`.
     pub argon2_limit: Arc<Semaphore>,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
     Json, Router,
     routing::{get, post, put},
 };
-use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::AppConfig, db, routes, services};
+use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, db, routes, services};
 use migration::{Migrator, MigratorTrait};
 use serde::Serialize;
 use tokio::sync::Semaphore;
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|_| "sqlite:../data/db/beerio-kart.db?mode=rwc".to_string());
 
     // Load config from env vars (errors if JWT_SECRET is missing)
-    let config = AppConfig::from_env()?;
+    let config = Config::from_env()?;
 
     // Build the SQLx pool with per-connection PRAGMAs (foreign_keys, busy_timeout,
     // synchronous, journal_mode), then wrap as a SeaORM DatabaseConnection. See

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -1,6 +1,6 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
 
-use crate::{domain::UserId, error::AppError};
+use crate::{domain::UserId, error::Error};
 
 /// Extractor that validates the JWT from the `Authorization: Bearer <token>`
 /// header and makes the authenticated user's info available to handlers.
@@ -12,22 +12,22 @@ use crate::{domain::UserId, error::AppError};
 ///
 /// Usage in a handler:
 /// ```ignore
-/// async fn protected(user: AuthUser) -> impl IntoResponse {
+/// async fn protected(user: User) -> impl IntoResponse {
 ///     format!("Hello, {}", user.username)
 /// }
 /// ```
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct AuthUser {
+pub struct User {
     pub user_id: UserId,
     pub username: String,
 }
 
-/// Axum extractor implementation. Pulls `AppConfig` from state and validates
+/// Axum extractor implementation. Pulls `Config` from state and validates
 /// the bearer token. Returns 401 if the token is missing, malformed, expired,
 /// or not an access token.
-impl FromRequestParts<crate::AppState> for AuthUser {
-    type Rejection = AppError;
+impl FromRequestParts<crate::AppState> for User {
+    type Rejection = Error;
 
     async fn from_request_parts(
         parts: &mut Parts,
@@ -37,18 +37,18 @@ impl FromRequestParts<crate::AppState> for AuthUser {
             .headers
             .get("Authorization")
             .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| AppError::Unauthorized("Missing Authorization header".to_string()))?;
+            .ok_or_else(|| Error::Unauthorized("Missing Authorization header".to_string()))?;
 
         let token = auth_header.strip_prefix("Bearer ").ok_or_else(|| {
-            AppError::Unauthorized("Invalid Authorization header format".to_string())
+            Error::Unauthorized("Invalid Authorization header format".to_string())
         })?;
 
         let claims = crate::services::auth::validate_access_token(token, &state.config)
-            .map_err(|_| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+            .map_err(|_| Error::Unauthorized("Invalid or expired token".to_string()))?;
 
         // Reject refresh tokens used as access tokens
         if claims.token_type != "access" {
-            return Err(AppError::Unauthorized("Invalid token type".to_string()));
+            return Err(Error::Unauthorized("Invalid token type".to_string()));
         }
 
         Ok(Self {
@@ -58,7 +58,7 @@ impl FromRequestParts<crate::AppState> for AuthUser {
     }
 }
 
-/// Extractor for admin-only routes. First validates the JWT (via `AuthUser`),
+/// Extractor for admin-only routes. First validates the JWT (via `User`),
 /// then checks the user ID against the `ADMIN_USER_ID` env var.
 ///
 /// Returns 403 if the user is authenticated but not the admin.
@@ -70,24 +70,24 @@ pub struct AdminUser {
 }
 
 impl FromRequestParts<crate::AppState> for AdminUser {
-    type Rejection = AppError;
+    type Rejection = Error;
 
     async fn from_request_parts(
         parts: &mut Parts,
         state: &crate::AppState,
     ) -> Result<Self, Self::Rejection> {
         // First, authenticate normally
-        let auth_user = AuthUser::from_request_parts(parts, state).await?;
+        let auth_user = User::from_request_parts(parts, state).await?;
 
         // Then check admin status
         let admin_id = state
             .config
             .admin_user_id
             .as_ref()
-            .ok_or_else(|| AppError::Forbidden("Admin access not configured".to_string()))?;
+            .ok_or_else(|| Error::Forbidden("Admin access not configured".to_string()))?;
 
         if auth_user.user_id.as_str() != admin_id {
-            return Err(AppError::Forbidden("Admin access required".to_string()));
+            return Err(Error::Forbidden("Admin access required".to_string()));
         }
 
         Ok(Self {

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -8,7 +8,7 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, Query
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AppState, domain::UserId, entities::users, error::AppError, middleware::auth::AuthUser,
+    AppState, domain::UserId, entities::users, error::Error, middleware::auth::User,
     services::auth as auth_service,
 };
 
@@ -33,7 +33,7 @@ pub struct ChangePasswordRequest {
 }
 
 #[derive(Serialize)]
-pub struct AuthResponse {
+pub struct Response {
     pub access_token: String,
     pub user: UserInfo,
 }
@@ -54,15 +54,15 @@ pub struct UserInfo {
 /// Build response headers that set the refresh token cookie.
 fn make_refresh_headers(
     refresh_token: &str,
-    config: &crate::config::AppConfig,
-) -> Result<HeaderMap, AppError> {
-    let max_age_seconds = config.jwt_refresh_expiry_days as i64 * 86400;
+    config: &crate::config::Config,
+) -> Result<HeaderMap, Error> {
+    let max_age_seconds = config.jwt_refresh_expiry_days * 86400;
     let cookie = auth_service::refresh_cookie(refresh_token, max_age_seconds, config);
     let mut headers = HeaderMap::new();
     headers.insert(
         header::SET_COOKIE,
         cookie.parse().map_err(|e| {
-            AppError::Internal(anyhow::Error::new(e).context("Failed to build Set-Cookie header"))
+            Error::Internal(anyhow::Error::new(e).context("Failed to build Set-Cookie header"))
         })?,
     );
     Ok(headers)
@@ -90,16 +90,14 @@ fn extract_refresh_cookie(headers: &HeaderMap) -> Option<String> {
 pub async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let username = body.username.trim();
     if username.is_empty() || username.chars().count() > 30 {
-        return Err(AppError::BadRequest(
-            "Username must be 1-30 characters".into(),
-        ));
+        return Err(Error::BadRequest("Username must be 1-30 characters".into()));
     }
 
     if body.password.len() < 8 || body.password.len() > 128 {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "Password must be 8-128 characters".into(),
         ));
     }
@@ -111,7 +109,7 @@ pub async fn register(
         .await?;
 
     if existing.is_some() {
-        return Err(AppError::Conflict("Username already taken".into()));
+        return Err(Error::Conflict("Username already taken".into()));
     }
 
     // Hash password (offloaded to the blocking pool, capped by argon2_limit)
@@ -147,7 +145,7 @@ pub async fn register(
     Ok((
         StatusCode::CREATED,
         headers,
-        Json(AuthResponse {
+        Json(Response {
             access_token,
             user: UserInfo {
                 id: UserId::new(user_id),
@@ -164,7 +162,7 @@ pub async fn register(
 pub async fn login(
     State(state): State<AppState>,
     Json(body): Json<LoginRequest>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let username = body.username.trim();
 
     let Some(user) = users::Entity::find()
@@ -181,9 +179,7 @@ pub async fn login(
                 .to_string(),
         )
         .await;
-        return Err(AppError::Unauthorized(
-            "Invalid username or password".into(),
-        ));
+        return Err(Error::Unauthorized("Invalid username or password".into()));
     };
 
     // Verify password (offloaded to the blocking pool, capped by argon2_limit)
@@ -194,9 +190,7 @@ pub async fn login(
     )
     .await?;
     if !password_ok {
-        return Err(AppError::Unauthorized(
-            "Invalid username or password".into(),
-        ));
+        return Err(Error::Unauthorized("Invalid username or password".into()));
     }
 
     // Generate tokens
@@ -207,7 +201,7 @@ pub async fn login(
 
     Ok((
         headers,
-        Json(AuthResponse {
+        Json(Response {
             access_token,
             user: UserInfo {
                 id: UserId::new(user.id),
@@ -229,32 +223,30 @@ pub async fn login(
 pub async fn refresh(
     State(state): State<AppState>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let cookie_value = match extract_refresh_cookie(&headers) {
         Some(v) if !v.is_empty() => v,
-        _ => return Err(AppError::Unauthorized("Missing refresh token".into())),
+        _ => return Err(Error::Unauthorized("Missing refresh token".into())),
     };
 
     // Validate the JWT signature and expiry
     let claims = auth_service::validate_refresh_token(&cookie_value, &state.config)
-        .map_err(|_| AppError::Unauthorized("Invalid or expired refresh token".into()))?;
+        .map_err(|_| Error::Unauthorized("Invalid or expired refresh token".into()))?;
 
     // Reject if token_type is not "refresh"
     if claims.token_type != "refresh" {
-        return Err(AppError::Unauthorized("Invalid token type".into()));
+        return Err(Error::Unauthorized("Invalid token type".into()));
     }
 
     // Look up user and check refresh_token_version
     let user = users::Entity::find_by_id(&claims.sub)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
+        .ok_or_else(|| Error::Unauthorized("User not found".into()))?;
 
     // Version mismatch means the token was revoked (logout or password change)
     if claims.refresh_token_version != user.refresh_token_version {
-        return Err(AppError::Unauthorized(
-            "Refresh token has been revoked".into(),
-        ));
+        return Err(Error::Unauthorized("Refresh token has been revoked".into()));
     }
 
     // Issue new tokens
@@ -273,16 +265,13 @@ pub async fn refresh(
 /// Requires authentication. Increments `refresh_token_version` in the database,
 /// which invalidates ALL refresh tokens for this user across all devices.
 /// Also clears the refresh cookie on the current browser.
-pub async fn logout(
-    State(state): State<AppState>,
-    user: AuthUser,
-) -> Result<impl IntoResponse, AppError> {
+pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl IntoResponse, Error> {
     // Look up user to get current version
     let db_user = users::Entity::find_by_id(&user.user_id)
         .one(&state.db)
         .await?
         .ok_or_else(|| {
-            AppError::Internal(anyhow::anyhow!("Authenticated user not found in database"))
+            Error::Internal(anyhow::anyhow!("Authenticated user not found in database"))
         })?;
 
     // Increment version to invalidate all existing refresh tokens
@@ -299,7 +288,7 @@ pub async fn logout(
     headers.insert(
         header::SET_COOKIE,
         cookie.parse().map_err(|e| {
-            AppError::Internal(anyhow::Error::new(e).context("Failed to build Set-Cookie header"))
+            Error::Internal(anyhow::Error::new(e).context("Failed to build Set-Cookie header"))
         })?,
     );
 
@@ -313,12 +302,12 @@ pub async fn logout(
 /// Returns new tokens for the current session so the user stays logged in.
 pub async fn change_password(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: User,
     Json(body): Json<ChangePasswordRequest>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     // Validate new password length
     if body.new_password.len() < 8 || body.new_password.len() > 128 {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "New password must be 8-128 characters".into(),
         ));
     }
@@ -327,7 +316,7 @@ pub async fn change_password(
     let db_user = users::Entity::find_by_id(&user.user_id)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::NotFound("User not found".into()))?;
+        .ok_or_else(|| Error::NotFound("User not found".into()))?;
 
     // Verify current password
     let current_ok = auth_service::verify_password(
@@ -337,9 +326,7 @@ pub async fn change_password(
     )
     .await?;
     if !current_ok {
-        return Err(AppError::Unauthorized(
-            "Current password is incorrect".into(),
-        ));
+        return Err(Error::Unauthorized("Current password is incorrect".into()));
     }
 
     // Hash new password

--- a/backend/src/routes/drink_types.rs
+++ b/backend/src/routes/drink_types.rs
@@ -7,8 +7,8 @@ use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AppState, drink_type_id::drink_type_uuid, entities::drink_types, error::AppError,
-    middleware::auth::AuthUser,
+    AppState, drink_type_id::drink_type_uuid, entities::drink_types, error::Error,
+    middleware::auth::User,
 };
 
 // ── Response types ───────────────────────────────────────────────────
@@ -43,25 +43,25 @@ pub struct CreateDrinkTypeRequest {
 }
 
 #[derive(Deserialize)]
-pub struct DrinkTypesQuery {
+pub struct Filters {
     pub alcoholic: Option<bool>,
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────
 
 pub async fn create_drink_type(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Json(req): Json<CreateDrinkTypeRequest>,
-) -> Result<Json<DrinkTypeResponse>, AppError> {
+) -> Result<Json<DrinkTypeResponse>, Error> {
     let name = req.name.trim().to_string();
     if name.is_empty() {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "Drink type name cannot be empty".to_string(),
         ));
     }
     if name.len() > 200 {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "Drink type name must be 200 characters or fewer".to_string(),
         ));
     }
@@ -90,10 +90,10 @@ pub async fn create_drink_type(
 }
 
 pub async fn list_drink_types(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-    Query(params): Query<DrinkTypesQuery>,
-) -> Result<Json<Vec<DrinkTypeResponse>>, AppError> {
+    Query(params): Query<Filters>,
+) -> Result<Json<Vec<DrinkTypeResponse>>, Error> {
     let mut query = drink_types::Entity::find();
     if let Some(alcoholic) = params.alcoholic {
         query = query.filter(drink_types::Column::Alcoholic.eq(alcoholic));
@@ -106,14 +106,14 @@ pub async fn list_drink_types(
 }
 
 pub async fn get_drink_type(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<DrinkTypeResponse>, AppError> {
+) -> Result<Json<DrinkTypeResponse>, Error> {
     let dt = drink_types::Entity::find_by_id(&id)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("Drink type {id} not found")))?;
+        .ok_or_else(|| Error::NotFound(format!("Drink type {id} not found")))?;
 
     Ok(Json(dt.into()))
 }

--- a/backend/src/routes/game_data.rs
+++ b/backend/src/routes/game_data.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AppState,
     entities::{bodies, characters, cups, gliders, tracks, wheels},
-    error::AppError,
-    middleware::auth::AuthUser,
+    error::Error,
+    middleware::auth::User,
 };
 
 // ── Response types ───────────────────────────────────────────────────
@@ -73,54 +73,54 @@ pub struct TracksQuery {
 // ── Handlers ─────────────────────────────────────────────────────────
 
 pub async fn list_characters(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, AppError> {
+) -> Result<Json<Vec<SimpleItem>>, Error> {
     let items = characters::Entity::find().all(&state.db).await?;
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
 pub async fn list_bodies(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, AppError> {
+) -> Result<Json<Vec<SimpleItem>>, Error> {
     let items = bodies::Entity::find().all(&state.db).await?;
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
 pub async fn list_wheels(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, AppError> {
+) -> Result<Json<Vec<SimpleItem>>, Error> {
     let items = wheels::Entity::find().all(&state.db).await?;
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
 pub async fn list_gliders(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, AppError> {
+) -> Result<Json<Vec<SimpleItem>>, Error> {
     let items = gliders::Entity::find().all(&state.db).await?;
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
 pub async fn list_cups(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, AppError> {
+) -> Result<Json<Vec<SimpleItem>>, Error> {
     let items = cups::Entity::find().all(&state.db).await?;
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
 pub async fn get_cup(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<i32>,
-) -> Result<Json<CupWithTracksResponse>, AppError> {
+) -> Result<Json<CupWithTracksResponse>, Error> {
     let cup = cups::Entity::find_by_id(id)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("Cup {id} not found")))?;
+        .ok_or_else(|| Error::NotFound(format!("Cup {id} not found")))?;
 
     let cup_tracks: Vec<TrackResponse> = tracks::Entity::find()
         .filter(tracks::Column::CupId.eq(id))
@@ -139,10 +139,10 @@ pub async fn get_cup(
 }
 
 pub async fn list_tracks(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Query(params): Query<TracksQuery>,
-) -> Result<Json<Vec<TrackResponse>>, AppError> {
+) -> Result<Json<Vec<TrackResponse>>, Error> {
     let mut query = tracks::Entity::find();
     if let Some(cup_id) = params.cup_id {
         query = query.filter(tracks::Column::CupId.eq(cup_id));
@@ -153,14 +153,14 @@ pub async fn list_tracks(
 }
 
 pub async fn get_track(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<i32>,
-) -> Result<Json<TrackResponse>, AppError> {
+) -> Result<Json<TrackResponse>, Error> {
     let track = tracks::Entity::find_by_id(id)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("Track {id} not found")))?;
+        .ok_or_else(|| Error::NotFound(format!("Track {id} not found")))?;
 
     Ok(Json(track.into()))
 }

--- a/backend/src/routes/runs.rs
+++ b/backend/src/routes/runs.rs
@@ -9,17 +9,17 @@ use serde::Deserialize;
 use crate::{
     AppState,
     domain::{RunId, SessionRaceId, UserId},
-    error::AppError,
-    middleware::auth::AuthUser,
+    error::Error,
+    middleware::auth::User,
     services::runs,
 };
 
 /// POST /runs — create a run.
 pub async fn create_run(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Json(body): Json<runs::CreateRunRequest>,
-) -> Result<(StatusCode, Json<runs::RunDetail>), AppError> {
+) -> Result<(StatusCode, Json<runs::RunDetail>), Error> {
     let detail = runs::create_run(&state.db, &user.user_id, body).await?;
     Ok((StatusCode::CREATED, Json(detail)))
 }
@@ -33,10 +33,10 @@ pub struct ListRunsQuery {
 
 /// GET /runs — list runs with optional filters.
 pub async fn list_runs(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Query(query): Query<ListRunsQuery>,
-) -> Result<Json<Vec<runs::RunDetail>>, AppError> {
+) -> Result<Json<Vec<runs::RunDetail>>, Error> {
     let filters = runs::RunFilters {
         session_race_id: query.session_race_id.map(SessionRaceId::new),
         user_id: query.user_id.map(UserId::new),
@@ -48,19 +48,19 @@ pub async fn list_runs(
 
 /// GET /runs/defaults — get defaults for the authenticated user.
 pub async fn get_defaults(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
-) -> Result<Json<runs::RunDefaults>, AppError> {
+) -> Result<Json<runs::RunDefaults>, Error> {
     let defaults = runs::get_run_defaults(&state.db, &user.user_id).await?;
     Ok(Json(defaults))
 }
 
 /// GET /runs/:id — get a single run.
 pub async fn get_run(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<runs::RunDetail>, AppError> {
+) -> Result<Json<runs::RunDetail>, Error> {
     let run_id = RunId::new(id);
     let detail = runs::get_run(&state.db, &run_id).await?;
     Ok(Json(detail))
@@ -68,10 +68,10 @@ pub async fn get_run(
 
 /// DELETE /runs/:id — delete a run. Owner only, active session only.
 pub async fn delete_run(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let run_id = RunId::new(id);
     runs::delete_run(&state.db, &run_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AppState,
     domain::{SessionId, SessionRaceId},
-    error::AppError,
-    middleware::auth::AuthUser,
+    error::Error,
+    middleware::auth::User,
     services::sessions,
 };
 
@@ -21,10 +21,10 @@ pub struct CreateSessionRequest {
 
 /// POST /sessions — create a new session. Returns full session detail.
 pub async fn create_session(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Json(body): Json<CreateSessionRequest>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let detail = sessions::create_session(&state.db, &user.user_id, &body.ruleset).await?;
     Ok((StatusCode::CREATED, Json(detail)))
 }
@@ -36,28 +36,28 @@ pub struct MySessionResponse {
 
 /// GET /sessions/mine — get the user's current active session ID.
 pub async fn my_session(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
-) -> Result<Json<MySessionResponse>, AppError> {
+) -> Result<Json<MySessionResponse>, Error> {
     let session_id = sessions::get_active_session_id(&state.db, &user.user_id).await?;
     Ok(Json(MySessionResponse { session_id }))
 }
 
 /// GET /sessions — list active sessions.
 pub async fn list_sessions(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<sessions::SessionSummary>>, AppError> {
+) -> Result<Json<Vec<sessions::SessionSummary>>, Error> {
     let summaries = sessions::list_active_sessions(&state.db).await?;
     Ok(Json(summaries))
 }
 
 /// GET /sessions/:id — full session state for polling.
 pub async fn get_session(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<sessions::SessionDetail>, AppError> {
+) -> Result<Json<sessions::SessionDetail>, Error> {
     let session_id = SessionId::new(id);
     let detail = sessions::get_session_detail(&state.db, &session_id, Some(&user.user_id)).await?;
     Ok(Json(detail))
@@ -65,10 +65,10 @@ pub async fn get_session(
 
 /// POST /sessions/:id/join — join a session.
 pub async fn join_session(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let session_id = SessionId::new(id);
     sessions::join_session(&state.db, &session_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -76,10 +76,10 @@ pub async fn join_session(
 
 /// POST /sessions/:id/leave — leave a session.
 pub async fn leave_session(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let session_id = SessionId::new(id);
     sessions::leave_session(&state.db, &session_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -87,10 +87,10 @@ pub async fn leave_session(
 
 /// POST /sessions/:id/next-track — pick the next random track.
 pub async fn next_track(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), AppError> {
+) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), Error> {
     let session_id = SessionId::new(id);
     let race = sessions::next_track(&state.db, &session_id, &user.user_id).await?;
     Ok((StatusCode::CREATED, Json(race)))
@@ -98,10 +98,10 @@ pub async fn next_track(
 
 /// POST /sessions/:id/skip-turn — re-roll the current track.
 pub async fn skip_turn(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), AppError> {
+) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), Error> {
     let session_id = SessionId::new(id);
     let race = sessions::skip_turn(&state.db, &session_id, &user.user_id).await?;
     Ok((StatusCode::CREATED, Json(race)))
@@ -110,10 +110,10 @@ pub async fn skip_turn(
 /// POST /sessions/:id/races/:race_id/skip — mark a pending race as skipped
 /// for the requesting user. Idempotent.
 pub async fn skip_pending_race(
-    user: AuthUser,
+    user: User,
     State(state): State<AppState>,
     Path((session_id, race_id)): Path<(String, String)>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<impl IntoResponse, Error> {
     let session_id = SessionId::new(session_id);
     let race_id = SessionRaceId::new(race_id);
     sessions::skip_pending_race(&state.db, &session_id, &race_id, &user.user_id).await?;
@@ -122,10 +122,10 @@ pub async fn skip_pending_race(
 
 /// GET /sessions/:id/races — list all races in a session.
 pub async fn list_races(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<Vec<sessions::RaceInfo>>, AppError> {
+) -> Result<Json<Vec<sessions::RaceInfo>>, Error> {
     let session_id = SessionId::new(id);
     let races = sessions::list_races(&state.db, &session_id).await?;
     Ok(Json(races))

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -7,7 +7,7 @@ use sea_orm::EntityTrait;
 use serde::Serialize;
 
 use crate::{
-    AppState, domain::UserId, entities::users, error::AppError, middleware::auth::AuthUser,
+    AppState, domain::UserId, entities::users, error::Error, middleware::auth::User,
     services::users as user_service,
 };
 
@@ -28,9 +28,9 @@ pub struct UserPublicProfile {
 // ── Handlers ────────────────────────────────────────────────────────
 
 pub async fn list_users(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<UserPublicProfile>>, AppError> {
+) -> Result<Json<Vec<UserPublicProfile>>, Error> {
     let all_users = users::Entity::find().all(&state.db).await?;
     Ok(Json(
         all_users
@@ -50,25 +50,25 @@ pub async fn list_users(
 }
 
 pub async fn get_user(
-    _user: AuthUser,
+    _user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<user_service::UserDetailProfile>, AppError> {
+) -> Result<Json<user_service::UserDetailProfile>, Error> {
     let user = users::Entity::find_by_id(&id)
         .one(&state.db)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("User {id} not found")))?;
+        .ok_or_else(|| Error::NotFound(format!("User {id} not found")))?;
 
     let profile = user_service::build_detail_profile(&state.db, user).await?;
     Ok(Json(profile))
 }
 
 pub async fn update_user(
-    auth_user: AuthUser,
+    auth_user: User,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<user_service::UpdateProfileRequest>,
-) -> Result<Json<user_service::UserDetailProfile>, AppError> {
+) -> Result<Json<user_service::UserDetailProfile>, Error> {
     let target_user_id = UserId::new(id);
     let profile =
         user_service::update_profile(&state.db, &auth_user.user_id, &target_user_id, req).await?;

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -7,7 +7,7 @@ use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode}
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
-use crate::{config::AppConfig, error::AppError};
+use crate::{config::Config, error::Error};
 
 /// Claims for short-lived access tokens (sent in response body, stored in JS memory).
 #[derive(Debug, Serialize, Deserialize)]
@@ -51,19 +51,20 @@ pub struct RefreshClaims {
 /// runs on Tokio's blocking pool via `spawn_blocking` so it never stalls an
 /// async worker, and `limiter` caps concurrent hashes (see
 /// `coding-standards/tokio.md` § 2 and § 12).
-pub async fn hash_password(limiter: &Semaphore, password: String) -> Result<String, AppError> {
-    let _permit = limiter.acquire().await.map_err(|e| {
-        AppError::Internal(anyhow::Error::new(e).context("Argon2 semaphore closed"))
-    })?;
+pub async fn hash_password(limiter: &Semaphore, password: String) -> Result<String, Error> {
+    let _permit = limiter
+        .acquire()
+        .await
+        .map_err(|e| Error::Internal(anyhow::Error::new(e).context("Argon2 semaphore closed")))?;
     tokio::task::spawn_blocking(move || {
         let salt = SaltString::generate(&mut rand_core::OsRng);
         Argon2::default()
             .hash_password(password.as_bytes(), &salt)
             .map(|h| h.to_string())
-            .map_err(AppError::from)
+            .map_err(Error::from)
     })
     .await
-    .map_err(|e| AppError::Internal(anyhow::Error::new(e).context("Argon2 hash task panicked")))?
+    .map_err(|e| Error::Internal(anyhow::Error::new(e).context("Argon2 hash task panicked")))?
 }
 
 /// Verify a plaintext password against a stored Argon2id hash.
@@ -74,28 +75,29 @@ pub async fn verify_password(
     limiter: &Semaphore,
     password: String,
     hash: String,
-) -> Result<bool, AppError> {
-    let _permit = limiter.acquire().await.map_err(|e| {
-        AppError::Internal(anyhow::Error::new(e).context("Argon2 semaphore closed"))
-    })?;
+) -> Result<bool, Error> {
+    let _permit = limiter
+        .acquire()
+        .await
+        .map_err(|e| Error::Internal(anyhow::Error::new(e).context("Argon2 semaphore closed")))?;
     tokio::task::spawn_blocking(move || {
-        let parsed = PasswordHash::new(&hash).map_err(AppError::from)?;
+        let parsed = PasswordHash::new(&hash).map_err(Error::from)?;
         Ok(Argon2::default()
             .verify_password(password.as_bytes(), &parsed)
             .is_ok())
     })
     .await
-    .map_err(|e| AppError::Internal(anyhow::Error::new(e).context("Argon2 verify task panicked")))?
+    .map_err(|e| Error::Internal(anyhow::Error::new(e).context("Argon2 verify task panicked")))?
 }
 
 /// Create a short-lived access token for the given user.
 pub fn create_access_token(
     user_id: &str,
     username: &str,
-    config: &AppConfig,
+    config: &Config,
 ) -> Result<String, jsonwebtoken::errors::Error> {
     let now = Utc::now();
-    let expiry = now + TimeDelta::minutes(config.jwt_access_expiry_minutes as i64);
+    let expiry = now + TimeDelta::minutes(config.jwt_access_expiry_minutes);
 
     let claims = AccessClaims {
         sub: user_id.to_string(),
@@ -116,10 +118,10 @@ pub fn create_access_token(
 pub fn create_refresh_token(
     user_id: &str,
     refresh_token_version: i32,
-    config: &AppConfig,
+    config: &Config,
 ) -> Result<String, jsonwebtoken::errors::Error> {
     let now = Utc::now();
-    let expiry = now + TimeDelta::days(config.jwt_refresh_expiry_days as i64);
+    let expiry = now + TimeDelta::days(config.jwt_refresh_expiry_days);
 
     let claims = RefreshClaims {
         sub: user_id.to_string(),
@@ -139,7 +141,7 @@ pub fn create_refresh_token(
 /// Validate an access token and return its claims.
 pub fn validate_access_token(
     token: &str,
-    config: &AppConfig,
+    config: &Config,
 ) -> Result<AccessClaims, jsonwebtoken::errors::Error> {
     let token_data = decode::<AccessClaims>(
         token,
@@ -152,7 +154,7 @@ pub fn validate_access_token(
 /// Validate a refresh token and return its claims.
 pub fn validate_refresh_token(
     token: &str,
-    config: &AppConfig,
+    config: &Config,
 ) -> Result<RefreshClaims, jsonwebtoken::errors::Error> {
     let token_data = decode::<RefreshClaims>(
         token,
@@ -164,7 +166,7 @@ pub fn validate_refresh_token(
 
 /// Build the `Set-Cookie` header value for a refresh token.
 #[must_use]
-pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &AppConfig) -> String {
+pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &Config) -> String {
     let secure = if config.cookie_secure { "Secure; " } else { "" };
     format!(
         "refresh_token={token}; HttpOnly; {secure}SameSite=Lax; Path=/api/v1/auth/refresh; Max-Age={max_age_seconds}"
@@ -173,7 +175,7 @@ pub fn refresh_cookie(token: &str, max_age_seconds: i64, config: &AppConfig) -> 
 
 /// Build a `Set-Cookie` header value that clears the refresh token cookie.
 #[must_use]
-pub fn clear_refresh_cookie(config: &AppConfig) -> String {
+pub fn clear_refresh_cookie(config: &Config) -> String {
     refresh_cookie("", 0, config)
 }
 
@@ -190,8 +192,8 @@ mod tests {
     use super::*;
     use crate::ARGON2_MAX_CONCURRENT;
 
-    fn test_config() -> Arc<AppConfig> {
-        Arc::new(AppConfig {
+    fn test_config() -> Arc<Config> {
+        Arc::new(Config {
             jwt_secret: "test-secret-key-for-unit-tests".to_string(),
             jwt_access_expiry_minutes: 15,
             jwt_refresh_expiry_days: 7,
@@ -355,7 +357,7 @@ mod tests {
         let config = test_config();
         let token = create_access_token("user-123", "testuser", &config).unwrap();
 
-        let wrong_config = Arc::new(AppConfig {
+        let wrong_config = Arc::new(Config {
             jwt_secret: "wrong-secret".to_string(),
             jwt_access_expiry_minutes: 15,
             jwt_refresh_expiry_days: 7,
@@ -374,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_access_token_contains_correct_expiry_window() {
-        let config = Arc::new(AppConfig {
+        let config = Arc::new(Config {
             jwt_secret: "test-secret".to_string(),
             jwt_access_expiry_minutes: 30,
             jwt_refresh_expiry_days: 7,
@@ -391,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_refresh_cookie_format() {
-        let config = Arc::new(AppConfig {
+        let config = Arc::new(Config {
             jwt_secret: "s".to_string(),
             jwt_access_expiry_minutes: 15,
             jwt_refresh_expiry_days: 7,
@@ -408,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_refresh_cookie_no_secure_in_dev() {
-        let config = Arc::new(AppConfig {
+        let config = Arc::new(Config {
             jwt_secret: "s".to_string(),
             jwt_access_expiry_minutes: 15,
             jwt_refresh_expiry_days: 7,

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -13,7 +13,7 @@ use sea_orm::{
 use crate::{
     domain::{SessionId, SessionRaceId, UserId, enums::SessionStatus},
     entities::{session_participants, session_race_participations, sessions, tracks},
-    error::AppError,
+    error::Error,
 };
 
 /// Load a session by ID and require that it is in the `Active` state.
@@ -23,13 +23,13 @@ use crate::{
 pub async fn load_active_session<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
-) -> Result<sessions::Model, AppError> {
+) -> Result<sessions::Model, Error> {
     let session = sessions::Entity::find_by_id(session_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Session not found".into()))?;
+        .ok_or_else(|| Error::NotFound("Session not found".into()))?;
     if session.status != SessionStatus::Active.as_str() {
-        return Err(AppError::Conflict("Session is not active".into()));
+        return Err(Error::Conflict("Session is not active".into()));
     }
     Ok(session)
 }
@@ -42,7 +42,7 @@ pub async fn require_active_participant<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
     user_id: &UserId,
-) -> Result<session_participants::Model, AppError> {
+) -> Result<session_participants::Model, Error> {
     session_participants::Entity::find()
         .filter(
             Condition::all()
@@ -52,7 +52,7 @@ pub async fn require_active_participant<C: ConnectionTrait>(
         )
         .one(db)
         .await?
-        .ok_or_else(|| AppError::Forbidden("Not a participant in this session".into()))
+        .ok_or_else(|| Error::Forbidden("Not a participant in this session".into()))
 }
 
 /// Snapshot per-race presence at race-creation time.
@@ -70,7 +70,7 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
     txn: &C,
     session_id: &SessionId,
     session_race_id: &SessionRaceId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     let now = Utc::now().naive_utc();
 
     let present = session_participants::Entity::find()
@@ -111,7 +111,7 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
 pub async fn touch_session<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     let now = Utc::now().naive_utc();
     sessions::Entity::update_many()
         .col_expr(sessions::Column::LastActivityAt, Expr::value(now))
@@ -131,13 +131,13 @@ pub async fn require_exists<E, C>(
     db: &C,
     id: <<E as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType,
     entity_label: &str,
-) -> Result<(), AppError>
+) -> Result<(), Error>
 where
     E: EntityTrait,
     C: ConnectionTrait,
 {
     if E::find_by_id(id).one(db).await?.is_none() {
-        return Err(AppError::BadRequest(format!("Invalid {entity_label}_id")));
+        return Err(Error::BadRequest(format!("Invalid {entity_label}_id")));
     }
     Ok(())
 }
@@ -156,10 +156,10 @@ pub async fn pick_random_track<C: ConnectionTrait>(
     db: &C,
     exclude: &[i32],
     always_exclude: &[i32],
-) -> Result<tracks::Model, AppError> {
+) -> Result<tracks::Model, Error> {
     let all_tracks = tracks::Entity::find().all(db).await?;
     if all_tracks.is_empty() {
-        return Err(AppError::Internal(anyhow::anyhow!("No tracks configured")));
+        return Err(Error::Internal(anyhow::anyhow!("No tracks configured")));
     }
 
     let available: Vec<&tracks::Model> = all_tracks
@@ -188,7 +188,7 @@ pub async fn pick_random_track<C: ConnectionTrait>(
         pool.choose(&mut rng).copied().cloned()
     };
 
-    chosen.ok_or_else(|| AppError::Internal(anyhow::anyhow!("Empty track pool after reset")))
+    chosen.ok_or_else(|| Error::Internal(anyhow::anyhow!("Empty track pool after reset")))
 }
 
 #[cfg(test)]
@@ -223,7 +223,7 @@ mod tests {
         let err = load_active_session(&db, &SessionId::new("does-not-exist"))
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)));
+        assert!(matches!(err, Error::NotFound(_)));
     }
 
     #[tokio::test]
@@ -233,7 +233,7 @@ mod tests {
         let session_id = insert_session(&db, &host, "closed").await;
 
         let err = load_active_session(&db, &session_id).await.unwrap_err();
-        assert!(matches!(err, AppError::Conflict(_)));
+        assert!(matches!(err, Error::Conflict(_)));
     }
 
     // --- require_active_participant ---
@@ -261,7 +261,7 @@ mod tests {
         let err = require_active_participant(&db, &session_id, &user)
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)));
+        assert!(matches!(err, Error::Forbidden(_)));
     }
 
     #[tokio::test]
@@ -274,7 +274,7 @@ mod tests {
         let err = require_active_participant(&db, &session_id, &user)
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)));
+        assert!(matches!(err, Error::Forbidden(_)));
     }
 
     // --- touch_session ---
@@ -339,7 +339,7 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            AppError::BadRequest(msg) => assert_eq!(msg, "Invalid character_id"),
+            Error::BadRequest(msg) => assert_eq!(msg, "Invalid character_id"),
             other => panic!("expected BadRequest, got {other:?}"),
         }
     }
@@ -391,7 +391,7 @@ mod tests {
         let db = setup_db().await;
         // No tracks seeded.
         let err = pick_random_track(&db, &[], &[]).await.unwrap_err();
-        assert!(matches!(err, AppError::Internal(_)));
+        assert!(matches!(err, Error::Internal(_)));
     }
 
     #[tokio::test]

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -12,7 +12,7 @@ use crate::{
         bodies, characters, drink_types, gliders, runs, session_race_participations, session_races,
         users, wheels,
     },
-    error::AppError,
+    error::Error,
     services::{helpers, sessions},
 };
 
@@ -119,14 +119,14 @@ pub struct RunFilters {
 
 /// Validate time fields on a run submission: track_time range, lap times
 /// positive and within range, and lap sum equals track_time.
-fn validate_time_fields(body: &CreateRunRequest) -> Result<(), AppError> {
+fn validate_time_fields(body: &CreateRunRequest) -> Result<(), Error> {
     if body.track_time <= 0 || body.track_time > MAX_TRACK_TIME_MS {
-        return Err(AppError::BadRequest(format!(
+        return Err(Error::BadRequest(format!(
             "track_time must be between 1 and {MAX_TRACK_TIME_MS} ms"
         )));
     }
     if body.lap1_time <= 0 || body.lap2_time <= 0 || body.lap3_time <= 0 {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "All lap times must be positive".to_string(),
         ));
     }
@@ -134,14 +134,14 @@ fn validate_time_fields(body: &CreateRunRequest) -> Result<(), AppError> {
         || body.lap2_time > MAX_TRACK_TIME_MS
         || body.lap3_time > MAX_TRACK_TIME_MS
     {
-        return Err(AppError::BadRequest(format!(
+        return Err(Error::BadRequest(format!(
             "Each lap time must be at most {MAX_TRACK_TIME_MS} ms"
         )));
     }
     let lap_sum = body.lap1_time + body.lap2_time + body.lap3_time;
     if lap_sum != body.track_time {
         let diff = (lap_sum - body.track_time).abs();
-        return Err(AppError::BadRequest(format!(
+        return Err(Error::BadRequest(format!(
             "Lap times must add up to total time (off by {diff}ms)"
         )));
     }
@@ -155,7 +155,7 @@ pub async fn create_run(
     db: &DatabaseConnection,
     user_id: &UserId,
     body: CreateRunRequest,
-) -> Result<RunDetail, AppError> {
+) -> Result<RunDetail, Error> {
     let session_race = validate_run_request(db, user_id, &body).await?;
     let run_id = insert_run(db, user_id, body, &session_race).await?;
     get_run(db, &run_id).await
@@ -179,20 +179,20 @@ async fn validate_run_request(
     db: &DatabaseConnection,
     user_id: &UserId,
     body: &CreateRunRequest,
-) -> Result<session_races::Model, AppError> {
+) -> Result<session_races::Model, Error> {
     validate_time_fields(body)?;
 
     let session_race = session_races::Entity::find_by_id(&body.session_race_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Session race not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Session race not found".to_string()))?;
 
     let session_id = SessionId::new(session_race.session_id.clone());
     helpers::load_active_session(db, &session_id)
         .await
         .map_err(|e| match e {
-            AppError::Conflict(_) => {
-                AppError::Conflict("Cannot submit run for a closed session".to_string())
+            Error::Conflict(_) => {
+                Error::Conflict("Cannot submit run for a closed session".to_string())
             }
             other => other,
         })?;
@@ -209,7 +209,7 @@ async fn validate_run_request(
         .await?;
 
     if existing.is_some() {
-        return Err(AppError::Conflict(
+        return Err(Error::Conflict(
             "Already submitted a run for this race".to_string(),
         ));
     }
@@ -231,7 +231,7 @@ async fn validate_run_request(
         .as_ref()
         .is_some_and(|p| p.skipped_at.is_some())
     {
-        return Err(AppError::Conflict(
+        return Err(Error::Conflict(
             "Cannot submit a run for a skipped race".to_string(),
         ));
     }
@@ -254,7 +254,7 @@ async fn validate_run_request(
         .filter(|p| p.race_number < session_race.race_number)
         .min_by_key(|p| p.race_number)
     {
-        return Err(AppError::Conflict(format!(
+        return Err(Error::Conflict(format!(
             "Must submit or skip pending race #{} first",
             older.race_number
         )));
@@ -279,7 +279,7 @@ async fn insert_run(
     user_id: &UserId,
     body: CreateRunRequest,
     session_race: &session_races::Model,
-) -> Result<RunId, AppError> {
+) -> Result<RunId, Error> {
     let now = Utc::now().naive_utc();
     let run_id = RunId::new(Uuid::new_v4().to_string());
 
@@ -316,7 +316,7 @@ async fn insert_run(
 }
 
 /// Fetch a single run by ID with JOINed username and drink_type_name.
-pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetail, AppError> {
+pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetail, Error> {
     let row = RunDetailRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -334,7 +334,7 @@ pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetai
     ))
     .one(db)
     .await?
-    .ok_or_else(|| AppError::NotFound("Run not found".to_string()))?;
+    .ok_or_else(|| Error::NotFound("Run not found".to_string()))?;
 
     Ok(row.into())
 }
@@ -343,7 +343,7 @@ pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetai
 pub async fn list_runs(
     db: &DatabaseConnection,
     filters: RunFilters,
-) -> Result<Vec<RunDetail>, AppError> {
+) -> Result<Vec<RunDetail>, Error> {
     let mut conditions = Vec::new();
     let mut params: Vec<sea_orm::Value> = Vec::new();
 
@@ -401,14 +401,14 @@ pub async fn delete_run(
     db: &DatabaseConnection,
     run_id: &RunId,
     user_id: &UserId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     let run = runs::Entity::find_by_id(run_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Run not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Run not found".to_string()))?;
 
     if run.user_id.as_str() != user_id.as_str() {
-        return Err(AppError::Forbidden(
+        return Err(Error::Forbidden(
             "Only the run's owner can delete it".to_string(),
         ));
     }
@@ -417,18 +417,18 @@ pub async fn delete_run(
     let session_race = session_races::Entity::find_by_id(&run.session_race_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("Session race not found for run")))?;
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Session race not found for run")))?;
 
     let session_id = SessionId::new(session_race.session_id.clone());
     // FK guarantees the session exists; NotFound here signals data corruption.
     helpers::load_active_session(db, &session_id)
         .await
         .map_err(|e| match e {
-            AppError::NotFound(msg) => {
-                AppError::Internal(anyhow::anyhow!("Session not found for run: {msg}"))
+            Error::NotFound(msg) => {
+                Error::Internal(anyhow::anyhow!("Session not found for run: {msg}"))
             }
-            AppError::Conflict(_) => {
-                AppError::Conflict("Cannot delete run from a closed session".to_string())
+            Error::Conflict(_) => {
+                Error::Conflict("Cannot delete run from a closed session".to_string())
             }
             other => other,
         })?;
@@ -449,7 +449,7 @@ pub async fn delete_run(
 pub async fn get_run_defaults(
     db: &DatabaseConnection,
     user_id: &UserId,
-) -> Result<RunDefaults, AppError> {
+) -> Result<RunDefaults, Error> {
     // Try most recent run
     let latest_run = runs::Entity::find()
         .filter(runs::Column::UserId.eq(user_id))
@@ -472,7 +472,7 @@ pub async fn get_run_defaults(
     let user = users::Entity::find_by_id(user_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("User not found".to_string()))?;
 
     if user.preferred_character_id.is_some() || user.preferred_drink_type_id.is_some() {
         return Ok(RunDefaults {
@@ -1025,7 +1025,7 @@ mod tests {
 
         // Try to submit race 3 while races 1 and 2 are still pending.
         match create_run(&db, &host_id, valid_run_request(&race_ids[2])).await {
-            Err(AppError::Conflict(msg)) => assert!(
+            Err(Error::Conflict(msg)) => assert!(
                 msg.contains("Must submit or skip pending race #1"),
                 "expected message about race #1, got: {msg}"
             ),
@@ -1060,7 +1060,7 @@ mod tests {
         let (_session_id, race_ids) = setup_session_with_n_races(&db, &host_id, 2).await;
 
         match create_run(&db, &host_id, valid_run_request(&race_ids[1])).await {
-            Err(AppError::Conflict(_)) => {}
+            Err(Error::Conflict(_)) => {}
             Err(other) => panic!("expected Conflict, got {other:?}"),
             Ok(_) => panic!("expected Conflict, got Ok"),
         }
@@ -1103,7 +1103,7 @@ mod tests {
             .expect("skip succeeds");
 
         match create_run(&db, &host_id, valid_run_request(&race_ids[0])).await {
-            Err(AppError::Conflict(msg)) => assert!(
+            Err(Error::Conflict(msg)) => assert!(
                 msg.contains("skipped"),
                 "expected message about skipped race, got: {msg}"
             ),

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -9,7 +9,7 @@ use sea_orm::ConnectionTrait;
 use crate::{
     domain::{SessionId, UserId},
     entities::{session_participants, sessions},
-    error::AppError,
+    error::Error,
     services::helpers,
 };
 
@@ -28,7 +28,7 @@ impl SessionContext {
     pub async fn load_active<C: ConnectionTrait>(
         db: &C,
         session_id: &SessionId,
-    ) -> Result<Self, AppError> {
+    ) -> Result<Self, Error> {
         let session = helpers::load_active_session(db, session_id).await?;
         let session_id = SessionId::new(session.id.clone());
         Ok(Self {
@@ -38,9 +38,9 @@ impl SessionContext {
     }
 
     /// Require that `user_id` is the host of this session.
-    pub fn require_host(&self, user_id: &UserId) -> Result<(), AppError> {
+    pub fn require_host(&self, user_id: &UserId) -> Result<(), Error> {
         if self.session.host_id.as_str() != user_id.as_str() {
-            return Err(AppError::Forbidden("Only the host can do that".into()));
+            return Err(Error::Forbidden("Only the host can do that".into()));
         }
         Ok(())
     }
@@ -50,7 +50,7 @@ impl SessionContext {
         &self,
         db: &C,
         user_id: &UserId,
-    ) -> Result<session_participants::Model, AppError> {
+    ) -> Result<session_participants::Model, Error> {
         helpers::require_active_participant(db, &self.session_id, user_id).await
     }
 
@@ -58,7 +58,7 @@ impl SessionContext {
     /// Delegates the UPDATE to `helpers::touch_session`, then refreshes
     /// the in-memory field so callers that read it post-touch see the
     /// updated value.
-    pub async fn touch<C: ConnectionTrait>(&mut self, db: &C) -> Result<(), AppError> {
+    pub async fn touch<C: ConnectionTrait>(&mut self, db: &C) -> Result<(), Error> {
         helpers::touch_session(db, &self.session_id).await?;
         self.session.last_activity_at = chrono::Utc::now().naive_utc();
         Ok(())
@@ -89,7 +89,7 @@ mod tests {
         let err = SessionContext::load_active(&db, &SessionId::new("missing"))
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)));
+        assert!(matches!(err, Error::NotFound(_)));
     }
 
     #[tokio::test]
@@ -101,7 +101,7 @@ mod tests {
         let err = SessionContext::load_active(&db, &session_id)
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::Conflict(_)));
+        assert!(matches!(err, Error::Conflict(_)));
     }
 
     #[tokio::test]
@@ -123,7 +123,7 @@ mod tests {
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         let err = ctx.require_host(&other).unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)));
+        assert!(matches!(err, Error::Forbidden(_)));
     }
 
     #[tokio::test]
@@ -141,7 +141,7 @@ mod tests {
         // Forbidden path: another user isn't.
         let outsider = create_user(&db, "outsider").await;
         let err = ctx.require_participant(&db, &outsider).await.unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)));
+        assert!(matches!(err, Error::Forbidden(_)));
     }
 
     #[tokio::test]

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -670,9 +670,15 @@ pub async fn get_session_detail(
     // 1-indexed and gapless: `next_track` appends monotonically, and
     // `skip_turn` replaces in-place (preserves race_number). No deletion
     // path exists. Under this invariant, last().race_number == COUNT(*).
-    let race_number = races
-        .last()
-        .map_or(1, |r| usize::try_from(r.race_number).unwrap_or(0));
+    let race_number = match races.last() {
+        None => 1,
+        Some(r) => usize::try_from(r.race_number).map_err(|_| {
+            Error::Internal(anyhow::anyhow!(
+                "race_number invariant violated: got {}",
+                r.race_number
+            ))
+        })?,
+    };
 
     Ok(SessionDetail {
         id: SessionId::new(session.id),
@@ -915,7 +921,12 @@ pub async fn next_track(
         .filter(session_races::Column::SessionId.eq(session_id))
         .all(db)
         .await?;
-    let race_count = i32::try_from(used_races.len()).unwrap_or(i32::MAX);
+    let race_count = i32::try_from(used_races.len()).map_err(|_| {
+        Error::Internal(anyhow::anyhow!(
+            "session has more races than i32 can represent: {}",
+            used_races.len()
+        ))
+    })?;
     let used_track_ids: Vec<i32> = used_races.iter().map(|r| r.track_id).collect();
 
     let chosen = helpers::pick_random_track(db, &used_track_ids, &[]).await?;

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -15,7 +15,7 @@ use crate::{
         cups, runs, session_participants, session_race_participations, session_races, sessions,
         users,
     },
-    error::AppError,
+    error::Error,
     services::helpers,
 };
 
@@ -31,7 +31,7 @@ struct ActiveParticipantRow {
 async fn check_not_in_any_session(
     db: &impl ConnectionTrait,
     user_id: &UserId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     let existing =
         ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
             db.get_database_backend(),
@@ -50,7 +50,7 @@ async fn check_not_in_any_session(
         .await?;
 
     if let Some(row) = existing {
-        return Err(AppError::Conflict(format!(
+        return Err(Error::Conflict(format!(
             "Already in session {}",
             row.session_id
         )));
@@ -64,7 +64,7 @@ async fn check_not_in_any_session(
 pub async fn get_active_session_id(
     db: &DatabaseConnection,
     user_id: &UserId,
-) -> Result<Option<SessionId>, AppError> {
+) -> Result<Option<SessionId>, Error> {
     let row = ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -90,7 +90,7 @@ pub async fn create_session(
     db: &DatabaseConnection,
     user_id: &UserId,
     ruleset: &str,
-) -> Result<SessionDetail, AppError> {
+) -> Result<SessionDetail, Error> {
     let parsed: Ruleset = ruleset.parse()?;
 
     check_not_in_any_session(db, user_id).await?;
@@ -151,9 +151,7 @@ struct SessionSummaryRow {
 
 /// List active sessions sorted by last_activity_at DESC.
 /// Uses a single JOIN query instead of N+1 queries.
-pub async fn list_active_sessions(
-    db: &DatabaseConnection,
-) -> Result<Vec<SessionSummary>, AppError> {
+pub async fn list_active_sessions(db: &DatabaseConnection) -> Result<Vec<SessionSummary>, Error> {
     let rows = SessionSummaryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -300,16 +298,13 @@ pub struct SessionDetail {
 
 /// Look up the host's username. Returns `Internal` if the FK-referenced
 /// user row is missing (data corruption — FKs should prevent this).
-async fn load_host_username(
-    db: &impl ConnectionTrait,
-    host_id: &UserId,
-) -> Result<String, AppError> {
+async fn load_host_username(db: &impl ConnectionTrait, host_id: &UserId) -> Result<String, Error> {
     users::Entity::find_by_id(host_id)
         .one(db)
         .await?
         .map(|u| u.username)
         .ok_or_else(|| {
-            AppError::Internal(anyhow::anyhow!("Host user not found for host_id {host_id}"))
+            Error::Internal(anyhow::anyhow!("Host user not found for host_id {host_id}"))
         })
 }
 
@@ -317,7 +312,7 @@ async fn load_host_username(
 async fn load_participants(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
-) -> Result<Vec<ParticipantInfo>, AppError> {
+) -> Result<Vec<ParticipantInfo>, Error> {
     let rows = ParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -348,7 +343,7 @@ async fn load_participants(
 async fn load_current_race_with_submissions(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
-) -> Result<Option<SessionRaceInfo>, AppError> {
+) -> Result<Option<SessionRaceInfo>, Error> {
     let race_row = CurrentRaceRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -409,7 +404,7 @@ async fn load_current_race_with_submissions(
 async fn load_race_history(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
-) -> Result<Vec<RaceInfo>, AppError> {
+) -> Result<Vec<RaceInfo>, Error> {
     let rows = RaceHistoryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -491,7 +486,7 @@ pub async fn get_pending_races(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
     user_id: &UserId,
-) -> Result<Vec<SessionRaceInfo>, AppError> {
+) -> Result<Vec<SessionRaceInfo>, Error> {
     let now = Utc::now().naive_utc();
     let grace_cutoff = now - chrono::Duration::minutes(REJOIN_GRACE_MINUTES);
 
@@ -575,13 +570,11 @@ pub async fn skip_pending_race(
     session_id: &SessionId,
     session_race_id: &SessionRaceId,
     user_id: &UserId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     helpers::load_active_session(db, session_id)
         .await
         .map_err(|e| match e {
-            AppError::Conflict(_) => {
-                AppError::Conflict("Cannot skip in a closed session".to_string())
-            }
+            Error::Conflict(_) => Error::Conflict("Cannot skip in a closed session".to_string()),
             other => other,
         })?;
     // Symmetry with `create_run`: the user must currently be in the session
@@ -597,7 +590,7 @@ pub async fn skip_pending_race(
         .one(db)
         .await?;
     let Some(race) = race.filter(|r| r.session_id == session_id.as_str()) else {
-        return Err(AppError::NotFound(
+        return Err(Error::NotFound(
             "Race not found in this session".to_string(),
         ));
     };
@@ -610,7 +603,7 @@ pub async fn skip_pending_race(
         )
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Pending race not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Pending race not found".to_string()))?;
 
     // Reject if user already submitted a run for this race.
     let existing_run = runs::Entity::find()
@@ -622,7 +615,7 @@ pub async fn skip_pending_race(
         .one(db)
         .await?;
     if existing_run.is_some() {
-        return Err(AppError::Conflict("Already submitted".to_string()));
+        return Err(Error::Conflict("Already submitted".to_string()));
     }
 
     // Idempotent: already skipped → return success without changing
@@ -656,11 +649,11 @@ pub async fn get_session_detail(
     db: &DatabaseConnection,
     session_id: &SessionId,
     requesting_user_id: Option<&UserId>,
-) -> Result<SessionDetail, AppError> {
+) -> Result<SessionDetail, Error> {
     let session = sessions::Entity::find_by_id(session_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Session not found".to_string()))?;
 
     let host_id = UserId::new(session.host_id);
     let host_username = load_host_username(db, &host_id).await?;
@@ -677,7 +670,9 @@ pub async fn get_session_detail(
     // 1-indexed and gapless: `next_track` appends monotonically, and
     // `skip_turn` replaces in-place (preserves race_number). No deletion
     // path exists. Under this invariant, last().race_number == COUNT(*).
-    let race_number = races.last().map_or(1, |r| r.race_number as usize);
+    let race_number = races
+        .last()
+        .map_or(1, |r| usize::try_from(r.race_number).unwrap_or(0));
 
     Ok(SessionDetail {
         id: SessionId::new(session.id),
@@ -717,11 +712,11 @@ pub async fn join_session(
     db: &DatabaseConnection,
     session_id: &SessionId,
     user_id: &UserId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     helpers::load_active_session(db, session_id)
         .await
         .map_err(|e| match e {
-            AppError::Conflict(_) => AppError::Conflict("Cannot join a closed session".to_string()),
+            Error::Conflict(_) => Error::Conflict("Cannot join a closed session".to_string()),
             other => other,
         })?;
     check_not_in_any_session(db, user_id).await?;
@@ -760,7 +755,7 @@ pub async fn join_session(
                 // this branch implies a race between the two queries (very
                 // unlikely without external manipulation) or direct DB
                 // tampering. Return Conflict either way for safety.
-                return Err(AppError::Conflict(
+                return Err(Error::Conflict(
                     "Already an active participant in this session".to_string(),
                 ));
             };
@@ -819,7 +814,7 @@ async fn transfer_host_or_close(
     session_id: &SessionId,
     leaving_user_id: &UserId,
     is_host_leaving: bool,
-) -> Result<HostDisposition, AppError> {
+) -> Result<HostDisposition, Error> {
     if is_host_leaving {
         let next_host = session_participants::Entity::find()
             .filter(
@@ -861,17 +856,17 @@ pub async fn leave_session(
     db: &DatabaseConnection,
     session_id: &SessionId,
     user_id: &UserId,
-) -> Result<(), AppError> {
+) -> Result<(), Error> {
     let session = sessions::Entity::find_by_id(session_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Session not found".to_string()))?;
 
     // require_active_participant returns Forbidden (authorization guard), but
     // leaving a session you're not in is bad input, not an auth failure.
     let participant = helpers::require_active_participant(db, session_id, user_id)
         .await
-        .map_err(|_| AppError::BadRequest("Not currently in this session".to_string()))?;
+        .map_err(|_| Error::BadRequest("Not currently in this session".to_string()))?;
 
     let now = Utc::now().naive_utc();
     let txn = db.begin().await?;
@@ -909,7 +904,7 @@ pub async fn next_track(
     db: &DatabaseConnection,
     session_id: &SessionId,
     user_id: &UserId,
-) -> Result<SessionRaceInfo, AppError> {
+) -> Result<SessionRaceInfo, Error> {
     use crate::services::session_context::SessionContext;
 
     let ctx = SessionContext::load_active(db, session_id).await?;
@@ -920,7 +915,7 @@ pub async fn next_track(
         .filter(session_races::Column::SessionId.eq(session_id))
         .all(db)
         .await?;
-    let race_count = used_races.len() as i32;
+    let race_count = i32::try_from(used_races.len()).unwrap_or(i32::MAX);
     let used_track_ids: Vec<i32> = used_races.iter().map(|r| r.track_id).collect();
 
     let chosen = helpers::pick_random_track(db, &used_track_ids, &[]).await?;
@@ -952,7 +947,7 @@ pub async fn next_track(
         .one(db)
         .await?
         .ok_or_else(|| {
-            AppError::Internal(anyhow::anyhow!(
+            Error::Internal(anyhow::anyhow!(
                 "Cup not found for cup_id {}",
                 chosen.cup_id
             ))
@@ -980,7 +975,7 @@ pub async fn skip_turn(
     db: &DatabaseConnection,
     session_id: &SessionId,
     _user_id: &UserId,
-) -> Result<SessionRaceInfo, AppError> {
+) -> Result<SessionRaceInfo, Error> {
     helpers::load_active_session(db, session_id).await?;
 
     // Find the most recent race
@@ -989,7 +984,7 @@ pub async fn skip_turn(
         .order_by_desc(session_races::Column::RaceNumber)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::BadRequest("No track to skip".to_string()))?;
+        .ok_or_else(|| Error::BadRequest("No track to skip".to_string()))?;
 
     // Verify no runs exist for this race
     let run_count = runs::Entity::find()
@@ -998,7 +993,7 @@ pub async fn skip_turn(
         .await?;
 
     if run_count > 0 {
-        return Err(AppError::BadRequest(
+        return Err(Error::BadRequest(
             "Can't skip — runs already submitted".to_string(),
         ));
     }
@@ -1047,7 +1042,7 @@ pub async fn skip_turn(
         .one(db)
         .await?
         .ok_or_else(|| {
-            AppError::Internal(anyhow::anyhow!(
+            Error::Internal(anyhow::anyhow!(
                 "Cup not found for cup_id {}",
                 chosen.cup_id
             ))
@@ -1070,12 +1065,12 @@ pub async fn skip_turn(
 pub async fn list_races(
     db: &DatabaseConnection,
     session_id: &SessionId,
-) -> Result<Vec<RaceInfo>, AppError> {
+) -> Result<Vec<RaceInfo>, Error> {
     // Verify session exists
     sessions::Entity::find_by_id(session_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound("Session not found".to_string()))?;
+        .ok_or_else(|| Error::NotFound("Session not found".to_string()))?;
 
     let rows = RaceHistoryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
@@ -1114,7 +1109,7 @@ pub async fn list_races(
 /// Also marks all remaining active participants as left, preventing
 /// users from being soft-locked out of creating/joining new sessions.
 /// Returns the number of sessions closed.
-pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, AppError> {
+pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error> {
     let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).naive_utc();
 
     let stale = sessions::Entity::find()
@@ -1180,7 +1175,7 @@ mod tests {
         let err = load_host_username(&db, &UserId::new("nonexistent-id"))
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::Internal(_)));
+        assert!(matches!(err, Error::Internal(_)));
     }
 
     // ── transfer_host_or_close ───────────────────────────────────────
@@ -2381,7 +2376,7 @@ mod tests {
         let err = skip_pending_race(&db, &session.id, &bogus_race_id, &host_id)
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)));
+        assert!(matches!(err, Error::NotFound(_)));
     }
 
     #[tokio::test]
@@ -2434,7 +2429,7 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            AppError::Conflict(msg) => assert_eq!(msg, "Already submitted"),
+            Error::Conflict(msg) => assert_eq!(msg, "Already submitted"),
             other => panic!("expected Conflict, got {other:?}"),
         }
     }
@@ -2459,7 +2454,7 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            AppError::Conflict(msg) => {
+            Error::Conflict(msg) => {
                 assert!(
                     msg.contains("closed"),
                     "expected closed-session message, got: {msg}"
@@ -2494,7 +2489,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(err, AppError::Forbidden(_)),
+            matches!(err, Error::Forbidden(_)),
             "expected Forbidden for left user, got {err:?}"
         );
     }

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -2,7 +2,7 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    domain::{UserId, race_setup::Update},
+    domain::{UserId, race_setup},
     entities::{bodies, characters, drink_types, gliders, users, wheels},
     error::Error,
     services::helpers,
@@ -78,8 +78,8 @@ pub async fn update_profile(
 
     let mut active: users::ActiveModel = user.into();
 
-    // Race setup: all-or-nothing via Update
-    if let Some(setup) = Update::try_from_optional(
+    // Race setup: all-or-nothing via race_setup::Update
+    if let Some(setup) = race_setup::Update::try_from_optional(
         req.preferred_character_id,
         req.preferred_body_id,
         req.preferred_wheel_id,

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -2,9 +2,9 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    domain::{UserId, race_setup::RaceSetupUpdate},
+    domain::{UserId, race_setup::Update},
     entities::{bodies, characters, drink_types, gliders, users, wheels},
-    error::AppError,
+    error::Error,
     services::helpers,
 };
 
@@ -64,9 +64,9 @@ pub async fn update_profile(
     actor_user_id: &UserId,
     target_user_id: &UserId,
     req: UpdateProfileRequest,
-) -> Result<UserDetailProfile, AppError> {
+) -> Result<UserDetailProfile, Error> {
     if actor_user_id.as_str() != target_user_id.as_str() {
-        return Err(AppError::Forbidden(
+        return Err(Error::Forbidden(
             "You can only update your own profile".to_string(),
         ));
     }
@@ -74,12 +74,12 @@ pub async fn update_profile(
     let user = users::Entity::find_by_id(target_user_id)
         .one(db)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("User {target_user_id} not found")))?;
+        .ok_or_else(|| Error::NotFound(format!("User {target_user_id} not found")))?;
 
     let mut active: users::ActiveModel = user.into();
 
-    // Race setup: all-or-nothing via RaceSetupUpdate
-    if let Some(setup) = RaceSetupUpdate::try_from_optional(
+    // Race setup: all-or-nothing via Update
+    if let Some(setup) = Update::try_from_optional(
         req.preferred_character_id,
         req.preferred_body_id,
         req.preferred_wheel_id,
@@ -118,7 +118,7 @@ pub async fn update_profile(
 pub async fn build_detail_profile(
     db: &DatabaseConnection,
     user: users::Model,
-) -> Result<UserDetailProfile, AppError> {
+) -> Result<UserDetailProfile, Error> {
     let drink_type = if let Some(ref dt_id) = user.preferred_drink_type_id {
         drink_types::Entity::find_by_id(dt_id)
             .one(db)
@@ -174,7 +174,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(AppError::Forbidden(_))));
+        assert!(matches!(result, Err(Error::Forbidden(_))));
     }
 
     #[tokio::test]
@@ -196,7 +196,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(AppError::NotFound(_))));
+        assert!(matches!(result, Err(Error::NotFound(_))));
     }
 
     #[tokio::test]
@@ -246,7 +246,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(Error::BadRequest(_))));
     }
 
     #[tokio::test]
@@ -269,7 +269,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(Error::BadRequest(_))));
     }
 
     #[tokio::test]
@@ -292,7 +292,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(Error::BadRequest(_))));
     }
 
     #[tokio::test]

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -70,7 +70,7 @@ pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
     let cup_names = ["Test Cup A", "Test Cup B", "Test Cup C"];
     for (i, name) in cup_names.iter().enumerate() {
         cups::ActiveModel {
-            id: Set((i + 1) as i32),
+            id: Set(i32::try_from(i + 1).expect("test cup index fits in i32")),
             name: Set((*name).to_string()),
             image_path: Set(format!("images/cups/test-cup-{}.webp", i + 1)),
         }

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{get, post},
 };
 use axum_test::TestServer;
-use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::AppConfig, routes};
+use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, routes};
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
 use serde_json::{Value, json};
@@ -19,8 +19,8 @@ use tokio::sync::Semaphore;
 
 const TEST_SECRET: &str = "test-secret-for-integration-tests";
 
-fn test_config() -> Arc<AppConfig> {
-    Arc::new(AppConfig {
+fn test_config() -> Arc<Config> {
+    Arc::new(Config {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post, put},
 };
 use axum_test::TestServer;
-use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::AppConfig, routes};
+use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, routes};
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
 use serde_json::{Value, json};
@@ -17,8 +17,8 @@ use tokio::sync::Semaphore;
 
 const TEST_SECRET: &str = "test-secret-for-integration-tests";
 
-fn test_config() -> Arc<AppConfig> {
-    Arc::new(AppConfig {
+fn test_config() -> Arc<Config> {
+    Arc::new(Config {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,
@@ -27,8 +27,8 @@ fn test_config() -> Arc<AppConfig> {
     })
 }
 
-/// A trivial authenticated endpoint used to verify that the AuthUser extractor works.
-async fn protected_hello(user: beerio_kart::middleware::auth::AuthUser) -> axum::Json<Value> {
+/// A trivial authenticated endpoint used to verify that the User extractor works.
+async fn protected_hello(user: beerio_kart::middleware::auth::User) -> axum::Json<Value> {
     axum::Json(json!({ "hello": user.username }))
 }
 

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -7,8 +7,8 @@ use axum::{Router, http::StatusCode, routing::get};
 use axum_test::TestServer;
 use beerio_kart::{
     ARGON2_MAX_CONCURRENT, AppState,
-    config::AppConfig,
-    middleware::auth::{AdminUser, AuthUser},
+    config::Config,
+    middleware::auth::{AdminUser, User},
 };
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
@@ -17,8 +17,8 @@ use tokio::sync::Semaphore;
 
 const TEST_SECRET: &str = "middleware-test-secret";
 
-/// Minimal handler that requires AuthUser.
-async fn auth_handler(user: AuthUser) -> axum::Json<Value> {
+/// Minimal handler that requires User.
+async fn auth_handler(user: User) -> axum::Json<Value> {
     axum::Json(serde_json::json!({ "user_id": user.user_id }))
 }
 
@@ -27,8 +27,8 @@ async fn admin_handler(admin: AdminUser) -> axum::Json<Value> {
     axum::Json(serde_json::json!({ "admin_id": admin.user_id }))
 }
 
-fn make_config(admin_user_id: Option<&str>) -> Arc<AppConfig> {
-    Arc::new(AppConfig {
+fn make_config(admin_user_id: Option<&str>) -> Arc<Config> {
+    Arc::new(Config {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,
@@ -69,7 +69,7 @@ fn create_refresh_token(user_id: &str) -> String {
     beerio_kart::services::auth::create_refresh_token(user_id, 0, &config).unwrap()
 }
 
-// ── AuthUser extractor tests ────────────────────────────────────────
+// ── User extractor tests ────────────────────────────────────────
 
 #[tokio::test]
 async fn test_auth_user_missing_header_returns_401() {

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -13,7 +13,7 @@ use axum::{
 use axum_test::TestServer;
 use beerio_kart::{
     ARGON2_MAX_CONCURRENT, AppState,
-    config::AppConfig,
+    config::Config,
     drink_type_id::drink_type_uuid,
     entities::{bodies, characters, cups, drink_types, gliders, sessions, tracks, wheels},
     routes,
@@ -27,8 +27,8 @@ use uuid::Uuid;
 
 const TEST_SECRET: &str = "test-secret-for-session-tests";
 
-fn test_config() -> Arc<AppConfig> {
-    Arc::new(AppConfig {
+fn test_config() -> Arc<Config> {
+    Arc::new(Config {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -119,7 +119,7 @@ PUT    /admin/flags/:id            Resolve a flag (admin only)
 ## 2. API client generation
 
 - **Decision:** The backend emits an OpenAPI 3.x spec from `utoipa` annotations on every route handler. The frontend consumes a generated TypeScript client (`openapi-typescript-codegen` or `openapi-fetch`) — no hand-rolled `fetch` wrappers per endpoint.
-- **Why:** § 1 lists ~40 endpoints. Hand-rolling a typed client and keeping it in sync with `AppError`'s shape, request/response DTOs, and query-parameter quirks is a part-time job. With `utoipa`, the spec is derived from the same Rust types that handlers already use, so drift is impossible by construction. The cost is ~5 lines of `#[utoipa::path(...)]` per handler — cheap if added as routes are written, painful to retrofit.
+- **Why:** § 1 lists ~40 endpoints. Hand-rolling a typed client and keeping it in sync with `error::Error`'s shape, request/response DTOs, and query-parameter quirks is a part-time job. With `utoipa`, the spec is derived from the same Rust types that handlers already use, so drift is impossible by construction. The cost is ~5 lines of `#[utoipa::path(...)]` per handler — cheap if added as routes are written, painful to retrofit.
 - **Implementation:**
   - Add `utoipa = { version = "5", features = ["axum_extras", "uuid", "chrono"] }` and `utoipa-axum = "0.2"` to `backend/Cargo.toml`.
   - Each route handler gets a `#[utoipa::path(...)]` attribute describing method, path, request body, responses, and tags.
@@ -141,13 +141,13 @@ PUT    /admin/flags/:id            Resolve a flag (admin only)
   { "error": "Session is closed.", "code": "session_closed" }
   ```
   The `error` field is human-readable (may change wording without notice). The `code` field is a stable string the frontend matches on (changing a code is a breaking change).
-- **Why:** Status code alone (`409 Conflict`) doesn't tell the frontend whether to render "session is closed, start a new one" or "username is taken, pick another" — both are 409. The current `AppError` variants carry a free-text message, which forces the frontend to either show raw backend text (bad UX) or pattern-match on substrings (brittle). A stable code lets the frontend pick the right copy and the right recovery action without coupling to backend wording.
+- **Why:** Status code alone (`409 Conflict`) doesn't tell the frontend whether to render "session is closed, start a new one" or "username is taken, pick another" — both are 409. The current `error::Error` variants carry a free-text message, which forces the frontend to either show raw backend text (bad UX) or pattern-match on substrings (brittle). A stable code lets the frontend pick the right copy and the right recovery action without coupling to backend wording.
 - **Implementation:**
-  - Add a `code: &'static str` to each `AppError` variant, or better — split `AppError` into a flat enum where each variant carries its own code:
+  - Add a `code: &'static str` to each `error::Error` variant, or better — split `error::Error` into a flat enum where each variant carries its own code:
     ```rust
     #[derive(thiserror::Error, Debug)]
     #[non_exhaustive]
-    pub enum AppError {
+    pub enum Error {
         #[error("Session is closed.")]
         SessionClosed,
         #[error("Username already taken.")]
@@ -157,7 +157,7 @@ PUT    /admin/flags/:id            Resolve a flag (admin only)
         // ...
     }
 
-    impl AppError {
+    impl Error {
         fn code(&self) -> &'static str {
             match self {
                 Self::SessionClosed => "session_closed",
@@ -292,3 +292,4 @@ The list of stable `code` values returned in error responses. Add to this list w
 - 2026-05-02 — Initial draft. Sets API client generation, error code contract, polling/ETag, refresh flow, idempotency, time format, error code registry, versioning, CORS. The first six (API client generation through Time format) are the "decide before the backend gets much further" set; the rest (Error code registry, Versioning, CORS) are clarifications of decisions that were already made or implied. To be revisited when the frontend work starts.
 - 2026-05-02 — Added prelaunch carve-out to the Versioning section: while prelaunch, breaking changes ship in `/api/v1` directly rather than spinning up a v2 path. Mirrors the "launch" definition in `seaorm.md` § 5.
 - 2026-05-06 — Merged the API Surface section from `design.md` as new § 1 "Endpoint catalog". Convention sections renumbered: previous §§ 1–9 are now §§ 2–10; previous § 10 (history) is now § 11. Internal cross-references updated: § 3 (Error response contract) "see § 7 below for the registry" → "see § 8 below"; § 4 (Polling) and § 6 (Idempotency) updated to reference § 1.5 / Issue #75 instead of `design.md` callouts. Top-of-document scope statement expanded to cover both catalog and conventions. ADR 0031 reference added to § 5 to replace the `design.md` "Auth token strategy" pointer. PR 4 of the docs restructure.
+- 2026-05-10 — Renamed `AppError` → `error::Error` in the § 3 (error response contract) prose and example. Companion to the module-name-repetition cleanup in PR-H1+ (d). PR #103 sequence.

--- a/docs/design.md
+++ b/docs/design.md
@@ -70,9 +70,9 @@ Use SeaORM's builder API for single-table reads and writes (`Entity::find()`, `E
 
 ### Error response pattern
 
-All route handlers return `Result<impl IntoResponse, AppError>` where `AppError` (`src/error.rs`) is a unified error type that implements Axum's `IntoResponse` trait. This enables idiomatic `?` error propagation instead of verbose match arms.
+All route handlers return `Result<impl IntoResponse, error::Error>` where `error::Error` (`src/error.rs`) is a unified error type that implements Axum's `IntoResponse` trait. This enables idiomatic `?` error propagation instead of verbose match arms.
 
-**`AppError` variants:**
+**`error::Error` variants:**
 
 | Variant | HTTP Status | User-facing message |
 |---------|-------------|---------------------|
@@ -89,8 +89,8 @@ All route handlers return `Result<impl IntoResponse, AppError>` where `AppError`
 - The 500-class variants (`Internal`, `Token`, `Hash`) log the real error chain via `tracing::error!` (walking `error.source()`) but return a generic message to the client — internal details are never exposed.
 - `Internal` wraps an `anyhow::Error` (via `#[from]`). Construct source-bearing internals as `anyhow::Error::new(e).context("Loading user")` and synthetic ones (invariant violations, missing seed data) as `anyhow::anyhow!("Cup not found for cup_id {id}")`. The `.context(...)` static-string layer answers *what we were doing*; the wrapped source's `Display` answers *what failed concretely*. The boundary log walks the full chain. Per `coding-standards/rust.md` § 1, error-message strings start with a capital letter and have no trailing punctuation.
 - `Token` and `Hash` are typed wrappers (with `#[from]`) around `jsonwebtoken::errors::Error` and `argon2::password_hash::Error` respectively, so `?` works directly on token operations and password hashing. The wrapped error is reachable via `error.source()` so the boundary log captures the underlying detail.
-- `From<sea_orm::DbErr>` is variant-aware: `RecordNotFound` → `NotFound` (404), `SqlErr::UniqueConstraintViolation` → `Conflict` (409), `SqlErr::ForeignKeyConstraintViolation` → `BadRequest` (400), everything else → `Internal` (500) wrapped with the static context `"Database error"`. This preserves error semantics that a blanket-Internal mapping would otherwise hide. (Note: the fallback context is generic; sites that want richer call-site context use `.map_err(|e| AppError::Internal(anyhow::Error::new(e).context("…")))` instead of `?`.)
-- `AppError` is `#[non_exhaustive]`: the compiler enforces a wildcard arm in any external matcher so adding a future variant (e.g., `Timeout`, `RateLimited`) doesn't break callers.
+- `From<sea_orm::DbErr>` is variant-aware: `RecordNotFound` → `NotFound` (404), `SqlErr::UniqueConstraintViolation` → `Conflict` (409), `SqlErr::ForeignKeyConstraintViolation` → `BadRequest` (400), everything else → `Internal` (500) wrapped with the static context `"Database error"`. This preserves error semantics that a blanket-Internal mapping would otherwise hide. (Note: the fallback context is generic; sites that want richer call-site context use `.map_err(|e| error::Error::Internal(anyhow::Error::new(e).context("…")))` instead of `?`.)
+- `error::Error` is `#[non_exhaustive]`: the compiler enforces a wildcard arm in any external matcher so adding a future variant (e.g., `Timeout`, `RateLimited`) doesn't break callers.
 - Client-facing errors (`BadRequest`, `Unauthorized`, etc.) are always constructed explicitly — they require human judgment about the appropriate status code and message.
 
 **Response format:** All errors return JSON: `{ "error": "<message>" }`
@@ -164,3 +164,4 @@ See [`decisions/`](./decisions/) — each prior bullet has been distilled into a
 - 2026-05-08 — Removed the Project Structure section entirely (heading + body, ~99 lines of repo tree). The tree now lives only in the rebuilt repo-root `README.md`. Diverges from PR 4's stub-pointer pattern (User Workflows / API Surface / UI Screens kept their headings) — design.md is for architecture, repo tree is bootstrap content. PR 5 of the docs restructure.
 - 2026-05-09 — Updated the AppError variants table and Key behaviors bullets to reflect the thiserror migration: added `Token` and `Hash` rows; clarified that the 500-class log path now walks `error.source()` for the full chain; noted `#[non_exhaustive]`. PR #105.
 - 2026-05-09 — Reshaped `Internal` from `String` to `anyhow::Error` (PR-C2). Updated the variants table row and the Key behaviors bullet describing `Internal` construction patterns (`.context(...)` for source-bearing, `anyhow::anyhow!(...)` for synthetic). Noted that the `From<DbErr>` fallback uses a generic `"Database error"` context and that callers wanting richer context use `.map_err(...)` rather than `?`. PR #107.
+- 2026-05-10 — Renamed `AppError` → `error::Error` (and `AppConfig` → `config::Config`, `AuthUser` → `auth::User`, `AuthResponse` → `auth::Response`, `RaceSetupUpdate` → `race_setup::Update`, plus the `list_<resource>` route/service functions → `list`) per the module-name-repetition cleanup in PR-H1+ (d). Live-prose references in this section updated; historical PR notes preserve the old names. PR #103 sequence.


### PR DESCRIPTION
Closes #103. Fourth PR in the PR-H1+ lint cleanup sequence.

## Summary

Removes **five** workspace allows in `backend/Cargo.toml` (`module_name_repetitions` + the four `cast_*` lints) by renaming the 13 module-name-repetition sites and fixing the 6 cast sites. After this PR, the only pedantic lints still allow-listed are `missing_errors_doc` / `missing_panics_doc` (queued for PR-G3, doc-comment audit).

## Renames (13 sites)

| Old | New |
|---|---|
| `AppConfig` | `config::Config` |
| `AppError` | `error::Error` |
| `AuthUser` | `middleware::auth::User` |
| `AuthResponse` | `routes::auth::Response` |
| `DrinkTypesQuery` | `routes::drink_types::Filters` *(avoids collision with `axum::extract::Query`)* |
| `RaceSetupUpdate` | `domain::race_setup::Update` |
| `list_drink_types` / `list_runs` / `list_sessions` / `list_users` | `list` |
| `list_active_sessions` | `list_active` |
| `close_stale_sessions` | `close_stale` |

All renames are mechanical — `sed -i 's/\bOLD\b/NEW/g'` across `backend/**/*.rs`, with `DrinkTypesQuery → Filters` (not `Query`) to dodge the `axum::extract::Query` collision the obvious rename would have caused.

`AppState` (in `lib.rs`, not in an `app` module) was **not** flagged by clippy and is left as-is.

## Cast cleanups (6 sites)

| Site | Before | After |
|---|---|---|
| `services/auth.rs:98, 122` | `config.jwt_*_expiry_minutes as i64` | field type changed `u64 → i64` |
| `routes/auth.rs:59` | `config.jwt_refresh_expiry_days as i64 * 86400` | cast removed (field is now `i64`) |
| `services/sessions.rs:680` | `r.race_number as usize` | `usize::try_from(r.race_number).unwrap_or(0)` |
| `services/sessions.rs:923` | `used_races.len() as i32` | `i32::try_from(used_races.len()).unwrap_or(i32::MAX)` |
| `test_helpers.rs:73` | `(i + 1) as i32` | `i32::try_from(i + 1).expect("test cup index fits in i32")` (test code; `expect_used` allowed) |

Field-type change rationale: `chrono::TimeDelta::{minutes,days}` take `i64`. The fields were `u64` to express non-negativity, but the cast was happening at every call site. Storing them as `i64` removes the cast.

## Docs updated

Live prose only — historical PR notes preserve the old names:

- `backend/CLAUDE.md` § Errors
- `docs/design.md` § Observability → Error response pattern + Document history entry
- `docs/api-contract.md` § 3 (error response contract example) + Document history entry

## Workspace `Cargo.toml` after this PR

Remaining pedantic allows:
- `missing_errors_doc`, `missing_panics_doc` — queued for **PR-G3** (doc-comment audit).
- `cargo_common_metadata`, `multiple_crate_versions` — leave alone (publishing concerns).
- `doc_markdown`, `too_long_first_doc_paragraph` — queued for **PR-G3**.
- `needless_raw_string_hashes`, `too_many_lines` — leave alone (style).

That closes the H1+ a/b/c/d sequence per the handoff. **#98 (e — nursery)** remains.

## Verification

```
cd backend
cargo clippy --all-targets   # clean
cargo test                    # 164 unit + 27 + 21 + 8 + 1 + 19 integration tests pass
```

Manual reproduction:

1. **The cleared lints stay clean.** From `backend/`:
   ```
   cargo clippy --all-targets -- \
     -W clippy::module_name_repetitions \
     -W clippy::cast_possible_wrap \
     -W clippy::cast_possible_truncation \
     -W clippy::cast_sign_loss \
     -W clippy::cast_precision_loss
   ```
   Should be silent.

2. **The renamed types still resolve.** `cargo doc --no-deps` produces module pages under `config::Config`, `error::Error`, `middleware::auth::User`, etc. (No `AppError` page anywhere in the generated docs.)

3. **Auth still works end-to-end.** Run `cargo test --test auth_integration` — 8 tests covering register / login / refresh / logout / change_password / cookie handling.

4. **Session lifecycle still works.** `cargo test --test session_integration` — 19 tests, including `test_stale_session_cleanup` which exercises the renamed `close_stale` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)