### PR TITLE
114: doc-comment audit (PR-G3) — clear 4 workspace lint allows, 147 sites

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,16 +10,11 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
-# Tame the noisy pedantic ones:
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
 # `cargo` group — relevant for crates.io publishing, not an internal binary:
 cargo_common_metadata = "allow"
 multiple_crate_versions = "allow"
 # Phase H scaffolding — clear each in a follow-up PR per rust.md § 8:
-doc_markdown = "allow"
 needless_raw_string_hashes = "allow"
-too_long_first_doc_paragraph = "allow"
 too_many_lines = "allow"
 # High-value extras:
 dbg_macro = "deny"

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -1,7 +1,15 @@
+//! Consolidated migration crate for Beerio Kart.
+//!
+//! Prelaunch convention (see `backend/CLAUDE.md` § Schema changes): all
+//! schema lives in one consolidated migration file, edited in place rather
+//! than appended to. [`Migrator`] is the entry point —
+//! `Migrator::up(&db, None).await` applies the schema to a fresh database.
+
 pub use sea_orm_migration::prelude::*;
 
 pub mod m20260101_000001_initial_schema;
 
+/// Runs the consolidated initial-schema migration.
 pub struct Migrator;
 
 #[async_trait::async_trait]

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -16,15 +16,15 @@ use sea_orm_migration::prelude::*;
 /// - There is a circular FK between `users.preferred_drink_type_id` and
 ///   `drink_types.created_by`. We break the cycle by creating `drink_types`
 ///   first without `created_by`, creating `users`, then adding `created_by`
-///   via raw `ALTER TABLE` (SQLite supports inline REFERENCES on ADD COLUMN
-///   but SeaORM's builder doesn't reliably emit it).
-/// - Timestamp columns use SeaORM's `.date_time()` which emits the literal
-///   SQL type `datetime_text`. SeaORM's codegen recognizes that type and
+///   via raw `ALTER TABLE` (`SQLite` supports inline REFERENCES on ADD COLUMN
+///   but `SeaORM`'s builder doesn't reliably emit it).
+/// - Timestamp columns use `SeaORM`'s `.date_time()` which emits the literal
+///   SQL type `datetime_text`. `SeaORM`'s codegen recognizes that type and
 ///   maps the column to `chrono::NaiveDateTime` when entities are regenerated.
 ///   The session/race/run tables are written as raw SQL (matching the prior
 ///   pattern) and use the same `datetime_text` type literally for consistency.
 /// - The partial unique index on `session_participants(user_id) WHERE left_at
-///   IS NULL` is created via raw SQL because SeaORM's builder doesn't support
+///   IS NULL` is created via raw SQL because `SeaORM`'s builder doesn't support
 ///   partial-index `WHERE` clauses.
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
     /// because `chrono::TimeDelta::minutes` takes `i64`.
     pub jwt_access_expiry_minutes: i64,
     /// How long refresh tokens are valid (days). Longer-lived because they're
-    /// stored in an HttpOnly cookie (no JavaScript access) and can be revoked
+    /// stored in an `HttpOnly` cookie (no JavaScript access) and can be revoked
     /// by bumping `refresh_token_version` in the database. Stored as `i64`
     /// because `chrono::TimeDelta::days` takes `i64`.
     pub jwt_refresh_expiry_days: i64,
@@ -27,8 +27,11 @@ pub struct Config {
 impl Config {
     /// Load configuration from environment variables.
     ///
-    /// Errors if `JWT_SECRET` is not set — running without a signing key would
-    /// silently produce unsigned or weak tokens.
+    /// # Errors
+    ///
+    /// Returns `Err` if `JWT_SECRET` is unset (no signing key means unsigned
+    /// or weak tokens), or if `JWT_ACCESS_EXPIRY_MINUTES` / `JWT_REFRESH_EXPIRY_DAYS`
+    /// is set to a non-positive value or fails to parse as an `i64`.
     pub fn from_env() -> anyhow::Result<Arc<Self>> {
         let jwt_secret = std::env::var("JWT_SECRET")
             .context("JWT_SECRET must be set — it's the signing key for auth tokens")?;

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,12 +1,12 @@
 //! Database connection setup.
 //!
-//! Per `seaorm.md` § 8: SQLite enforces `journal_mode` at the database-file
+//! Per `seaorm.md` § 8: `SQLite` enforces `journal_mode` at the database-file
 //! level (sticky) but `busy_timeout`, `synchronous`, and `foreign_keys` are
 //! per-connection — they reset on every new connection in the pool. The
 //! pre-PR-B2 startup pattern of `Database::connect(url)` followed by a single
 //! `PRAGMA foreign_keys = ON` only configured the connection that served that
 //! statement; subsequent pool connections opened later had FKs disabled. This
-//! module fixes that by building the SQLx pool with `SqliteConnectOptions`
+//! module fixes that by building the `SQLx` pool with `SqliteConnectOptions`
 //! (which applies the per-connection PRAGMAs at connection setup time) and
 //! wrapping it with `SqlxSqliteConnector`.
 
@@ -18,10 +18,16 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
 };
 
-/// Connect to the SQLite database with per-connection PRAGMAs applied.
+/// Connect to the `SQLite` database with per-connection PRAGMAs applied.
 ///
 /// Returns a `DatabaseConnection` whose every pool connection has WAL mode,
-/// synchronous=Normal, busy_timeout=5s, and foreign keys enforced.
+/// synchronous=Normal, `busy_timeout=5s`, and foreign keys enforced.
+///
+/// # Errors
+///
+/// Returns `DbErr` if `url` fails to parse as a `SQLite` connection string,
+/// the pool can't be created (e.g., file permission errors for a file-backed
+/// `SQLite`), or the initial connection handshake fails.
 pub async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
     let sqlx_opts = SqliteConnectOptions::from_str(url)
         .map_err(|e| DbErr::Conn(RuntimeErr::SqlxError(e)))?
@@ -54,7 +60,7 @@ mod tests {
     use crate::entities::users;
 
     /// Drives a connection through the new `connect()` path against an in-memory
-    /// SQLite database. `cache=shared` makes the same DB visible to every pool
+    /// `SQLite` database. `cache=shared` makes the same DB visible to every pool
     /// connection (otherwise each connection gets its own ephemeral DB and
     /// migrations applied on one wouldn't be visible on the next).
     async fn shared_memory_db() -> DatabaseConnection {

--- a/backend/src/domain/ids.rs
+++ b/backend/src/domain/ids.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// The newtype is transparent for serde (so it serializes as a bare string),
 /// implements `Display`, `AsRef<str>`, `Deref<Target = str>`, and conversion
 /// from `String` / `&str`. `Deref` lets call sites treat the newtype as a
-/// `&str` for read-only operations (e.g. passing into SeaORM filters that
+/// `&str` for read-only operations (e.g. passing into `SeaORM` filters that
 /// expect `&str`). `From<&Self> for sea_orm::Value` is provided so call
 /// sites can pass `&UserId` (etc.) directly to `Column::Foo.eq(...)` and
 /// `find_by_id(...)` without an explicit `.as_str()` conversion.

--- a/backend/src/domain/race_setup.rs
+++ b/backend/src/domain/race_setup.rs
@@ -20,6 +20,11 @@ impl Update {
     /// - All four `None` → `Ok(None)` (caller is not updating race setup).
     /// - All four `Some` → `Ok(Some(Update))`.
     /// - Any mix        → `Err(BadRequest)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BadRequest` if the four arguments are a mix of `Some`
+    /// and `None` — race setup is all-or-nothing.
     pub fn try_from_optional(
         character_id: Option<i32>,
         body_id: Option<i32>,

--- a/backend/src/entities/mod.rs
+++ b/backend/src/entities/mod.rs
@@ -1,6 +1,8 @@
-//! Hand-written SeaORM entities. Schema-as-code source of truth lives in
-//! `migration/`; entities mirror that shape and are edited alongside the
-//! migration in the same PR. See `docs/coding-standards/seaorm.md` § 6.
+//! Hand-written `SeaORM` entities.
+//!
+//! Schema-as-code source of truth lives in `migration/`; entities mirror that
+//! shape and are edited alongside the migration in the same PR. See
+//! `docs/coding-standards/seaorm.md` § 6.
 
 pub mod prelude;
 

--- a/backend/src/entities/session_participants.rs
+++ b/backend/src/entities/session_participants.rs
@@ -13,7 +13,7 @@
 //! `users` ↔ `session_participants` relation reflects that a user accumulates
 //! one row per session they've ever joined (many rows across many sessions),
 //! even though within any single session there's only ever one row per user.
-//! Marking `user_id` `unique` here would coerce SeaORM into `has_one` and
+//! Marking `user_id` `unique` here would coerce `SeaORM` into `has_one` and
 //! break loading of a user's full participation history.
 
 use sea_orm::entity::prelude::*;

--- a/backend/src/entities/session_races.rs
+++ b/backend/src/entities/session_races.rs
@@ -2,7 +2,7 @@
 //!
 //! `chosen_by` is the user who picked this race's track. It exists as a
 //! nullable FK column (preserved for audit/UX), but no caller currently
-//! traverses that direction through SeaORM, so no `Relation` variant is
+//! traverses that direction through `SeaORM`, so no `Relation` variant is
 //! declared for it. Adding one (e.g. `Chooser` with `belongs_to = users`)
 //! would require keeping its name distinct from any direct variant on the
 //! `users` side pointing here — see `seaorm.md` § 11.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,14 @@
+//! Beerio Kart backend — Axum HTTP API on top of `SeaORM` + `SQLite`.
+//!
+//! The composition root and shared application state live here; the
+//! per-area modules ([`routes`], [`services`], [`entities`], [`middleware`])
+//! are wired together by `main.rs`. See [`AppState`] for the handler-visible
+//! state and [`ARGON2_MAX_CONCURRENT`] for the password-hash concurrency cap.
+//!
+//! Architecture, naming, and error conventions live in `docs/design.md` and
+//! `docs/coding-standards/`; backend-specific conventions (schema-changes
+//! prelaunch, testing, ORM usage) live in `backend/CLAUDE.md`.
+
 // Tests legitimately want to panic — per rust.md § 8.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
@@ -36,7 +47,10 @@ pub const ARGON2_MAX_CONCURRENT: usize = 16;
 /// and `Arc<Semaphore>` are all reference-counted internally.
 #[derive(Clone)]
 pub struct AppState {
+    /// `SeaORM` connection pool. Cheaply cloneable — internally an `Arc`.
     pub db: DatabaseConnection,
+    /// Loaded configuration (JWT secret, cookie flags, token expiries).
+    /// Wrapped in `Arc` so clones share one allocation.
     pub config: Arc<Config>,
     /// Caps concurrent Argon2 hash/verify operations across all handlers.
     /// See `services::auth::{hash_password, verify_password}`.

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -86,7 +86,13 @@ fn extract_refresh_cookie(headers: &HeaderMap) -> Option<String> {
 /// POST /api/v1/auth/register
 ///
 /// Creates a new user account. Returns an access token in the response body
-/// and sets a refresh token as an HttpOnly cookie.
+/// and sets a refresh token as an `HttpOnly` cookie.
+///
+/// # Errors
+///
+/// Returns `BadRequest` if the username is empty / >30 chars or the password
+/// is <8 / >128 chars; `Conflict` if the username is taken; `Internal` for
+/// password-hash, token-issue, or DB failures.
 pub async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
@@ -156,7 +162,13 @@ pub async fn register(
 /// POST /api/v1/auth/login
 ///
 /// Authenticates with username + password. Returns an access token in the
-/// response body and sets a refresh token as an HttpOnly cookie.
+/// response body and sets a refresh token as an `HttpOnly` cookie.
+///
+/// # Errors
+///
+/// Returns `Unauthorized` if the username doesn't exist or the password is
+/// wrong (both surfaced as the same generic message to prevent username
+/// enumeration); `Internal` for password-verify, token-issue, or DB failures.
 pub async fn login(
     State(state): State<AppState>,
     Json(body): Json<LoginRequest>,
@@ -211,13 +223,20 @@ pub async fn login(
 
 /// POST /api/v1/auth/refresh
 ///
-/// Reads the refresh token from the HttpOnly cookie (NOT from the request body
+/// Reads the refresh token from the `HttpOnly` cookie (NOT from the request body
 /// or Authorization header). If valid and the `refresh_token_version` matches
 /// the DB, returns a new access token and rotates the refresh cookie.
 ///
 /// "Rotation" means issuing a fresh refresh JWT with a fresh expiry on every
 /// successful refresh. This extends the session window without bumping the
 /// version (which would invalidate other devices).
+///
+/// # Errors
+///
+/// Returns `Unauthorized` if the refresh cookie is missing, the JWT fails
+/// validation, the token type is not `refresh`, the user no longer exists,
+/// or the token's `refresh_token_version` doesn't match the DB (revoked via
+/// logout or password change). `Internal` for token-issue or DB failures.
 pub async fn refresh(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -263,6 +282,11 @@ pub async fn refresh(
 /// Requires authentication. Increments `refresh_token_version` in the database,
 /// which invalidates ALL refresh tokens for this user across all devices.
 /// Also clears the refresh cookie on the current browser.
+///
+/// # Errors
+///
+/// Returns `Internal` if the authenticated user no longer exists in the DB
+/// (invariant violation), or for DB / cookie-build failures.
 pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl IntoResponse, Error> {
     // Look up user to get current version
     let db_user = users::Entity::find_by_id(&user.user_id)
@@ -298,6 +322,13 @@ pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl In
 /// Requires authentication. Validates the current password, updates the hash,
 /// and increments `refresh_token_version` to force re-login on all other devices.
 /// Returns new tokens for the current session so the user stays logged in.
+///
+/// # Errors
+///
+/// Returns `BadRequest` if the new password is <8 / >128 chars; `NotFound`
+/// if the authenticated user no longer exists; `Unauthorized` if the current
+/// password is wrong; `Internal` for password-hash, token-issue, or DB
+/// failures.
 pub async fn change_password(
     State(state): State<AppState>,
     user: User,

--- a/backend/src/routes/drink_types.rs
+++ b/backend/src/routes/drink_types.rs
@@ -49,6 +49,16 @@ pub struct Filters {
 
 // ── Handlers ─────────────────────────────────────────────────────────
 
+/// POST /api/v1/drink-types — create or return an existing drink type.
+///
+/// Dedup is case-insensitive (the UUID is derived from the uppercased name),
+/// so re-submitting an existing name returns the original row with 200 rather
+/// than a 409.
+///
+/// # Errors
+///
+/// Returns `BadRequest` if the trimmed name is empty or >200 chars;
+/// `Internal` for unexpected DB failures.
 pub async fn create_drink_type(
     user: User,
     State(state): State<AppState>,
@@ -87,6 +97,12 @@ pub async fn create_drink_type(
     Ok(Json(inserted.into()))
 }
 
+/// GET /api/v1/drink-types — list drink types. Optional `alcoholic` query
+/// filter narrows the result.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_drink_types(
     _user: User,
     State(state): State<AppState>,
@@ -103,6 +119,12 @@ pub async fn list_drink_types(
     ))
 }
 
+/// GET /api/v1/drink-types/:id — get a single drink type.
+///
+/// # Errors
+///
+/// Returns `NotFound` if `id` doesn't match a drink type; `Internal` for
+/// unexpected DB failures.
 pub async fn get_drink_type(
     _user: User,
     State(state): State<AppState>,

--- a/backend/src/routes/game_data.rs
+++ b/backend/src/routes/game_data.rs
@@ -38,7 +38,7 @@ pub struct CupWithTracksResponse {
     pub tracks: Vec<TrackResponse>,
 }
 
-/// Convert any entity Model with (id: i32, name: String, image_path: String) to SimpleItem.
+/// Convert any entity Model with (id: i32, name: String, `image_path`: String) to `SimpleItem`.
 macro_rules! impl_into_simple_item {
     ($($module:ident),+) => {
         $(
@@ -72,6 +72,11 @@ pub struct TracksQuery {
 
 // ── Handlers ─────────────────────────────────────────────────────────
 
+/// GET /api/v1/characters — list all characters.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_characters(
     _user: User,
     State(state): State<AppState>,
@@ -80,6 +85,11 @@ pub async fn list_characters(
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
+/// GET /api/v1/bodies — list all kart bodies.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_bodies(
     _user: User,
     State(state): State<AppState>,
@@ -88,6 +98,11 @@ pub async fn list_bodies(
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
+/// GET /api/v1/wheels — list all wheels.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_wheels(
     _user: User,
     State(state): State<AppState>,
@@ -96,6 +111,11 @@ pub async fn list_wheels(
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
+/// GET /api/v1/gliders — list all gliders.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_gliders(
     _user: User,
     State(state): State<AppState>,
@@ -104,6 +124,11 @@ pub async fn list_gliders(
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
+/// GET /api/v1/cups — list all cups.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_cups(
     _user: User,
     State(state): State<AppState>,
@@ -112,6 +137,12 @@ pub async fn list_cups(
     Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
 }
 
+/// GET /api/v1/cups/:id — get a cup with its tracks.
+///
+/// # Errors
+///
+/// Returns `NotFound` if `id` doesn't match a cup; `Internal` for unexpected
+/// DB failures.
 pub async fn get_cup(
     _user: User,
     State(state): State<AppState>,
@@ -138,6 +169,12 @@ pub async fn get_cup(
     }))
 }
 
+/// GET /api/v1/tracks — list all tracks. Optional `cup_id` query filter
+/// narrows the result to a single cup.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_tracks(
     _user: User,
     State(state): State<AppState>,
@@ -152,6 +189,12 @@ pub async fn list_tracks(
     Ok(Json(items.into_iter().map(TrackResponse::from).collect()))
 }
 
+/// GET /api/v1/tracks/:id — get a single track.
+///
+/// # Errors
+///
+/// Returns `NotFound` if `id` doesn't match a track; `Internal` for
+/// unexpected DB failures.
 pub async fn get_track(
     _user: User,
     State(state): State<AppState>,

--- a/backend/src/routes/runs.rs
+++ b/backend/src/routes/runs.rs
@@ -15,6 +15,14 @@ use crate::{
 };
 
 /// POST /runs — create a run.
+///
+/// # Errors
+///
+/// Propagates the errors of [`runs::create_run`]: `BadRequest` for invalid
+/// time fields or unknown FK references, `NotFound` if the session race
+/// doesn't exist, `Conflict` if the session is closed, the user already
+/// submitted, or an older pending race is blocking, `Forbidden` if the user
+/// is not an active participant.
 pub async fn create_run(
     user: User,
     State(state): State<AppState>,
@@ -32,6 +40,11 @@ pub struct ListRunsQuery {
 }
 
 /// GET /runs — list runs with optional filters.
+///
+/// # Errors
+///
+/// Propagates the errors of [`runs::list_runs`] — currently only `Internal`
+/// for unexpected DB failures.
 pub async fn list_runs(
     _user: User,
     State(state): State<AppState>,
@@ -47,6 +60,11 @@ pub async fn list_runs(
 }
 
 /// GET /runs/defaults — get defaults for the authenticated user.
+///
+/// # Errors
+///
+/// Propagates the errors of [`runs::get_run_defaults`] — currently only
+/// `Internal` for unexpected DB failures.
 pub async fn get_defaults(
     user: User,
     State(state): State<AppState>,
@@ -56,6 +74,11 @@ pub async fn get_defaults(
 }
 
 /// GET /runs/:id — get a single run.
+///
+/// # Errors
+///
+/// Propagates the errors of [`runs::get_run`]: `NotFound` if the run doesn't
+/// exist.
 pub async fn get_run(
     _user: User,
     State(state): State<AppState>,
@@ -67,6 +90,12 @@ pub async fn get_run(
 }
 
 /// DELETE /runs/:id — delete a run. Owner only, active session only.
+///
+/// # Errors
+///
+/// Propagates the errors of [`runs::delete_run`]: `NotFound` if the run
+/// doesn't exist, `Forbidden` if the caller is not the run's owner,
+/// `Conflict` if the run's session is closed.
 pub async fn delete_run(
     user: User,
     State(state): State<AppState>,

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -151,7 +151,7 @@ pub async fn skip_turn(
     Ok((StatusCode::CREATED, Json(race)))
 }
 
-/// POST /`sessions/:id/races/:race_id/skip` — mark a pending race as skipped
+/// `POST /sessions/:id/races/:race_id/skip` — mark a pending race as skipped
 /// for the requesting user. Idempotent.
 ///
 /// # Errors

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -20,6 +20,11 @@ pub struct CreateSessionRequest {
 }
 
 /// POST /sessions — create a new session. Returns full session detail.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::create_session`]: `BadRequest` for an
+/// unknown ruleset, `Conflict` if the user is already in another active session.
 pub async fn create_session(
     user: User,
     State(state): State<AppState>,
@@ -35,6 +40,11 @@ pub struct MySessionResponse {
 }
 
 /// GET /sessions/mine — get the user's current active session ID.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::get_active_session_id`] — currently
+/// only `Internal` for unexpected DB failures.
 pub async fn my_session(
     user: User,
     State(state): State<AppState>,
@@ -44,6 +54,11 @@ pub async fn my_session(
 }
 
 /// GET /sessions — list active sessions.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::list_active_sessions`] — currently
+/// only `Internal` for unexpected DB failures.
 pub async fn list_sessions(
     _user: User,
     State(state): State<AppState>,
@@ -53,6 +68,11 @@ pub async fn list_sessions(
 }
 
 /// GET /sessions/:id — full session state for polling.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::get_session_detail`]: `NotFound` if
+/// the session does not exist.
 pub async fn get_session(
     user: User,
     State(state): State<AppState>,
@@ -64,6 +84,12 @@ pub async fn get_session(
 }
 
 /// POST /sessions/:id/join — join a session.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::join_session`]: `NotFound` if the
+/// session doesn't exist, `Conflict` if the session is closed or the user is
+/// already in another session.
 pub async fn join_session(
     user: User,
     State(state): State<AppState>,
@@ -75,6 +101,11 @@ pub async fn join_session(
 }
 
 /// POST /sessions/:id/leave — leave a session.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::leave_session`]: `NotFound` if the
+/// session doesn't exist, `BadRequest` if the user is not currently in it.
 pub async fn leave_session(
     user: User,
     State(state): State<AppState>,
@@ -86,6 +117,12 @@ pub async fn leave_session(
 }
 
 /// POST /sessions/:id/next-track — pick the next random track.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::next_track`]: `NotFound` if the
+/// session doesn't exist, `Conflict` if it's closed, `Forbidden` if the user
+/// is not an active participant.
 pub async fn next_track(
     user: User,
     State(state): State<AppState>,
@@ -97,6 +134,13 @@ pub async fn next_track(
 }
 
 /// POST /sessions/:id/skip-turn — re-roll the current track.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::skip_turn`]: `NotFound` if the
+/// session doesn't exist, `Conflict` if it's closed or if runs have already
+/// been submitted for the current race, `BadRequest` if there is no track to
+/// skip.
 pub async fn skip_turn(
     user: User,
     State(state): State<AppState>,
@@ -107,8 +151,15 @@ pub async fn skip_turn(
     Ok((StatusCode::CREATED, Json(race)))
 }
 
-/// POST /sessions/:id/races/:race_id/skip — mark a pending race as skipped
+/// POST /`sessions/:id/races/:race_id/skip` — mark a pending race as skipped
 /// for the requesting user. Idempotent.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::skip_pending_race`]: `NotFound` if
+/// the session or race doesn't exist, `Conflict` if the session is closed or
+/// the user already submitted a run for the race, `Forbidden` if the user is
+/// not an active participant.
 pub async fn skip_pending_race(
     user: User,
     State(state): State<AppState>,
@@ -121,6 +172,11 @@ pub async fn skip_pending_race(
 }
 
 /// GET /sessions/:id/races — list all races in a session.
+///
+/// # Errors
+///
+/// Propagates the errors of [`sessions::list_races`] — currently only
+/// `Internal` for unexpected DB failures.
 pub async fn list_races(
     _user: User,
     State(state): State<AppState>,

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -27,6 +27,11 @@ pub struct UserPublicProfile {
 
 // ── Handlers ────────────────────────────────────────────────────────
 
+/// GET /api/v1/users — list users (public profile shape).
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_users(
     _user: User,
     State(state): State<AppState>,
@@ -49,6 +54,12 @@ pub async fn list_users(
     ))
 }
 
+/// GET /api/v1/users/:id — get a user's detail profile.
+///
+/// # Errors
+///
+/// Returns `NotFound` if `id` doesn't match a user; propagates the errors
+/// of [`user_service::build_detail_profile`] for DB failures.
 pub async fn get_user(
     _user: User,
     State(state): State<AppState>,
@@ -63,6 +74,13 @@ pub async fn get_user(
     Ok(Json(profile))
 }
 
+/// PATCH /api/v1/users/:id — update a user's profile fields.
+///
+/// # Errors
+///
+/// Propagates the errors of [`user_service::update_profile`]: `Forbidden`
+/// if a user tries to modify another user, `NotFound` if the target user
+/// doesn't exist, `BadRequest` for invalid race-setup or drink-type IDs.
 pub async fn update_user(
     auth_user: User,
     State(state): State<AppState>,

--- a/backend/src/seed.rs
+++ b/backend/src/seed.rs
@@ -78,7 +78,7 @@ pub async fn run(db: &DatabaseConnection) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Seed a table that has the simple (id, name, image_path) schema.
+/// Seed a table that has the simple (id, name, `image_path`) schema.
 /// Skips if the table already has data.
 async fn seed_simple_table<E, A>(
     db: &DatabaseConnection,
@@ -115,7 +115,7 @@ where
     Ok(())
 }
 
-/// Intermediate struct for converting JSON data into any simple ActiveModel.
+/// Intermediate struct for converting JSON data into any simple `ActiveModel`.
 /// Each simple entity (characters, bodies, wheels, gliders, cups) implements
 /// From<SimpleActiveModel> via the macro below.
 struct SimpleActiveModel {

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -24,7 +24,8 @@ pub struct AccessClaims {
     pub token_type: String,
 }
 
-/// Claims for long-lived refresh tokens (stored in an HttpOnly cookie).
+/// Claims for long-lived refresh tokens (stored in an `HttpOnly` cookie).
+///
 /// Contains `refresh_token_version` which must match the DB value — this is
 /// how we revoke all refresh tokens for a user (e.g., on logout or password change).
 #[derive(Debug, Serialize, Deserialize)]
@@ -51,6 +52,12 @@ pub struct RefreshClaims {
 /// runs on Tokio's blocking pool via `spawn_blocking` so it never stalls an
 /// async worker, and `limiter` caps concurrent hashes (see
 /// `coding-standards/tokio.md` § 2 and § 12).
+///
+/// # Errors
+///
+/// Returns `Error::Hash` if Argon2 rejects the input (extremely unusual —
+/// e.g., RNG failure during salt generation); `Error::Internal` if the
+/// blocking task panics or the limiter semaphore is closed.
 pub async fn hash_password(limiter: &Semaphore, password: String) -> Result<String, Error> {
     let _permit = limiter
         .acquire()
@@ -71,6 +78,12 @@ pub async fn hash_password(limiter: &Semaphore, password: String) -> Result<Stri
 ///
 /// Like `hash_password`, this offloads the verify to the blocking pool and
 /// is gated by the shared semaphore.
+///
+/// # Errors
+///
+/// Returns `Error::Hash` if `hash` doesn't parse as a valid Argon2 string;
+/// `Error::Internal` if the blocking task panics or the semaphore is closed.
+/// Note: a wrong password is `Ok(false)`, not an error.
 pub async fn verify_password(
     limiter: &Semaphore,
     password: String,
@@ -91,6 +104,11 @@ pub async fn verify_password(
 }
 
 /// Create a short-lived access token for the given user.
+///
+/// # Errors
+///
+/// Returns `jsonwebtoken::errors::Error` if HMAC signing fails — in practice
+/// only possible if `config.jwt_secret` is empty or otherwise unusable.
 pub fn create_access_token(
     user_id: &str,
     username: &str,
@@ -115,6 +133,11 @@ pub fn create_access_token(
 }
 
 /// Create a long-lived refresh token for the given user.
+///
+/// # Errors
+///
+/// Returns `jsonwebtoken::errors::Error` if HMAC signing fails — in practice
+/// only possible if `config.jwt_secret` is empty or otherwise unusable.
 pub fn create_refresh_token(
     user_id: &str,
     refresh_token_version: i32,
@@ -139,6 +162,11 @@ pub fn create_refresh_token(
 }
 
 /// Validate an access token and return its claims.
+///
+/// # Errors
+///
+/// Returns `jsonwebtoken::errors::Error` if the JWT signature is invalid,
+/// the token is expired or malformed, or the algorithm doesn't match HS256.
 pub fn validate_access_token(
     token: &str,
     config: &Config,
@@ -152,6 +180,12 @@ pub fn validate_access_token(
 }
 
 /// Validate a refresh token and return its claims.
+///
+/// # Errors
+///
+/// Returns `jsonwebtoken::errors::Error` if the JWT signature is invalid,
+/// the token is expired or malformed, or the algorithm doesn't match HS256.
+/// Callers should additionally check `claims.token_type == "refresh"`.
 pub fn validate_refresh_token(
     token: &str,
     config: &Config,

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -18,8 +18,11 @@ use crate::{
 
 /// Load a session by ID and require that it is in the `Active` state.
 ///
+/// # Errors
+///
 /// - `NotFound` if no row with that ID exists.
 /// - `Conflict` if the session exists but is closed.
+/// - `Internal` for unexpected DB failures.
 pub async fn load_active_session<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
@@ -37,7 +40,10 @@ pub async fn load_active_session<C: ConnectionTrait>(
 /// Require that `user_id` is an active (not-yet-left) participant in the
 /// session. Returns the participant row on success.
 ///
-/// `Forbidden` if the user has no active participant row for this session.
+/// # Errors
+///
+/// Returns `Forbidden` if the user has no active participant row for this
+/// session; `Internal` for unexpected DB failures.
 pub async fn require_active_participant<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
@@ -66,6 +72,11 @@ pub async fn require_active_participant<C: ConnectionTrait>(
 /// **Caller contract:** must run inside the same transaction as the
 /// `session_races` INSERT. If any participation insert fails the whole
 /// transaction rolls back, leaving no orphan race or partial snapshot.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures on either the SELECT of
+/// present participants or the bulk insert of participation rows.
 pub async fn insert_race_participations<C: ConnectionTrait>(
     txn: &C,
     session_id: &SessionId,
@@ -108,6 +119,10 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
 
 /// Bump the session's `last_activity_at` column to now. Single `UPDATE`,
 /// no prior read required.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn touch_session<C: ConnectionTrait>(
     db: &C,
     session_id: &SessionId,
@@ -122,11 +137,14 @@ pub async fn touch_session<C: ConnectionTrait>(
 }
 
 /// Assert that a row with the given primary key exists in entity `E`.
-/// Returns `BadRequest` with a formatted message on miss (e.g., "Invalid
-/// character_id").
 ///
 /// The generic bounds mirror `EntityTrait::find_by_id` — the primary key's
 /// `ValueType` is what the caller must pass in.
+///
+/// # Errors
+///
+/// Returns `BadRequest` with a formatted message on miss (e.g., "Invalid
+/// `character_id`"); `Internal` for unexpected DB failures.
 pub async fn require_exists<E, C>(
     db: &C,
     id: <<E as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType,
@@ -151,7 +169,11 @@ where
 /// - `skip_turn`:  `exclude = &used_ids, always_exclude = &[skipped_id]` —
 ///   the skipped track stays excluded even through a reset.
 ///
-/// Returns `Internal` only if the `tracks` table is empty (seed error).
+/// # Errors
+///
+/// Returns `Internal` if the `tracks` table is empty (seed error) or if the
+/// pool is empty after a reset (e.g., every track is in `always_exclude`);
+/// `Internal` for unexpected DB failures.
 pub async fn pick_random_track<C: ConnectionTrait>(
     db: &C,
     exclude: &[i32],

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -117,8 +117,8 @@ pub struct RunFilters {
     pub track_id: Option<i32>,
 }
 
-/// Validate time fields on a run submission: track_time range, lap times
-/// positive and within range, and lap sum equals track_time.
+/// Validate time fields on a run submission: `track_time` range, lap times
+/// positive and within range, and lap sum equals `track_time`.
 fn validate_time_fields(body: &CreateRunRequest) -> Result<(), Error> {
     if body.track_time <= 0 || body.track_time > MAX_TRACK_TIME_MS {
         return Err(Error::bad_request(format!(
@@ -149,6 +149,14 @@ fn validate_time_fields(body: &CreateRunRequest) -> Result<(), Error> {
 /// Create a run for a session race. Top-level orchestrator: validate, insert,
 /// fetch. The validation surface and the transactional insert each live in
 /// their own helper below.
+///
+/// # Errors
+///
+/// Returns `BadRequest` for invalid time fields or unknown FK references;
+/// `NotFound` if the session race doesn't exist; `Conflict` if the session
+/// is closed, the user already submitted, the user skipped the race, or an
+/// older pending race blocks the submission; `Forbidden` if the user is not
+/// an active participant; `Internal` for unexpected DB failures.
 pub async fn create_run(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -172,7 +180,7 @@ pub async fn create_run(
 ///    submit, per docs/design.md "Pending Race Tracking" → "Submission rules").
 /// 7. The user has no older pending race blocking this submission
 ///    (ordered-submit guard, same source).
-/// 8. All FK references (character/body/wheel/glider/drink_type) exist.
+/// 8. All FK references (`character/body/wheel/glider/drink_type`) exist.
 async fn validate_run_request(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -263,7 +271,7 @@ async fn validate_run_request(
     Ok(session_race)
 }
 
-/// Insert the run row and bump the session's last_activity_at, atomically.
+/// Insert the run row and bump the session's `last_activity_at`, atomically.
 /// Returns the new run's ID. Caller is expected to have already validated
 /// the request via `validate_run_request`.
 async fn insert_run(
@@ -307,7 +315,12 @@ async fn insert_run(
     Ok(run_id)
 }
 
-/// Fetch a single run by ID with JOINed username and drink_type_name.
+/// Fetch a single run by ID with `JOINed` username and `drink_type_name`.
+///
+/// # Errors
+///
+/// Returns `NotFound` if no run with that ID exists; `Internal` for
+/// unexpected DB failures.
 pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetail, Error> {
     let row = RunDetailRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
@@ -331,7 +344,11 @@ pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetai
     Ok(row.into())
 }
 
-/// List runs with optional filters, ordered by track_time ASC.
+/// List runs with optional filters, ordered by `track_time` ASC.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_runs(
     db: &DatabaseConnection,
     filters: RunFilters,
@@ -389,6 +406,13 @@ pub async fn list_runs(
 }
 
 /// Delete a run. Only the run's owner can delete, and the session must be active.
+///
+/// # Errors
+///
+/// Returns `NotFound` if no run with that ID exists; `Forbidden` if the
+/// caller is not the run's owner; `Conflict` if the run's session is closed;
+/// `Internal` for unexpected DB failures or data-corruption invariants (e.g.,
+/// missing session for an existing run).
 pub async fn delete_run(
     db: &DatabaseConnection,
     run_id: &RunId,
@@ -435,7 +459,12 @@ pub async fn delete_run(
 }
 
 /// Get run defaults for pre-filling the run entry form.
+///
 /// Cascade: previous run → user preferences → none.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn get_run_defaults(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -592,7 +621,7 @@ mod tests {
         }
     }
 
-    /// Helper: create session, pick a track, return (session_id, session_race_id)
+    /// Helper: create session, pick a track, return (`session_id`, `session_race_id`)
     async fn setup_session_with_race(
         db: &DatabaseConnection,
         host_id: &UserId,
@@ -974,7 +1003,7 @@ mod tests {
 
     // ── Ordered-submit guard (PR 3D-2) ────────────────────────────────────
 
-    /// Helper: create a session, pick N tracks, return (session_id, race_ids).
+    /// Helper: create a session, pick N tracks, return (`session_id`, `race_ids`).
     async fn setup_session_with_n_races(
         db: &DatabaseConnection,
         host_id: &UserId,

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -13,6 +13,8 @@ use crate::{
     services::helpers,
 };
 
+/// A loaded session plus its ID in typed form.
+///
 /// `session_id` mirrors `session.id` as a typed `SessionId` so the helper
 /// methods can borrow `&self.session_id` instead of allocating a fresh wrapper
 /// on every call. Both fields hold the same UUID; the typed copy is the one
@@ -25,6 +27,11 @@ pub struct SessionContext {
 
 impl SessionContext {
     /// Load the session by ID and require it to be in the `Active` state.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the errors of [`helpers::load_active_session`]: `NotFound`
+    /// if the session doesn't exist, `Conflict` if it's not active.
     pub async fn load_active<C: ConnectionTrait>(
         db: &C,
         session_id: &SessionId,
@@ -38,6 +45,10 @@ impl SessionContext {
     }
 
     /// Require that `user_id` is the host of this session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Forbidden` if `user_id` is not the host.
     pub fn require_host(&self, user_id: &UserId) -> Result<(), Error> {
         if self.session.host_id.as_str() != user_id.as_str() {
             return Err(Error::Forbidden("Only the host can do that".into()));
@@ -46,6 +57,11 @@ impl SessionContext {
     }
 
     /// Require that `user_id` is an active participant and return their row.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the errors of [`helpers::require_active_participant`]:
+    /// `Forbidden` if the user is not an active participant of this session.
     pub async fn require_participant<C: ConnectionTrait>(
         &self,
         db: &C,
@@ -58,6 +74,11 @@ impl SessionContext {
     /// Delegates the UPDATE to `helpers::touch_session`, then refreshes
     /// the in-memory field so callers that read it post-touch see the
     /// updated value.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the errors of [`helpers::touch_session`] — currently only
+    /// `Internal` for unexpected DB failures.
     pub async fn touch<C: ConnectionTrait>(&mut self, db: &C) -> Result<(), Error> {
         helpers::touch_session(db, &self.session_id).await?;
         self.session.last_activity_at = chrono::Utc::now().naive_utc();

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -61,6 +61,10 @@ async fn check_not_in_any_session(
 
 /// Returns the session ID the user is currently active in, or None.
 /// Only considers active sessions (not closed/stale ones).
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn get_active_session_id(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -86,6 +90,12 @@ pub async fn get_active_session_id(
 
 /// Create a new session. The creator becomes both the host and the first
 /// participant. Returns the full session detail.
+///
+/// # Errors
+///
+/// Returns `BadRequest` if `ruleset` doesn't parse as a known `Ruleset`;
+/// `Conflict` if the user is already in another active session; `Internal`
+/// for unexpected DB failures.
 pub async fn create_session(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -149,8 +159,12 @@ struct SessionSummaryRow {
     last_activity_at: NaiveDateTime,
 }
 
-/// List active sessions sorted by last_activity_at DESC.
+/// List active sessions sorted by `last_activity_at` DESC.
 /// Uses a single JOIN query instead of N+1 queries.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn list_active_sessions(db: &DatabaseConnection) -> Result<Vec<SessionSummary>, Error> {
     let rows = SessionSummaryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
@@ -400,7 +414,7 @@ async fn load_current_race_with_submissions(
     }))
 }
 
-/// Fetch all races in a session with run counts, ordered by race_number ASC.
+/// Fetch all races in a session with run counts, ordered by `race_number` ASC.
 async fn load_race_history(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
@@ -482,6 +496,10 @@ struct PendingRaceRow {
 /// race shell here; per-race submissions belong to the current/history views,
 /// not the pending list. This avoids an N+1 query and keeps the polling path
 /// fast.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures on the JOIN query.
 pub async fn get_pending_races(
     db: &impl ConnectionTrait,
     session_id: &SessionId,
@@ -565,6 +583,12 @@ pub async fn get_pending_races(
 ///   session. A user who left (even within their grace window) must rejoin
 ///   before they can act on pending races; otherwise the symmetry with
 ///   `create_run` breaks (which also requires an active participant).
+///
+/// # Errors
+///
+/// Returns the variants enumerated in the doc above, plus `NotFound` if the
+/// race or session-race-participation row doesn't exist, and `Internal` for
+/// unexpected DB failures.
 pub async fn skip_pending_race(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -645,6 +669,11 @@ pub async fn skip_pending_race(
 /// per-user `your_pending` list. Anonymous callers aren't supported by the
 /// route layer, so this is always `Some` in production; tests pass `None`
 /// when they don't care about pending state.
+///
+/// # Errors
+///
+/// Returns `NotFound` if no session with that ID exists; `Internal` for
+/// unexpected DB failures on any of the helper queries.
 pub async fn get_session_detail(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -696,11 +725,12 @@ pub async fn get_session_detail(
     })
 }
 
-/// Grace window for "rejoin without losing pre-leave pending races." Within
-/// this window of `left_at`, rejoining preserves `joined_at` (and therefore
-/// preserves access to pre-leave pending races, per the §3 grace semantics).
-/// After this window, `joined_at` is reset to NOW(), forfeiting any pre-gap
-/// pending records.
+/// Grace window for "rejoin without losing pre-leave pending races."
+///
+/// Within this window of `left_at`, rejoining preserves `joined_at` (and
+/// therefore preserves access to pre-leave pending races, per the §3 grace
+/// semantics). After this window, `joined_at` is reset to `NOW()`, forfeiting
+/// any pre-gap pending records.
 pub const REJOIN_GRACE_MINUTES: i64 = 5;
 
 /// Join (or rejoin) a session. **Single mutable row per (session, user)** —
@@ -714,6 +744,12 @@ pub const REJOIN_GRACE_MINUTES: i64 = 5;
 ///   `joined_at = NOW()`. Pre-gap pending records remain in the DB for
 ///   history but are filtered out by the pending-races query
 ///   (`session_races.created_at >= session_participants.joined_at`).
+///
+/// # Errors
+///
+/// Returns `NotFound` if the session doesn't exist; `Conflict` if the
+/// session is closed or the user is already in another active session;
+/// `Internal` for unexpected DB failures.
 pub async fn join_session(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -857,7 +893,14 @@ async fn transfer_host_or_close(
     }
 }
 
-/// Leave a session. Sets left_at and handles host transfer.
+/// Leave a session. Sets `left_at` and handles host transfer.
+///
+/// # Errors
+///
+/// Returns `NotFound` if the session doesn't exist; `BadRequest` if the
+/// user is not currently in the session; `Internal` for unexpected DB
+/// failures or invariant violations (e.g., last-active-participant flow
+/// failing to find any remaining participant to promote).
 pub async fn leave_session(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -906,6 +949,12 @@ pub async fn leave_session(
 /// Pick the next track for a session. Host-only.
 /// Randomly selects from tracks not yet used in this session.
 /// If all tracks have been used, resets the pool.
+///
+/// # Errors
+///
+/// Returns `NotFound` if the session doesn't exist; `Conflict` if the
+/// session is closed; `Forbidden` if `user_id` isn't the host; `Internal`
+/// for unexpected DB failures or an empty `tracks` table.
 pub async fn next_track(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -977,11 +1026,20 @@ pub async fn next_track(
     })
 }
 
-/// Re-roll the current track. Any participant can trigger this
-/// (per docs/design.md — "any participant can pass the chooser's turn").
-/// Only valid if the most recent race has no runs submitted.
-/// Deletes the current race and picks a new one in a single transaction,
-/// excluding the skipped track from the pool so it can't come back.
+/// Re-roll the current track.
+///
+/// Any participant can trigger this (per docs/design.md — "any participant
+/// can pass the chooser's turn"). Only valid if the most recent race has no
+/// runs submitted. Deletes the current race and picks a new one in a single
+/// transaction, excluding the skipped track from the pool so it can't come
+/// back.
+///
+/// # Errors
+///
+/// Returns `NotFound` if the session doesn't exist; `Conflict` if the
+/// session is closed; `BadRequest` if there is no track to skip; `Conflict`
+/// if any runs were already submitted for the current race; `Internal` for
+/// unexpected DB failures.
 pub async fn skip_turn(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -1070,7 +1128,12 @@ pub async fn skip_turn(
     })
 }
 
-/// List all races in a session, ordered by race_number ASC.
+/// List all races in a session, ordered by `race_number` ASC.
+///
+/// # Errors
+///
+/// Returns `NotFound` if the session doesn't exist; `Internal` for
+/// unexpected DB failures.
 pub async fn list_races(
     db: &DatabaseConnection,
     session_id: &SessionId,
@@ -1115,9 +1178,15 @@ pub async fn list_races(
 }
 
 /// Close sessions that have had no activity for over an hour.
+///
 /// Also marks all remaining active participants as left, preventing
 /// users from being soft-locked out of creating/joining new sessions.
 /// Returns the number of sessions closed.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures on any of the SELECT or
+/// UPDATE statements that drive the cleanup.
 pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error> {
     let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).naive_utc();
 

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -59,6 +59,13 @@ where
 
 /// Update a user's profile (preferred race setup and/or drink type).
 /// Only the user themselves can update their own profile.
+///
+/// # Errors
+///
+/// Returns `Forbidden` if `actor_user_id != target_user_id`; `NotFound` if
+/// the target user doesn't exist; `BadRequest` if race setup is provided as
+/// a partial set (not all-or-nothing) or any of the character / body / wheel
+/// / glider / drink-type IDs doesn't exist; `Internal` for DB failures.
 pub async fn update_profile(
     db: &DatabaseConnection,
     actor_user_id: &UserId,
@@ -113,8 +120,13 @@ pub async fn update_profile(
 }
 
 /// Load drink type details and assemble the full profile response.
+///
 /// TODO: if profile fetching becomes a hot path, collapse the separate
-/// drink_type lookup into a JOIN query to avoid the extra round trip.
+/// `drink_type` lookup into a JOIN query to avoid the extra round trip.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
 pub async fn build_detail_profile(
     db: &DatabaseConnection,
     user: users::Model,

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -8,6 +8,11 @@
 //! a shared `common/mod.rs`), relocate these helpers there instead.
 
 #![cfg(test)]
+// Every helper in this file panics on DB-setup failure by design — a failed
+// `setup_db()`, `Migrator::up`, or insert is treated as a test infrastructure
+// problem, not a recoverable error. Documenting each panic individually would
+// be repetition; the file-level contract is enough.
+#![allow(clippy::missing_panics_doc)]
 
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, DatabaseConnection, Set};
@@ -22,7 +27,7 @@ use crate::{
     },
 };
 
-/// Spin up an in-memory SQLite database with foreign keys enabled and all
+/// Spin up an in-memory `SQLite` database with foreign keys enabled and all
 /// migrations applied. Each call returns a fresh, isolated DB.
 pub async fn setup_db() -> DatabaseConnection {
     use migration::{Migrator, MigratorTrait};

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -29,7 +29,7 @@ fn test_config() -> Arc<Config> {
     })
 }
 
-/// Create a fresh in-memory SQLite database with all migrations applied and
+/// Create a fresh in-memory `SQLite` database with all migrations applied and
 /// static data seeded. Returns the test server and the underlying DB connection
 /// for direct queries in tests.
 async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
@@ -249,7 +249,7 @@ fn auth_value(token: &str) -> HeaderValue {
     HeaderValue::from_str(&format!("Bearer {token}")).unwrap()
 }
 
-/// Register a user and return (access_token, user_id).
+/// Register a user and return (`access_token`, `user_id`).
 async fn register_and_get_token(server: &TestServer, username: &str) -> (String, String) {
     let res = server
         .post("/api/v1/auth/register")

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -32,7 +32,7 @@ async fn protected_hello(user: beerio_kart::middleware::auth::User) -> axum::Jso
     axum::Json(json!({ "hello": user.username }))
 }
 
-/// Create a fresh in-memory SQLite database with all migrations applied.
+/// Create a fresh in-memory `SQLite` database with all migrations applied.
 async fn setup_test_app() -> TestServer {
     let db = Database::connect("sqlite::memory:")
         .await
@@ -75,7 +75,7 @@ async fn register_user(server: &TestServer, username: &str, password: &str) -> V
     response.json()
 }
 
-/// Helper: extract the refresh_token cookie value from a Set-Cookie header.
+/// Helper: extract the `refresh_token` cookie value from a Set-Cookie header.
 fn extract_refresh_cookie(response: &axum_test::TestResponse) -> Option<String> {
     let header = response.header("set-cookie");
     let header_str = header.to_str().ok()?;

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -22,7 +22,7 @@ async fn auth_handler(user: User) -> axum::Json<Value> {
     axum::Json(serde_json::json!({ "user_id": user.user_id }))
 }
 
-/// Minimal handler that requires AdminUser.
+/// Minimal handler that requires `AdminUser`.
 async fn admin_handler(admin: AdminUser) -> axum::Json<Value> {
     axum::Json(serde_json::json!({ "admin_id": admin.user_id }))
 }

--- a/backend/tests/schema_drift.rs
+++ b/backend/tests/schema_drift.rs
@@ -6,18 +6,18 @@
 //! are committed source (per `coding-standards/seaorm.md` § 6), codegen no
 //! longer acts as an implicit drift-checker between migration and entity.
 //! This test replaces that signal with a single CI-time guarantee: for every
-//! entity, force SeaORM to issue a `SELECT` covering all declared columns
+//! entity, force `SeaORM` to issue a `SELECT` covering all declared columns
 //! against the schema the migration produces.
 //!
 //! # What this catches
 //!
 //! - **Entity declares a column the migration didn't create** → the issued
-//!   `SELECT` references a non-existent column and SQLite returns an error
+//!   `SELECT` references a non-existent column and `SQLite` returns an error
 //!   at execution time. Verified by manual injection during PR-X2 dev:
 //!   adding a phantom `bogus_drift_column` to `run_flags` produced a clean
 //!   `no such column: run_flags.bogus_drift_column` failure.
 //! - **Entity points at a wrong table name** → same shape: `no such table:
-//!   …` from SQLite.
+//!   …` from `SQLite`.
 //!
 //! # What this does NOT catch
 //!
@@ -27,10 +27,10 @@
 //!   different mechanism (e.g. introspecting `PRAGMA table_info` and
 //!   diffing against the entity's `Column` enum) which is out of scope for
 //!   this test.
-//! - **Type mismatch on a column that exists in both.** SQLite uses column
+//! - **Type mismatch on a column that exists in both.** `SQLite` uses column
 //!   *affinity*, not strict typing, so a `TEXT`-declared column happily
 //!   accepts an integer value at the SQL layer. With `LIMIT 0` no rows are
-//!   returned, so SeaORM's per-row decode (where a Rust-level type
+//!   returned, so `SeaORM`'s per-row decode (where a Rust-level type
 //!   mismatch would surface) never runs. Catching type drift requires
 //!   seeding at least one row — out of scope for the bootstrap version of
 //!   this test. Verified by manual injection: changing `run_flags.reason`
@@ -40,7 +40,7 @@
 //!   and rely on review attention plus the atomic-PR rule from CLAUDE.md.
 //! - **Hand-corrected attributes** like the absent `unique` on
 //!   `session_participants.user_id`. The entity deliberately omits `unique`
-//!   so SeaORM doesn't infer `has_one` on the `users` ↔
+//!   so `SeaORM` doesn't infer `has_one` on the `users` ↔
 //!   `session_participants` relation (see that entity's doc-comment for
 //!   the full reasoning, including the two distinct migration constraints
 //!   that justify it). Intentional deviation, not drift; review catches it.

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -90,7 +90,7 @@ async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
     (TestServer::new(app), db)
 }
 
-/// Seed minimal game data needed by skip + create_run integration tests.
+/// Seed minimal game data needed by skip + `create_run` integration tests.
 /// Production seed (`seed::run`) lives in main.rs and isn't reachable from
 /// integration tests; this is a stripped-down equivalent — one each of
 /// cup, track, character, body, wheels, glider, drink type.
@@ -163,7 +163,7 @@ async fn seed_minimal_game_data(db: &sea_orm::DatabaseConnection) {
     .expect("insert drink type");
 }
 
-/// Build a valid CreateRunRequest body for the given race ID.
+/// Build a valid `CreateRunRequest` body for the given race ID.
 fn run_request_json(session_race_id: &str) -> Value {
     let drink_id = drink_type_uuid("Test Beer");
     json!({
@@ -509,7 +509,7 @@ async fn test_stale_session_cleanup() {
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Helper: register a host, seed minimal game data, create a session, pick a
-/// track. Returns (server, db, token, user_id, session_id, race_id).
+/// track. Returns (server, db, token, `user_id`, `session_id`, `race_id`).
 async fn setup_with_one_race() -> (
     TestServer,
     sea_orm::DatabaseConnection,

--- a/docs/compliance-plan.md
+++ b/docs/compliance-plan.md
@@ -347,7 +347,7 @@ The largest phase. Each PR is independently reviewable; sequence keeps blast rad
 - **Risk:** Low.
 - **Verification:** `cargo doc --no-deps` produces clean output; spot-check that summary tables are readable.
 - **Tracking:** Issue [#114](https://github.com/brendanbyrne/beerio-kart/issues/114).
-- **Sign-off:** [ ]
+- **Sign-off:** [x]
 
 ### PR-G4: File-length splits
 
@@ -492,3 +492,4 @@ Some PRs (B1, B3, E3, X1) have no dependencies and can land in parallel with A1/
 - 2026-05-11 — PR-H1+ (d) Issue [#103](https://github.com/brendanbyrne/beerio-kart/issues/103) closed via PR #112 (renamed 13 sites for `module_name_repetitions`: `App*` prefix dropped, `list_<resource>` shortened to `list`; fixed 6 cast sites by changing `Config.jwt_*_expiry` field types from `u64` to `i64` and propagating invariant violations as `Error::Internal` instead of silent fallbacks).
 - 2026-05-11 — PR-H1+ (e) Issue [#98](https://github.com/brendanbyrne/beerio-kart/issues/98) verified clean without code changes. PR-A1 (#24) never added module-level allows for `clippy::nursery` (verified by `gh pr diff 24` and `grep -rn "allow.*clippy" backend/src`); `nursery = "warn"` is enabled workspace-wide and the codebase has zero nursery-lint violations. Closes the PR-H1+ tracking parent [#95](https://github.com/brendanbyrne/beerio-kart/issues/95).
 - 2026-05-11 — Filed Issue [#114](https://github.com/brendanbyrne/beerio-kart/issues/114) tracking PR-G3 (doc-comment audit). Scoped to four lints (`missing_errors_doc`, `doc_markdown`, `missing_panics_doc`, `too_long_first_doc_paragraph`) and the 149 sites they surface as of today. Added Tracking line to PR-G3 row; added a note on the D1/D2 dependency relaxation since the Issue body discusses both pickup options.
+- 2026-05-11 — Marked PR-G3 sign-off complete. Removed the four `allow` lines from `backend/Cargo.toml`; cleared 147 sites (60 `doc_markdown` via `cargo clippy --fix`, 72 `missing_errors_doc` with hand-written `# Errors` sections, 9 `missing_panics_doc` via a per-file `#![allow]` on `test_helpers.rs` justified by the contract "every helper panics on DB-setup failure", 6 `too_long_first_doc_paragraph` via paragraph splits). `cargo clippy --all-targets -- -D warnings` and `cargo doc --no-deps` clean. The D1/D2 dependency was relaxed per the option-1 framing in #114 — some `# Errors` sections reference primitives (`i32`, `String`) that will become newtypes in the D-stream; the re-edit is expected to be cheap.

--- a/docs/compliance-plan.md
+++ b/docs/compliance-plan.md
@@ -347,7 +347,7 @@ The largest phase. Each PR is independently reviewable; sequence keeps blast rad
 - **Risk:** Low.
 - **Verification:** `cargo doc --no-deps` produces clean output; spot-check that summary tables are readable.
 - **Tracking:** Issue [#114](https://github.com/brendanbyrne/beerio-kart/issues/114).
-- **Sign-off:** [x]
+- **Sign-off:** [ ]
 
 ### PR-G4: File-length splits
 
@@ -492,4 +492,3 @@ Some PRs (B1, B3, E3, X1) have no dependencies and can land in parallel with A1/
 - 2026-05-11 — PR-H1+ (d) Issue [#103](https://github.com/brendanbyrne/beerio-kart/issues/103) closed via PR #112 (renamed 13 sites for `module_name_repetitions`: `App*` prefix dropped, `list_<resource>` shortened to `list`; fixed 6 cast sites by changing `Config.jwt_*_expiry` field types from `u64` to `i64` and propagating invariant violations as `Error::Internal` instead of silent fallbacks).
 - 2026-05-11 — PR-H1+ (e) Issue [#98](https://github.com/brendanbyrne/beerio-kart/issues/98) verified clean without code changes. PR-A1 (#24) never added module-level allows for `clippy::nursery` (verified by `gh pr diff 24` and `grep -rn "allow.*clippy" backend/src`); `nursery = "warn"` is enabled workspace-wide and the codebase has zero nursery-lint violations. Closes the PR-H1+ tracking parent [#95](https://github.com/brendanbyrne/beerio-kart/issues/95).
 - 2026-05-11 — Filed Issue [#114](https://github.com/brendanbyrne/beerio-kart/issues/114) tracking PR-G3 (doc-comment audit). Scoped to four lints (`missing_errors_doc`, `doc_markdown`, `missing_panics_doc`, `too_long_first_doc_paragraph`) and the 149 sites they surface as of today. Added Tracking line to PR-G3 row; added a note on the D1/D2 dependency relaxation since the Issue body discusses both pickup options.
-- 2026-05-11 — Marked PR-G3 sign-off complete. Removed the four `allow` lines from `backend/Cargo.toml`; cleared 147 sites (60 `doc_markdown` via `cargo clippy --fix`, 72 `missing_errors_doc` with hand-written `# Errors` sections, 9 `missing_panics_doc` via a per-file `#![allow]` on `test_helpers.rs` justified by the contract "every helper panics on DB-setup failure", 6 `too_long_first_doc_paragraph` via paragraph splits). `cargo clippy --all-targets -- -D warnings` and `cargo doc --no-deps` clean. The D1/D2 dependency was relaxed per the option-1 framing in #114 — some `# Errors` sections reference primitives (`i32`, `String`) that will become newtypes in the D-stream; the re-edit is expected to be cheap.


### PR DESCRIPTION
Closes #114.

## Summary

PR-G3 from the compliance plan: removes the four workspace-level `clippy` allows that were keeping doc-comment hygiene out of CI, and fixes the 147 sites they surfaced.

| Lint | Sites (this branch) | Resolution |
|---|---|---|
| `clippy::doc_markdown` | 60 | `cargo clippy --fix` auto-applied (wrap identifier in backticks) |
| `clippy::missing_errors_doc` | 72 | Hand-written `# Errors` sections |
| `clippy::missing_panics_doc` | 9 | Per-file allow on `test_helpers.rs` with justification |
| `clippy::too_long_first_doc_paragraph` | 6 | 2 auto-applied by `--fix`, 4 split by hand |

Snapshot in #114 was 149 (2026-05-11); re-counted on this branch before starting and got 147 — minor drift, no scope change.

## Notable decisions

**`test_helpers.rs` per-file allow.** Every helper in that file panics on a DB-setup failure (`Migrator::up`, `.insert(...).await.expect(...)`, etc.) by design — that's the contract test infrastructure is built on. Documenting nine separate `# Panics` sections that all say "panics on DB error" would be repetition without value. Resolved as `#![allow(clippy::missing_panics_doc)]` at the top of the file with a one-paragraph justification. The workspace-level allow is still gone, so any new non-test code that adds an undoc'd panic still trips the lint.

**D1/D2 dependency relaxation.** The compliance plan listed PR-G3 as depending on PR-D1 (ID newtypes) and PR-D2 (validated string newtypes) so docs reference newtypes, not primitives. Neither has landed. Per the option-1 framing in #114 and the explicit "acceptable" carve-out Cowork added to the plan on 2026-05-11, this PR goes ahead and accepts that some `# Errors` sections reference primitives (`i32`, `String`) that will later become newtypes. The re-edit during D-stream is expected to be `sed`-able for the common case.

**Route handlers' `# Errors` reference the underlying service.** Most route handlers are thin shims around a single service function (e.g., `routes::sessions::join_session` → `services::sessions::join_session`). Their `# Errors` sections name the propagated variants and point to the service via intradoc-link syntax, rather than re-asserting every gate. This keeps the docs accurate without coupling the route layer's doc to the service's implementation details.

## Test plan

```bash
cd backend

# 1. Clippy clean on the four lints that were previously allowed (no override required now).
cargo clippy --all-targets -- -D warnings
# Expect: "Finished ..." with no warnings.

# 2. cargo doc tree builds without warnings.
cargo doc --no-deps
# Expect: "Generated .../target/doc/beerio_kart/index.html" with no warnings.

# 3. Full test suite still passes.
cargo test --all-targets
# Expect: All test bins green. 172 lib + 27+21+8+1+19 integration = 248 tests.

# 4. The four allow lines are gone from Cargo.toml.
grep -E "(missing_errors_doc|missing_panics_doc|doc_markdown|too_long_first_doc_paragraph)\s*=\s*\"allow\"" Cargo.toml
# Expect: no output.

# 5. The Issue's reproduction command shows zero hits for the four lints.
cargo clean -p beerio-kart
cargo clippy --all-targets -- --cap-lints=warn \
  -W clippy::missing_errors_doc \
  -W clippy::doc_markdown \
  -W clippy::missing_panics_doc \
  -W clippy::too_long_first_doc_paragraph \
  > /tmp/g3-after.log 2>&1
grep -cE "^warning: " /tmp/g3-after.log
# Expect: only the workspace-summary "generated N warnings" lines, no per-site warnings.
```

Quick visual spot-check the diff against the auto-fix commit:

```bash
git log -1 --stat
```

29 files changed: Cargo.toml (4 lines removed), 1 migration file, and 27 source / test files getting doc additions. No code-behavior changes.
