### PR TITLE
104 + 118: ConnectionTrait sweep across runs/sessions/users services

### DIFF
--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -182,7 +182,7 @@ pub async fn create_run(
 ///    (ordered-submit guard, same source).
 /// 8. All FK references (`character/body/wheel/glider/drink_type`) exist.
 async fn validate_run_request(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     user_id: &UserId,
     body: &CreateRunRequest,
 ) -> Result<session_races::Model, Error> {
@@ -321,7 +321,7 @@ async fn insert_run(
 ///
 /// Returns `NotFound` if no run with that ID exists; `Internal` for
 /// unexpected DB failures.
-pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetail, Error> {
+pub async fn get_run(db: &impl ConnectionTrait, run_id: &RunId) -> Result<RunDetail, Error> {
     let row = RunDetailRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -350,7 +350,7 @@ pub async fn get_run(db: &DatabaseConnection, run_id: &RunId) -> Result<RunDetai
 ///
 /// Returns `Internal` for unexpected DB failures.
 pub async fn list_runs(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     filters: RunFilters,
 ) -> Result<Vec<RunDetail>, Error> {
     let mut conditions = Vec::new();
@@ -466,7 +466,7 @@ pub async fn delete_run(
 ///
 /// Returns `Internal` for unexpected DB failures.
 pub async fn get_run_defaults(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     user_id: &UserId,
 ) -> Result<RunDefaults, Error> {
     // Try most recent run

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -66,7 +66,7 @@ async fn check_not_in_any_session(
 ///
 /// Returns `Internal` for unexpected DB failures.
 pub async fn get_active_session_id(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     user_id: &UserId,
 ) -> Result<Option<SessionId>, Error> {
     let row = ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
@@ -165,7 +165,7 @@ struct SessionSummaryRow {
 /// # Errors
 ///
 /// Returns `Internal` for unexpected DB failures.
-pub async fn list_active_sessions(db: &DatabaseConnection) -> Result<Vec<SessionSummary>, Error> {
+pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<SessionSummary>, Error> {
     let rows = SessionSummaryRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
@@ -675,7 +675,7 @@ pub async fn skip_pending_race(
 /// Returns `NotFound` if no session with that ID exists; `Internal` for
 /// unexpected DB failures on any of the helper queries.
 pub async fn get_session_detail(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     session_id: &SessionId,
     requesting_user_id: Option<&UserId>,
 ) -> Result<SessionDetail, Error> {
@@ -1135,7 +1135,7 @@ pub async fn skip_turn(
 /// Returns `NotFound` if the session doesn't exist; `Internal` for
 /// unexpected DB failures.
 pub async fn list_races(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     session_id: &SessionId,
 ) -> Result<Vec<RaceInfo>, Error> {
     // Verify session exists

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -67,7 +67,7 @@ where
 /// a partial set (not all-or-nothing) or any of the character / body / wheel
 /// / glider / drink-type IDs doesn't exist; `Internal` for DB failures.
 pub async fn update_profile(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     actor_user_id: &UserId,
     target_user_id: &UserId,
     req: UpdateProfileRequest,
@@ -128,7 +128,7 @@ pub async fn update_profile(
 ///
 /// Returns `Internal` for unexpected DB failures.
 pub async fn build_detail_profile(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     user: users::Model,
 ) -> Result<UserDetailProfile, Error> {
     let drink_type = if let Some(ref dt_id) = user.preferred_drink_type_id {


### PR DESCRIPTION
## Summary

- Read-only / non-transaction service functions in [backend/src/services/runs.rs](backend/src/services/runs.rs), [backend/src/services/sessions.rs](backend/src/services/sessions.rs), and [backend/src/services/users.rs](backend/src/services/users.rs) now take `&impl ConnectionTrait` per [docs/coding-standards/seaorm.md § 4](docs/coding-standards/seaorm.md).
- Transaction-starting orchestrators intentionally keep `&DatabaseConnection` since they call `db.begin()`.
- Zero behavior change — pure signature refactor across two commits.

Closes #104 (runs.rs) and #118 (sessions.rs + users.rs).

## What changed

### `services/runs.rs` (#104, commit 67c783a)

| Function | Before | After |
|---|---|---|
| `get_run` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `list_runs` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `get_run_defaults` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `validate_run_request` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `create_run`, `insert_run`, `delete_run` | _(unchanged — orchestrators / call `db.begin()`)_ ||

### `services/sessions.rs` (#118, commit d87ac09)

| Function | Before | After |
|---|---|---|
| `get_active_session_id` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `list_active_sessions` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `get_session_detail` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `list_races` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `create_session`, `skip_pending_race`, `join_session`, `leave_session`, `next_track`, `skip_turn`, `close_stale_sessions` | _(unchanged — all call `db.begin()`)_ ||

### `services/users.rs` (#118, commit d87ac09)

| Function | Before | After |
|---|---|---|
| `update_profile` | `&DatabaseConnection` | `&impl ConnectionTrait` |
| `build_detail_profile` | `&DatabaseConnection` | `&impl ConnectionTrait` |

Neither calls `db.begin()`. Import swapped from `DatabaseConnection` to `ConnectionTrait`.

All downstream callees (`helpers::load_active_session`, `helpers::require_active_participant`, `helpers::require_exists`, `helpers::touch_session`, `sessions::get_pending_races`, all four `load_*` helpers inside `get_session_detail`) already accept `&impl ConnectionTrait`, so the change passes through without transitive edits.

## Test plan

Build, lint, and full test suite — all should pass clean:

```bash
cd backend
cargo build
cargo clippy --all-targets -- -D warnings
cargo test
```

Expected: 248 tests pass, no clippy warnings, build clean. (Locally verified after each commit: 172 unit + 19 + 27 + 21 + 8 + 1 integration tests all pass; clippy clean; build clean.)

Targeted service tests:

```bash
cargo test --lib services::runs::
cargo test --lib services::sessions::
cargo test --lib services::users::
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)