### PR TITLE
138: in-memory SQLite tests use unique cache=shared URLs (PR-G1)

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -53,7 +53,10 @@ pub async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
 #[cfg(test)]
 mod tests {
     use migration::{Migrator, MigratorTrait};
-    use sea_orm::{ActiveModelTrait, FromQueryResult, Set, Statement};
+    use sea_orm::{
+        ActiveModelTrait, EntityTrait, FromQueryResult, PaginatorTrait, Set, Statement,
+        TransactionTrait,
+    };
     use uuid::Uuid;
 
     use super::*;
@@ -100,6 +103,36 @@ mod tests {
             result.is_err(),
             "insert with bogus FK should fail when foreign_keys=ON"
         );
+    }
+
+    #[tokio::test]
+    async fn test_shared_cache_schema_visible_across_pool_connections() {
+        // Two concurrent transactions force the pool to hand out two distinct
+        // connections (each `begin()` pins one for the lifetime of the txn).
+        // Both must be able to SELECT from `users` — proving that the
+        // migration ran on connection #1 is visible to connection #2, i.e.
+        // the `cache=shared` URL is working. Without it (or with a plain
+        // `sqlite::memory:` URL), the second connection would open a fresh,
+        // empty in-memory DB and the query would fail with "no such table".
+        let db = shared_memory_db().await;
+
+        let txn_a = db.begin().await.expect("begin txn a");
+        let txn_b = db.begin().await.expect("begin txn b");
+
+        let count_a = users::Entity::find()
+            .count(&txn_a)
+            .await
+            .expect("count via txn a");
+        let count_b = users::Entity::find()
+            .count(&txn_b)
+            .await
+            .expect("count via txn b");
+
+        assert_eq!(count_a, 0);
+        assert_eq!(count_b, 0);
+
+        txn_a.commit().await.expect("commit a");
+        txn_b.commit().await.expect("commit b");
     }
 
     #[tokio::test]

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -29,12 +29,18 @@ use crate::{
 
 /// Spin up an in-memory `SQLite` database with foreign keys enabled and all
 /// migrations applied. Each call returns a fresh, isolated DB.
+///
+/// The URL uses a unique cache name so pool connections within this test all
+/// see the same DB (per `seaorm.md` § 9), while different tests stay isolated
+/// from each other. Plain `sqlite::memory:?cache=shared` would share one DB
+/// across every test in the process.
 pub async fn setup_db() -> DatabaseConnection {
     use migration::{Migrator, MigratorTrait};
 
-    let db = Database::connect("sqlite::memory:")
+    let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
+    let db = Database::connect(&url)
         .await
-        .expect("connect to sqlite::memory:");
+        .expect("connect to in-memory DB");
     db.execute_unprepared("PRAGMA foreign_keys = ON")
         .await
         .expect("enable foreign keys");

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -16,6 +16,7 @@ use migration::{Migrator, MigratorTrait};
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
 use serde_json::{Value, json};
 use tokio::sync::Semaphore;
+use uuid::Uuid;
 
 const TEST_SECRET: &str = "test-secret-for-integration-tests";
 
@@ -33,7 +34,8 @@ fn test_config() -> Arc<Config> {
 /// static data seeded. Returns the test server and the underlying DB connection
 /// for direct queries in tests.
 async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
-    let db = Database::connect("sqlite::memory:")
+    let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
+    let db = Database::connect(&url)
         .await
         .expect("Failed to connect to in-memory SQLite");
 

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -34,7 +34,11 @@ async fn protected_hello(user: beerio_kart::middleware::auth::User) -> axum::Jso
 
 /// Create a fresh in-memory `SQLite` database with all migrations applied.
 async fn setup_test_app() -> TestServer {
-    let db = Database::connect("sqlite::memory:")
+    let url = format!(
+        "sqlite:file:{}?mode=memory&cache=shared",
+        uuid::Uuid::new_v4()
+    );
+    let db = Database::connect(&url)
         .await
         .expect("Failed to connect to in-memory SQLite");
 

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -14,6 +14,7 @@ use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
 use serde_json::{Value, json};
 use tokio::sync::Semaphore;
+use uuid::Uuid;
 
 const TEST_SECRET: &str = "test-secret-for-integration-tests";
 
@@ -34,10 +35,7 @@ async fn protected_hello(user: beerio_kart::middleware::auth::User) -> axum::Jso
 
 /// Create a fresh in-memory `SQLite` database with all migrations applied.
 async fn setup_test_app() -> TestServer {
-    let url = format!(
-        "sqlite:file:{}?mode=memory&cache=shared",
-        uuid::Uuid::new_v4()
-    );
+    let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
     let db = Database::connect(&url)
         .await
         .expect("Failed to connect to in-memory SQLite");
@@ -112,7 +110,7 @@ async fn test_register_success_returns_201_with_access_token_and_refresh_cookie(
     assert_eq!(body["user"]["username"], "alice");
     assert!(body["user"]["id"].is_string());
     let id = body["user"]["id"].as_str().unwrap();
-    assert!(uuid::Uuid::parse_str(id).is_ok());
+    assert!(Uuid::parse_str(id).is_ok());
 
     // Should set a refresh cookie
     let cookie = extract_refresh_cookie(&response);

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -14,6 +14,7 @@ use migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectionTrait, Database};
 use serde_json::Value;
 use tokio::sync::Semaphore;
+use uuid::Uuid;
 
 const TEST_SECRET: &str = "middleware-test-secret";
 
@@ -38,7 +39,8 @@ fn make_config(admin_user_id: Option<&str>) -> Arc<Config> {
 }
 
 async fn setup_server(admin_user_id: Option<&str>) -> TestServer {
-    let db = Database::connect("sqlite::memory:").await.expect("connect");
+    let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
+    let db = Database::connect(&url).await.expect("connect");
     db.execute_unprepared("PRAGMA foreign_keys = ON")
         .await
         .expect("pragma");

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -38,7 +38,8 @@ fn test_config() -> Arc<Config> {
 }
 
 async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
-    let db = Database::connect("sqlite::memory:")
+    let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
+    let db = Database::connect(&url)
         .await
         .expect("Failed to connect to in-memory SQLite");
 


### PR DESCRIPTION
## Reviewer notes

Five tiny mechanical edits + one new verification test. The interesting bit is the URL form chosen — `sqlite:file:<uuid>?mode=memory&cache=shared`, not the literal `sqlite::memory:?cache=shared` named in the Issue scope. Reason: `sqlite::memory:?cache=shared` is the *anonymous* shared in-memory DB, which is one DB per process — every parallel test would share schema and rows. Adding `file:<uuid>` gives each test its own named in-memory DB while still sharing across that test's pool connections. The standard explicitly allows this ([`seaorm.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/seaorm.md) § 9, second rule: "For shared-cache mode, parameterize the URL with a unique cache name per test if cross-test isolation matters"), and the pattern was already in use at [`backend/src/db.rs:69`](https://github.com/brendanbyrne/beerio-kart/blob/main/backend/src/db.rs#L69).

## Summary

Switches the five in-memory SQLite test setups (1 helper + 4 integration test files) to `sqlite:file:<uuid>?mode=memory&cache=shared` so pool connections within a test see the migrated schema. Adds a verification test in `db::tests` that opens two concurrent transactions (pinning two distinct pool connections) and confirms both can SELECT from `users`.

## Linked work

- Closes #138
- Per [`docs/compliance-plan.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/compliance-plan.md) § PR-G1
- Standards ref: [`docs/coding-standards/seaorm.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/seaorm.md) § 9

## How to verify

Backend tests pass and the new pool-size verification test runs:

```bash
cd backend
cargo test --no-fail-fast
```

- [x] All test suites green (lib 173, integration suites unchanged at 27/21/8/19, schema_drift 1).
- [x] The new test specifically passes:
```bash
cd backend
cargo test --lib test_shared_cache_schema_visible_across_pool_connections
```
- [x] Audit confirms no `sqlite::memory:` remains:
```bash
grep -rn "sqlite::memory" backend/ || echo "OK: none found"
```
- [x] Clippy clean:
```bash
cd backend
cargo clippy --all-targets -- -D warnings
```

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated for new logic (new `test_shared_cache_schema_visible_across_pool_connections`).
- [x] Docs updated if applicable — none needed; standard already documents the rule.
- [x] Schema changes: none.
- [x] Tested locally end-to-end.