### PR TITLE
136: add rstest + insta as dev-deps with demo migrations (PR-G2)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -274,11 +274,13 @@ dependencies = [
  "chrono",
  "cookie",
  "dotenvy",
+ "insta",
  "jsonwebtoken",
  "log",
  "migration",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "rstest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -519,6 +521,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +762,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -797,6 +826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +883,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -899,6 +935,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,13 +958,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1303,6 +1358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1465,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1986,6 +2060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2147,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2215,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2461,6 +2584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2939,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -72,3 +72,9 @@ tower = "0.5.3"
 # error.rs tests to assert the client/detail split: driver-string detail must
 # reach `tracing::warn!` but must not reach the response body. See Issue #84.
 tracing-test = "0.2"
+# Table-driven test cases (rust.md § 7). Reach for it when the same logic
+# runs over half-a-dozen inputs.
+rstest = "0.23"
+# Snapshot assertions for HTTP response bodies in integration tests
+# (rust.md § 7). Updates land via `cargo insta accept`.
+insta = { version = "1.41", features = ["json"] }

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -275,12 +275,12 @@ async fn register_and_get_token(server: &TestServer, username: &str) -> (String,
 // still surfaces as its own line in `cargo test` output via the
 // auto-generated suffix (e.g. `test_list_endpoint_returns_seeded_count::case_1`).
 #[rstest]
-#[case("/api/v1/characters", 50)]
-#[case("/api/v1/bodies", 41)]
-#[case("/api/v1/wheels", 22)]
-#[case("/api/v1/gliders", 15)]
-#[case("/api/v1/cups", 24)]
-#[case("/api/v1/tracks", 96)]
+#[case::characters("/api/v1/characters", 50)]
+#[case::bodies("/api/v1/bodies", 41)]
+#[case::wheels("/api/v1/wheels", 22)]
+#[case::gliders("/api/v1/gliders", 15)]
+#[case::cups("/api/v1/cups", 24)]
+#[case::tracks("/api/v1/tracks", 96)]
 #[tokio::test]
 async fn test_list_endpoint_returns_seeded_count(#[case] endpoint: &str, #[case] expected: usize) {
     let (server, _db) = setup_test_app().await;

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -273,7 +273,7 @@ async fn register_and_get_token(server: &TestServer, username: &str) -> (String,
 // table-driven case. Adding a new game-data list endpoint here is one
 // `#[case]` line, not a fresh ~12-line `#[tokio::test]` clone. Each case
 // still surfaces as its own line in `cargo test` output via the
-// auto-generated suffix (e.g. `test_list_endpoint_returns_seeded_count::case_1`).
+// auto-generated suffix (e.g. `test_list_endpoint_returns_seeded_count::case_1_characters`).
 #[rstest]
 #[case::characters("/api/v1/characters", 50)]
 #[case::bodies("/api/v1/bodies", 41)]

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -13,6 +13,7 @@ use axum::{
 use axum_test::TestServer;
 use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, routes};
 use migration::{Migrator, MigratorTrait};
+use rstest::rstest;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, Set};
 use serde_json::{Value, json};
 use tokio::sync::Semaphore;
@@ -268,88 +269,34 @@ async fn register_and_get_token(server: &TestServer, username: &str) -> (String,
 // Game Data Endpoints
 // ═══════════════════════════════════════════════════════════════════════
 
+// rstest demo (rust.md § 7): six list-endpoint count tests collapsed into one
+// table-driven case. Adding a new game-data list endpoint here is one
+// `#[case]` line, not a fresh ~12-line `#[tokio::test]` clone. Each case
+// still surfaces as its own line in `cargo test` output via the
+// auto-generated suffix (e.g. `test_list_endpoint_returns_seeded_count::case_1`).
+#[rstest]
+#[case("/api/v1/characters", 50)]
+#[case("/api/v1/bodies", 41)]
+#[case("/api/v1/wheels", 22)]
+#[case("/api/v1/gliders", 15)]
+#[case("/api/v1/cups", 24)]
+#[case("/api/v1/tracks", 96)]
 #[tokio::test]
-async fn test_list_characters_returns_50_items() {
+async fn test_list_endpoint_returns_seeded_count(#[case] endpoint: &str, #[case] expected: usize) {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "testuser").await;
 
     let res = server
-        .get("/api/v1/characters")
+        .get(endpoint)
         .add_header(AUTH_HEADER, auth_value(&token))
         .await;
     res.assert_status(axum::http::StatusCode::OK);
     let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 50, "Expected 50 characters");
-}
-
-#[tokio::test]
-async fn test_list_bodies_returns_41_items() {
-    let (server, _db) = setup_test_app().await;
-    let (token, _) = register_and_get_token(&server, "testuser").await;
-
-    let res = server
-        .get("/api/v1/bodies")
-        .add_header(AUTH_HEADER, auth_value(&token))
-        .await;
-    res.assert_status(axum::http::StatusCode::OK);
-    let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 41, "Expected 41 bodies");
-}
-
-#[tokio::test]
-async fn test_list_wheels_returns_22_items() {
-    let (server, _db) = setup_test_app().await;
-    let (token, _) = register_and_get_token(&server, "testuser").await;
-
-    let res = server
-        .get("/api/v1/wheels")
-        .add_header(AUTH_HEADER, auth_value(&token))
-        .await;
-    res.assert_status(axum::http::StatusCode::OK);
-    let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 22, "Expected 22 wheels");
-}
-
-#[tokio::test]
-async fn test_list_gliders_returns_15_items() {
-    let (server, _db) = setup_test_app().await;
-    let (token, _) = register_and_get_token(&server, "testuser").await;
-
-    let res = server
-        .get("/api/v1/gliders")
-        .add_header(AUTH_HEADER, auth_value(&token))
-        .await;
-    res.assert_status(axum::http::StatusCode::OK);
-    let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 15, "Expected 15 gliders");
-}
-
-#[tokio::test]
-async fn test_list_cups_returns_24_items() {
-    let (server, _db) = setup_test_app().await;
-    let (token, _) = register_and_get_token(&server, "testuser").await;
-
-    let res = server
-        .get("/api/v1/cups")
-        .add_header(AUTH_HEADER, auth_value(&token))
-        .await;
-    res.assert_status(axum::http::StatusCode::OK);
-    let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 24, "Expected 24 cups");
-}
-
-#[tokio::test]
-async fn test_list_tracks_returns_96_items() {
-    let (server, _db) = setup_test_app().await;
-    let (token, _) = register_and_get_token(&server, "testuser").await;
-
-    let res = server
-        .get("/api/v1/tracks")
-        .add_header(AUTH_HEADER, auth_value(&token))
-        .await;
-    res.assert_status(axum::http::StatusCode::OK);
-    let body: Vec<Value> = res.json();
-    assert_eq!(body.len(), 96, "Expected 96 tracks");
+    assert_eq!(
+        body.len(),
+        expected,
+        "expected {expected} items from {endpoint}"
+    );
 }
 
 #[tokio::test]
@@ -366,6 +313,12 @@ async fn test_list_tracks_filtered_by_cup_returns_4_tracks() {
     assert_eq!(body.len(), 4, "Each cup should have exactly 4 tracks");
 }
 
+// insta demo (rust.md § 7): snapshot the full response body for
+// `/api/v1/cups/1`. Locks down the response shape — adding, removing, or
+// renaming a field surfaces as a reviewable diff in the snapshot file. To
+// update intentionally: re-run with `cargo insta accept` (or `cargo insta
+// review` for interactive triage). Cup #1 (Mushroom Cup) is seeded from
+// `data/cups.json` so the output is deterministic.
 #[tokio::test]
 async fn test_get_cup_with_tracks() {
     let (server, _db) = setup_test_app().await;
@@ -377,9 +330,7 @@ async fn test_get_cup_with_tracks() {
         .await;
     res.assert_status(axum::http::StatusCode::OK);
     let body: Value = res.json();
-    assert!(body["name"].is_string());
-    let tracks = body["tracks"].as_array().unwrap();
-    assert_eq!(tracks.len(), 4, "Cup should include its 4 tracks");
+    insta::assert_json_snapshot!("cup_1_with_tracks", body);
 }
 
 #[tokio::test]

--- a/backend/tests/snapshots/api_integration__cup_1_with_tracks.snap
+++ b/backend/tests/snapshots/api_integration__cup_1_with_tracks.snap
@@ -1,0 +1,39 @@
+---
+source: tests/api_integration.rs
+expression: body
+---
+{
+  "id": 1,
+  "image_path": "images/cups/mushroom-cup.webp",
+  "name": "Mushroom Cup",
+  "tracks": [
+    {
+      "cup_id": 1,
+      "id": 1,
+      "image_path": "images/tracks/mario-kart-stadium.webp",
+      "name": "Mario Kart Stadium",
+      "position": 1
+    },
+    {
+      "cup_id": 1,
+      "id": 2,
+      "image_path": "images/tracks/water-park.webp",
+      "name": "Water Park",
+      "position": 2
+    },
+    {
+      "cup_id": 1,
+      "id": 3,
+      "image_path": "images/tracks/sweet-sweet-canyon.webp",
+      "name": "Sweet Sweet Canyon",
+      "position": 3
+    },
+    {
+      "cup_id": 1,
+      "id": 4,
+      "image_path": "images/tracks/thwomp-ruins.webp",
+      "name": "Thwomp Ruins",
+      "position": 4
+    }
+  ]
+}


### PR DESCRIPTION
## Reviewer notes

- `cargo-insta` CLI is required to verify the insta accept workflow locally. Install: `cargo install cargo-insta`. The dev-dep `insta` crate itself comes through Cargo as usual.
- `proptest` is *not* added here — it was scope-trimmed out of PR-G2 on 2026-05-12 (see [`docs/compliance-plan.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/compliance-plan.md) § PR-G2 "Deferred to PR-D1/D2") and will land alongside its first real consumer. Issue #136's title/scope already reflect this.

## Summary

Adds `rstest` and `insta` to `backend/Cargo.toml` `[dev-dependencies]` and migrates two clusters of tests as demos so future contributors have a visible pattern to copy:

- **rstest:** the six game-data list-endpoint count tests in `tests/api_integration.rs` (characters / bodies / wheels / gliders / cups / tracks) collapse into one `#[rstest]` with six `#[case]` lines. ~80 lines → ~25.
- **insta:** `test_get_cup_with_tracks` switches to `insta::assert_json_snapshot!`. Snapshot lives at `tests/snapshots/api_integration__cup_1_with_tracks.snap`; updates land via `cargo insta accept`.

## Linked work

- Closes #136
- Per [`docs/compliance-plan.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/compliance-plan.md) § PR-G2
- Standards ref: [`docs/coding-standards/rust.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/rust.md) § 7
- Background on proptest deferral: #136 Context (linked to #122 / #133)

## How to verify

```bash
cd backend
cargo install cargo-insta   # one-time, if you don't already have it
cargo test --no-fail-fast
```

- [x] All suites green. Counts unchanged: lib 173, api_integration 27, auth_integration 21, auth_middleware 8, schema_drift 1, session_integration 19. The rstest cases each show up as their own line in the api_integration output:
```
test test_list_endpoint_returns_seeded_count::case_1 ... ok
...
test test_list_endpoint_returns_seeded_count::case_6 ... ok
```
- [x] Verify the insta accept workflow on a deliberate snapshot mismatch:
```bash
# 1. Edit `backend/tests/snapshots/api_integration__cup_1_with_tracks.snap`,
#    e.g. change "Mushroom Cup" to "Mushroom Cup!", save.
# 2. Run the test — it should fail with a diff.
cargo test --test api_integration test_get_cup_with_tracks
# 3. Restore the original snapshot:
cargo insta reject   # discards the .new file
# (or, if you wanted to keep the edit: `cargo insta accept`)
# 4. Test passes again.
cargo test --test api_integration test_get_cup_with_tracks
```
- [x] Clippy clean:
```bash
cargo clippy --all-targets -- -D warnings
```

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated for new logic — n/a (this PR migrates existing tests + adds dep infrastructure; no new business logic).
- [x] Docs updated if applicable — none needed; rust.md § 7 already documents when to reach for each crate.
- [x] Schema changes: none.
- [x] Tested locally end-to-end (full `cargo test` + `cargo insta accept` workflow).