### PR TITLE
132: tower middleware — timeout / concurrency / body / rate limits (PR-F3)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -285,10 +285,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -646,6 +647,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,7 +824,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "typetag",
  "uuid",
 ]
@@ -867,6 +882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1005,13 +1030,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -1024,6 +1063,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1093,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1559,6 +1627,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1869,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1932,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1945,6 +2057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2079,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1972,8 +2105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1998,6 +2141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,9 +2161,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2080,7 +2251,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2188,7 +2359,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.10.0",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2318,7 +2489,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -2418,7 +2589,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2597,7 +2768,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -2631,6 +2802,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -2689,7 +2869,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -2777,7 +2957,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -2820,7 +3000,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -2847,7 +3027,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -2955,11 +3135,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3129,6 +3329,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3171,6 +3372,22 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -3517,6 +3734,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,6 +3780,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -46,9 +46,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-# `limit` for ConcurrencyLimitLayer (request-level limit per tokio.md § 12).
-# Timeout uses `tower-http`'s HTTP-aware version — see main.rs for why.
-tower = { version = "0.5", features = ["limit"] }
+# `limit` for ConcurrencyLimitLayer, `load-shed` for LoadShedLayer (turns
+# ConcurrencyLimit's "queue indefinitely" into "shed with Overloaded" so the
+# stack returns 503 on saturation instead of hanging). Timeout uses
+# `tower-http`'s HTTP-aware version — see main.rs for why.
+tower = { version = "0.5", features = ["limit", "load-shed"] }
 # `limit` pulls in RequestBodyLimitLayer; `timeout` pulls in TimeoutLayer
 # (the HTTP-aware sibling of `tower::timeout` — see main.rs comment).
 tower-http = { version = "0.6", features = ["trace", "fs", "limit", "timeout"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -46,7 +46,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tower-http = { version = "0.6", features = ["trace", "fs"] }
+# `limit` for ConcurrencyLimitLayer (request-level limit per tokio.md § 12).
+# Timeout uses `tower-http`'s HTTP-aware version — see main.rs for why.
+tower = { version = "0.5", features = ["limit"] }
+# `limit` pulls in RequestBodyLimitLayer; `timeout` pulls in TimeoutLayer
+# (the HTTP-aware sibling of `tower::timeout` — see main.rs comment).
+tower-http = { version = "0.6", features = ["trace", "fs", "limit", "timeout"] }
+# Per-IP rate limiting (tokio.md § 12 — `RateLimitLayer` from `tower` produces
+# a non-`Clone` service that axum can't use; `tower-governor` is the standard
+# alternative).
+tower_governor = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -107,3 +107,41 @@ where
         .filter(|v| *v > T::from(0u8))
         .unwrap_or(default)
 }
+
+/// Convert `rate_limit_per_minute` into the millisecond interval between token
+/// replenishments expected by `tower_governor::GovernorConfigBuilder`.
+///
+/// The builder's `per_second` / `per_millisecond` set the *interval between
+/// replenishments*, not the rate — see `tower_governor-0.7.0/src/governor.rs:183`:
+/// "Set the interval after which one element of the quota is replenished".
+/// At sub-second rates that interval needs ms granularity (e.g. 120/min = 500
+/// ms between tokens), so this PR uses `per_millisecond` exclusively rather
+/// than the `per_second` form, which silently rounds to 1 s for any value
+/// `per_minute > 60`.
+///
+/// Clamp to `max(1)` on both the divisor (zero would div-by-zero) and the
+/// result (a sub-millisecond interval is meaningless on real hardware).
+#[must_use]
+pub fn governor_period_ms(per_minute: u32) -> u64 {
+    (60_000_u64 / u64::from(per_minute.max(1))).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::default_60_per_min(60, 1000)]
+    #[case::tight_10_per_min(10, 6000)]
+    #[case::loose_120_per_min(120, 500)]
+    #[case::sustained_30_per_min(30, 2000)]
+    #[case::zero_clamps(0, 60_000)]
+    fn governor_period_ms_maps_per_minute_to_interval(
+        #[case] per_minute: u32,
+        #[case] expected_ms: u64,
+    ) {
+        assert_eq!(governor_period_ms(per_minute), expected_ms);
+    }
+}

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -22,6 +22,23 @@ pub struct Config {
     /// Controls the `Secure` flag on the refresh cookie. Must be `false` for
     /// local `http://localhost` development, `true` in production behind HTTPS.
     pub cookie_secure: bool,
+
+    // Request-level limits applied via Tower middleware. All four are env-tunable
+    // so they can be adjusted from Unraid without a redeploy. See `tokio.md` § 12.
+    /// Hard ceiling on how long any single request can take, end-to-end. After
+    /// this elapses the response becomes 408. Doesn't replace the per-call
+    /// timeouts inside service code — defense in depth.
+    pub request_timeout_seconds: u64,
+    /// Cap on concurrent in-flight requests across the whole router. Requests
+    /// past this limit wait for a permit; this is upstream of the handler.
+    pub request_concurrency_limit: usize,
+    /// Max request body size in bytes. Rejected with 413 before the body is
+    /// fully read. Default matches the 10 MiB upload cap from `design.md`.
+    pub max_request_body_bytes: usize,
+    /// Per-peer-IP rate limit, in requests per minute. Used as both the
+    /// sustained rate and the burst capacity (`per_second = max(1, n / 60)`,
+    /// `burst_size = n`). Excess requests get 429.
+    pub rate_limit_per_minute: u32,
 }
 
 impl Config {
@@ -58,12 +75,35 @@ impl Config {
             .and_then(|v| v.parse().ok())
             .unwrap_or(true);
 
+        let request_timeout_seconds = parse_positive_env("REQUEST_TIMEOUT_SECONDS", 30);
+        let request_concurrency_limit = parse_positive_env("REQUEST_CONCURRENCY_LIMIT", 100);
+        let max_request_body_bytes = parse_positive_env("MAX_REQUEST_BODY_BYTES", 10 * 1024 * 1024);
+        let rate_limit_per_minute = parse_positive_env("RATE_LIMIT_PER_MINUTE", 60);
+
         Ok(Arc::new(Self {
             jwt_secret,
             jwt_access_expiry_minutes,
             jwt_refresh_expiry_days,
             admin_user_id,
             cookie_secure,
+            request_timeout_seconds,
+            request_concurrency_limit,
+            max_request_body_bytes,
+            rate_limit_per_minute,
         }))
     }
+}
+
+/// Parse a positive integer from the named env var, falling back to `default`
+/// on missing, unparseable, or zero values. Used for limits where zero or
+/// negative would silently disable the protection.
+fn parse_positive_env<T>(name: &str, default: T) -> T
+where
+    T: std::str::FromStr + PartialOrd + From<u8>,
+{
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<T>().ok())
+        .filter(|v| *v > T::from(0u8))
+        .unwrap_or(default)
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,7 +4,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use axum::{
-    BoxError, Json, Router,
+    Json, Router,
     error_handling::HandleErrorLayer,
     http::StatusCode,
     routing::{get, post, put},
@@ -12,7 +12,9 @@ use axum::{
 use beerio_kart::{
     ARGON2_MAX_CONCURRENT, AppState,
     config::{self, Config},
-    db, routes, services,
+    db,
+    middleware::limits::handle_load_shed_error,
+    routes, services,
 };
 use migration::{Migrator, MigratorTrait};
 use serde::Serialize;
@@ -284,17 +286,4 @@ async fn hello() -> Json<HelloResponse> {
     Json(HelloResponse {
         message: "Hello from Beerio Kart!".to_string(),
     })
-}
-
-/// Translate the only error type expected to reach `HandleErrorLayer` —
-/// `tower::load_shed::error::Overloaded` from `LoadShedLayer` — into a 503.
-/// Anything else is a programming bug (no other layer above this one errors),
-/// so map it to 500 rather than panic.
-async fn handle_load_shed_error(err: BoxError) -> (StatusCode, &'static str) {
-    if err.is::<tower::load_shed::error::Overloaded>() {
-        (StatusCode::SERVICE_UNAVAILABLE, "Service overloaded")
-    } else {
-        tracing::error!(error = %err, "unexpected error reached load-shed handler");
-        (StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
-    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 mod seed;
 
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use axum::{
@@ -11,8 +11,18 @@ use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, db, routes, s
 use migration::{Migrator, MigratorTrait};
 use serde::Serialize;
 use tokio::sync::Semaphore;
+use tower::limit::ConcurrencyLimitLayer;
+use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
+// `tower::timeout::TimeoutLayer` (cited in tokio.md § 12) produces a service
+// whose error type is `BoxError`, which `axum::Router::layer` refuses because
+// it needs `Into<Infallible>`. `tower_http::timeout::TimeoutLayer` is the
+// HTTP-aware sibling: on elapsed it returns a real `408 Request Timeout`
+// response, which is the right user-facing behavior anyway. Functionally
+// satisfies the same "cap per-request wall time" rule.
 use tower_http::{
+    limit::RequestBodyLimitLayer,
     services::{ServeDir, ServeFile},
+    timeout::TimeoutLayer,
     trace::TraceLayer,
 };
 use tracing_subscriber::EnvFilter;
@@ -60,6 +70,13 @@ async fn main() -> anyhow::Result<()> {
     seed::run(&db).await.context("Seeding database")?;
     tracing::info!("Seeding complete");
 
+    // Snapshot the limit knobs before `config` is moved into `state`. These
+    // power the Tower middleware stack below.
+    let request_timeout = Duration::from_secs(config.request_timeout_seconds);
+    let concurrency_limit = config.request_concurrency_limit;
+    let max_body_bytes = config.max_request_body_bytes;
+    let rate_limit_per_minute = config.rate_limit_per_minute;
+
     let state = AppState {
         db,
         config,
@@ -69,6 +86,32 @@ async fn main() -> anyhow::Result<()> {
     // Clone the DB connection for the background cleanup task before `state`
     // is moved into the router.
     let cleanup_db = state.db.clone();
+
+    // Per-peer-IP rate limit. The default `PeerIpKeyExtractor` reads the
+    // remote address from the `ConnectInfo<SocketAddr>` extension, so the
+    // server below must be served via `into_make_service_with_connect_info`.
+    // If we ever sit behind a *trusted* reverse proxy, swap to
+    // `SmartIpKeyExtractor` so the limit keys on the real client IP via
+    // `X-Forwarded-For` / `X-Real-IP` instead of the proxy's address.
+    let per_second = std::cmp::max(1, u64::from(rate_limit_per_minute) / 60);
+    let governor_conf = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(per_second)
+            .burst_size(rate_limit_per_minute)
+            .finish()
+            .context("invalid rate-limit config")?,
+    );
+    // The governor caches one entry per observed IP. Without periodic
+    // pruning, that map grows unbounded across the process lifetime; the
+    // standard `retain_recent()` cleanup loop is from `tower-governor`'s
+    // README. The background thread lives for the process lifetime.
+    let governor_limiter = governor_conf.limiter().clone();
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(Duration::from_secs(60));
+            governor_limiter.retain_recent();
+        }
+    });
 
     // STATIC_DIR defaults to ../frontend/dist for local dev (running from backend/).
     // In Docker, set to /app/static where the built frontend is copied.
@@ -150,6 +193,22 @@ async fn main() -> anyhow::Result<()> {
             "/api/v1/runs/{id}",
             get(routes::runs::get_run).delete(routes::runs::delete_run),
         )
+        // Request-shape limits (tokio.md § 12). Order is request-flow:
+        // trace wraps everything (so rejections are still logged), governor
+        // is next so abusive IPs lose nothing else, body-size and
+        // concurrency reject before any handler work, timeout is innermost
+        // so it budgets the actual handler — not the wait for a permit.
+        // `.layer()` adds layers as outer wrappers, so the last call is the
+        // outermost: in code order, innermost first.
+        .layer(TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            request_timeout,
+        ))
+        .layer(ConcurrencyLimitLayer::new(concurrency_limit))
+        .layer(RequestBodyLimitLayer::new(max_body_bytes))
+        .layer(GovernorLayer {
+            config: governor_conf,
+        })
         .layer(TraceLayer::new_for_http())
         .with_state(state)
         // Serve frontend static files. If no API route or static file matches,
@@ -176,9 +235,15 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Binding TCP listener on 0.0.0.0:3000")?;
     tracing::info!("Listening on http://localhost:3000");
-    axum::serve(listener, app)
-        .await
-        .context("HTTP server returned an error")?;
+    // `into_make_service_with_connect_info::<SocketAddr>` populates the
+    // `ConnectInfo<SocketAddr>` request extension that `tower-governor`'s
+    // `PeerIpKeyExtractor` reads to bucket rate-limit counters per IP.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .context("HTTP server returned an error")?;
 
     Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,14 +4,20 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use axum::{
-    Json, Router,
+    BoxError, Json, Router,
+    error_handling::HandleErrorLayer,
+    http::StatusCode,
     routing::{get, post, put},
 };
-use beerio_kart::{ARGON2_MAX_CONCURRENT, AppState, config::Config, db, routes, services};
+use beerio_kart::{
+    ARGON2_MAX_CONCURRENT, AppState,
+    config::{self, Config},
+    db, routes, services,
+};
 use migration::{Migrator, MigratorTrait};
 use serde::Serialize;
 use tokio::sync::Semaphore;
-use tower::limit::ConcurrencyLimitLayer;
+use tower::{ServiceBuilder, limit::ConcurrencyLimitLayer, load_shed::LoadShedLayer};
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 // `tower::timeout::TimeoutLayer` (cited in tokio.md § 12) produces a service
 // whose error type is `BoxError`, which `axum::Router::layer` refuses because
@@ -93,22 +99,28 @@ async fn main() -> anyhow::Result<()> {
     // If we ever sit behind a *trusted* reverse proxy, swap to
     // `SmartIpKeyExtractor` so the limit keys on the real client IP via
     // `X-Forwarded-For` / `X-Real-IP` instead of the proxy's address.
-    let per_second = std::cmp::max(1, u64::from(rate_limit_per_minute) / 60);
+    //
+    // Period (not rate) goes into `per_millisecond` — see
+    // `config::governor_period_ms` for the math + unit tests.
     let governor_conf = Arc::new(
         GovernorConfigBuilder::default()
-            .per_second(per_second)
+            .per_millisecond(config::governor_period_ms(rate_limit_per_minute))
             .burst_size(rate_limit_per_minute)
             .finish()
-            .context("invalid rate-limit config")?,
+            .context("Invalid rate-limit config")?,
     );
     // The governor caches one entry per observed IP. Without periodic
     // pruning, that map grows unbounded across the process lifetime; the
     // standard `retain_recent()` cleanup loop is from `tower-governor`'s
-    // README. The background thread lives for the process lifetime.
+    // README. Uses `tokio::time::interval` with `MissedTickBehavior::Skip`
+    // (tokio.md § 8) — same pattern as the stale-session loop below, and
+    // a real OS thread is overkill for a once-a-minute janitor.
     let governor_limiter = governor_conf.limiter().clone();
-    std::thread::spawn(move || {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(60));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            std::thread::sleep(Duration::from_secs(60));
+            tick.tick().await;
             governor_limiter.retain_recent();
         }
     });
@@ -195,16 +207,36 @@ async fn main() -> anyhow::Result<()> {
         )
         // Request-shape limits (tokio.md § 12). Order is request-flow:
         // trace wraps everything (so rejections are still logged), governor
-        // is next so abusive IPs lose nothing else, body-size and
-        // concurrency reject before any handler work, timeout is innermost
-        // so it budgets the actual handler — not the wait for a permit.
-        // `.layer()` adds layers as outer wrappers, so the last call is the
-        // outermost: in code order, innermost first.
+        // sheds abusive IPs, body-size rejects huge POSTs, then the
+        // concurrency cap + load-shed pair turn "would queue" into a 503,
+        // and timeout is innermost so it budgets the handler itself.
+        // `.layer()` adds layers as outer wrappers, so the last call is
+        // the outermost: in code order, innermost first.
+        //
+        // Saturation trade-off: `ConcurrencyLimitLayer` alone *queues* on
+        // saturation — the 101st in-flight request hangs until the client
+        // disconnects. `LoadShedLayer` makes the inner service return
+        // `Overloaded` when no permit is available; `HandleErrorLayer`
+        // maps that to 503. Net: under load, request #101 sees an
+        // immediate 503 instead of an indefinite wait. Matches the Issue's
+        // "503/429" verification contract.
         .layer(TimeoutLayer::with_status_code(
-            axum::http::StatusCode::REQUEST_TIMEOUT,
+            StatusCode::REQUEST_TIMEOUT,
             request_timeout,
         ))
-        .layer(ConcurrencyLimitLayer::new(concurrency_limit))
+        // ConcurrencyLimit alone *queues* on saturation. Wrap it with
+        // LoadShed (returns `Overloaded` when no permit is available) and
+        // HandleError (maps `Overloaded` to 503). ServiceBuilder composes
+        // the three into one stack whose top-level error type is `Infallible`
+        // — axum's `Router::layer` requires that, which is why this group
+        // is bundled into a ServiceBuilder instead of three separate
+        // `.layer()` calls.
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_load_shed_error))
+                .layer(LoadShedLayer::new())
+                .layer(ConcurrencyLimitLayer::new(concurrency_limit)),
+        )
         .layer(RequestBodyLimitLayer::new(max_body_bytes))
         .layer(GovernorLayer {
             config: governor_conf,
@@ -252,4 +284,17 @@ async fn hello() -> Json<HelloResponse> {
     Json(HelloResponse {
         message: "Hello from Beerio Kart!".to_string(),
     })
+}
+
+/// Translate the only error type expected to reach `HandleErrorLayer` —
+/// `tower::load_shed::error::Overloaded` from `LoadShedLayer` — into a 503.
+/// Anything else is a programming bug (no other layer above this one errors),
+/// so map it to 500 rather than panic.
+async fn handle_load_shed_error(err: BoxError) -> (StatusCode, &'static str) {
+    if err.is::<tower::load_shed::error::Overloaded>() {
+        (StatusCode::SERVICE_UNAVAILABLE, "Service overloaded")
+    } else {
+        tracing::error!(error = %err, "unexpected error reached load-shed handler");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
+    }
 }

--- a/backend/src/middleware/limits.rs
+++ b/backend/src/middleware/limits.rs
@@ -1,0 +1,108 @@
+//! Error mapping for request-shape middleware (tokio.md § 12).
+//!
+//! Lives here rather than in `main.rs` so it's reachable from the lib's
+//! test binary. The function is paired with `tower::load_shed::LoadShedLayer`
+//! and `axum::error_handling::HandleErrorLayer` in `main.rs`'s router stack.
+
+use axum::{
+    BoxError, Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+
+/// Maps `LoadShedLayer`'s `Overloaded` error to a 503 JSON response.
+///
+/// Paired with `tower::load_shed::LoadShedLayer` around
+/// `ConcurrencyLimitLayer` in `main.rs`. Anything other than `Overloaded`
+/// reaching this handler is a programming bug (no other layer above
+/// `HandleErrorLayer` errors fallibly today), so the fallback is 500.
+///
+/// The response body shape matches the project-wide JSON-error contract
+/// (`{ "error": "<message>" }`) documented in `docs/design.md` §
+/// Observability and implemented for the normal `Error::IntoResponse`
+/// path in `error.rs`.
+//
+// `async` looks unused (no `.await`), but `HandleErrorLayer::new` requires
+// a fn returning `Future`. Drop the `async` and the layer no longer
+// compiles. Allow the lint locally rather than rewriting to a manual
+// `impl Future` return.
+#[allow(clippy::unused_async)]
+pub async fn handle_load_shed_error(err: BoxError) -> Response {
+    if err.is::<tower::load_shed::error::Overloaded>() {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "Service overloaded" })),
+        )
+            .into_response()
+    } else {
+        tracing::error!(error = %err, "Unexpected error reached load-shed handler");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Internal server error" })),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::to_bytes, http::header::CONTENT_TYPE};
+    use tower::load_shed::error::Overloaded;
+
+    use super::*;
+
+    /// Pull the response body into a `serde_json::Value` so tests can assert
+    /// on the JSON contract directly rather than substring-matching a string.
+    /// `to_bytes` with `usize::MAX` is fine for tests — bodies here are
+    /// small and bounded.
+    async fn body_json(response: Response) -> (StatusCode, Option<String>, serde_json::Value) {
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .map(str::to_owned);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("body parses as JSON");
+        (status, content_type, json)
+    }
+
+    #[tokio::test]
+    async fn overloaded_becomes_503_json_error() {
+        let response = handle_load_shed_error(BoxError::from(Overloaded::new())).await;
+        let (status, content_type, body) = body_json(response).await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(content_type.as_deref(), Some("application/json"));
+        // Catches the regression that motivated this test: a plain-text
+        // body would fail `from_slice` above. Asserting the shape here is
+        // the contract from `docs/design.md` § Observability.
+        assert_eq!(body, json!({ "error": "Service overloaded" }));
+    }
+
+    #[tokio::test]
+    async fn unexpected_error_becomes_500_json_error() {
+        // Any non-`Overloaded` error reaching this handler is a programming
+        // bug — no other fallible layer sits above HandleErrorLayer today.
+        // Map to 500 with the same message string the rest of the codebase
+        // uses (`error.rs:113`) so client-side error grouping stays stable.
+        #[derive(Debug)]
+        struct Bogus;
+        impl std::fmt::Display for Bogus {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("bogus")
+            }
+        }
+        impl std::error::Error for Bogus {}
+
+        let response = handle_load_shed_error(BoxError::from(Bogus)).await;
+        let (status, content_type, body) = body_json(response).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(content_type.as_deref(), Some("application/json"));
+        assert_eq!(body, json!({ "error": "Internal server error" }));
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod limits;

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -233,6 +233,10 @@ mod tests {
             jwt_refresh_expiry_days: 7,
             admin_user_id: None,
             cookie_secure: false,
+            request_timeout_seconds: 30,
+            request_concurrency_limit: 100,
+            max_request_body_bytes: 10 * 1024 * 1024,
+            rate_limit_per_minute: 60,
         })
     }
 
@@ -397,6 +401,10 @@ mod tests {
             jwt_refresh_expiry_days: 7,
             admin_user_id: None,
             cookie_secure: false,
+            request_timeout_seconds: 30,
+            request_concurrency_limit: 100,
+            max_request_body_bytes: 10 * 1024 * 1024,
+            rate_limit_per_minute: 60,
         });
 
         assert!(validate_access_token(&token, &wrong_config).is_err());
@@ -416,6 +424,10 @@ mod tests {
             jwt_refresh_expiry_days: 7,
             admin_user_id: None,
             cookie_secure: false,
+            request_timeout_seconds: 30,
+            request_concurrency_limit: 100,
+            max_request_body_bytes: 10 * 1024 * 1024,
+            rate_limit_per_minute: 60,
         });
         let token = create_access_token("user-1", "alice", &config).unwrap();
         let claims = validate_access_token(&token, &config).unwrap();
@@ -433,6 +445,10 @@ mod tests {
             jwt_refresh_expiry_days: 7,
             admin_user_id: None,
             cookie_secure: true,
+            request_timeout_seconds: 30,
+            request_concurrency_limit: 100,
+            max_request_body_bytes: 10 * 1024 * 1024,
+            rate_limit_per_minute: 60,
         });
         let cookie = refresh_cookie("tok123", 3600, &config);
         assert!(cookie.contains("HttpOnly"));
@@ -450,6 +466,10 @@ mod tests {
             jwt_refresh_expiry_days: 7,
             admin_user_id: None,
             cookie_secure: false,
+            request_timeout_seconds: 30,
+            request_concurrency_limit: 100,
+            max_request_body_bytes: 10 * 1024 * 1024,
+            rate_limit_per_minute: 60,
         });
         let cookie = refresh_cookie("tok123", 3600, &config);
         assert!(!cookie.contains("Secure"));

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -28,6 +28,10 @@ fn test_config() -> Arc<Config> {
         jwt_refresh_expiry_days: 7,
         admin_user_id: None,
         cookie_secure: false,
+        request_timeout_seconds: 30,
+        request_concurrency_limit: 100,
+        max_request_body_bytes: 10 * 1024 * 1024,
+        rate_limit_per_minute: 60,
     })
 }
 

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -25,6 +25,10 @@ fn test_config() -> Arc<Config> {
         jwt_refresh_expiry_days: 7,
         admin_user_id: None,
         cookie_secure: false,
+        request_timeout_seconds: 30,
+        request_concurrency_limit: 100,
+        max_request_body_bytes: 10 * 1024 * 1024,
+        rate_limit_per_minute: 60,
     })
 }
 

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -35,6 +35,10 @@ fn make_config(admin_user_id: Option<&str>) -> Arc<Config> {
         jwt_refresh_expiry_days: 7,
         admin_user_id: admin_user_id.map(ToString::to_string),
         cookie_secure: false,
+        request_timeout_seconds: 30,
+        request_concurrency_limit: 100,
+        max_request_body_bytes: 10 * 1024 * 1024,
+        rate_limit_per_minute: 60,
     })
 }
 

--- a/backend/tests/middleware_limits.rs
+++ b/backend/tests/middleware_limits.rs
@@ -1,0 +1,44 @@
+//! Integration tests for the request-shape Tower middleware (tokio.md § 12).
+//!
+//! These exercise the *layers themselves* against minimal routers — not the
+//! production router from `main.rs` — which keeps the tests deterministic and
+//! fast. The production wiring (limits sourced from `Config`, ordering, the
+//! `ConnectInfo` make-service) is verified by build + manual `curl` per the
+//! Issue's Verification section; what's left to assert in code is the
+//! layer-by-layer behavior at the boundary value.
+
+// Tests legitimately want to panic — per rust.md § 8.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use axum::{Router, body::Bytes, http::StatusCode, routing::post};
+use axum_test::TestServer;
+use tower_http::limit::RequestBodyLimitLayer;
+
+/// Consume the body so the `RequestBodyLimitLayer` triggers on the
+/// streaming-read path (axum-test sends bodies with chunked transfer encoding
+/// by default, so there's no `Content-Length` for the layer to short-circuit
+/// on — the limit fires when the handler tries to read past the cap).
+async fn read_body(body: Bytes) -> StatusCode {
+    let _ = body;
+    StatusCode::OK
+}
+
+#[tokio::test]
+async fn request_body_limit_rejects_oversized_with_413() {
+    // 16 bytes is small enough to overflow with a trivial payload, large
+    // enough that the under-limit case is non-empty.
+    const LIMIT: usize = 16;
+
+    let app = Router::new()
+        .route("/echo", post(read_body))
+        .layer(RequestBodyLimitLayer::new(LIMIT));
+    let server = TestServer::new(app);
+
+    let under = Bytes::from(vec![b'x'; LIMIT]);
+    let response = server.post("/echo").bytes(under).await;
+    response.assert_status(StatusCode::OK);
+
+    let over = Bytes::from(vec![b'x'; LIMIT + 1]);
+    let response = server.post("/echo").bytes(over).await;
+    response.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+}

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -34,6 +34,10 @@ fn test_config() -> Arc<Config> {
         jwt_refresh_expiry_days: 7,
         admin_user_id: None,
         cookie_secure: false,
+        request_timeout_seconds: 30,
+        request_concurrency_limit: 100,
+        max_request_body_bytes: 10 * 1024 * 1024,
+        rate_limit_per_minute: 60,
     })
 }
 

--- a/docs/coding-standards/tokio.md
+++ b/docs/coding-standards/tokio.md
@@ -388,7 +388,8 @@ The 5-minute "close stale sessions" task is the canonical example for this proje
     ```
   - **Pitfall:** Writing `let _ = limiter.acquire().await?;` with a bare `_` instead of `_permit` drops the permit *immediately* — the limiter becomes a no-op. Always name the binding.
 
-- **Rule:** Use Tower middleware for request-level limits: `tower::timeout::TimeoutLayer`, `tower::limit::ConcurrencyLimitLayer`, `tower_http::limit::RequestBodyLimitLayer`.
+- **Rule:** Use Tower middleware for request-level limits: `tower_http::timeout::TimeoutLayer` (via `TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, ...)`), `tower::limit::ConcurrencyLimitLayer`, `tower_http::limit::RequestBodyLimitLayer`.
+  - **Why timeout comes from `tower-http`, not `tower`:** `tower::timeout::TimeoutLayer` produces a service whose error type is `tower::BoxError`. Axum's `Router::layer` requires `Error: Into<Infallible>` (Axum converts errors into responses *itself*; the layer can't fail at the service-error level). `tower-http`'s HTTP-aware version maps elapsed timeouts to a real `408 Request Timeout` response, which is the right user-facing behavior and satisfies the bound.
 
 - **Rule:** For rate limiting, use `tower-governor`, not `tower::limit::RateLimitLayer`.
   - **Why:** `RateLimitLayer` produces a service that isn't `Clone`, which Axum requires. Wrapping it in `BufferLayer` defeats the purpose.
@@ -480,3 +481,4 @@ Anyone modifying async code in this repo should have read at least the first thr
 - 2026-05-02 — Initial draft as part of `docs/rust-coding-standards.md`.
 - 2026-05-02 — Split into `docs/coding-standards/tokio.md`. Added `'static` discussion + scoped-task-trilemma reference in § 9. Held § 12 timeout rule strict (per project's "no corner cutting" stance). Took position on async traits in § 11 (native + trait-variant for spawn).
 - 2026-05-04 — § 12 semaphore example: switched from `let permit = …; drop(permit);` to the idiomatic `let _permit = …;` RAII binding, and added a pitfall callout for the bare-`_` foot-gun. Surfaced during PR #27 review (back-and-forth on which form to use); the explicit-drop form was the anti-RAII pattern. Standard now matches what idiomatic Rust would write.
+- 2026-05-12 — § 12 request-level limits rule: corrected the timeout layer from `tower::timeout::TimeoutLayer` to `tower_http::timeout::TimeoutLayer` (constructed via `TimeoutLayer::with_status_code`). The tower version's `BoxError` doesn't compose with `axum::Router::layer`, which requires `Error: Into<Infallible>`. Added a "Why" paragraph explaining the bound + the cleaner 408-response behavior of the tower-http sibling. Surfaced while implementing PR-F3 ([#132](https://github.com/brendanbyrne/beerio-kart/issues/132)) — the original rule didn't compile.


### PR DESCRIPTION
## Reviewer notes

- **Departure from [tokio.md § 12](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/tokio.md#12-backpressure-and-resource-limits)**: used `tower_http::timeout::TimeoutLayer::with_status_code` instead of the rule's literal `tower::timeout::TimeoutLayer`. The tower version's error type is `BoxError`, which `axum::Router::layer` refuses because Axum requires `Error: Into<Infallible>`. Updated the rule itself in the same PR so the doc no longer points at a layer that won't compile here; added a Why callout naming the bound + 408-response benefit.
- **Rate-limit key extractor**: defaults to `PeerIpKeyExtractor` (keys on TCP peer). If we ever sit behind a reverse proxy (Unraid setups often do), this collapses to a global limit. Flagged in a code comment recommending `SmartIpKeyExtractor` for that deploy mode. Deferred — needs an explicit "trusted proxy" decision.
- **`Config` sweep**: 9 sites (4 integration tests + 5 in services/auth.rs) gained the four new fields. Considered factoring a `Config::for_tests()` helper but kept scope tight; the duplication is real but pre-existing and worth a separate cleanup pass.
- **Integration test coverage is narrow by design**: one test for `RequestBodyLimitLayer` at the 413 boundary. The other three layers aren't tested in code because (a) `GovernorLayer` needs `ConnectInfo<SocketAddr>` which axum-test doesn't populate without extra plumbing, (b) `TimeoutLayer` and `ConcurrencyLimitLayer` need timing shenanigans for deterministic asserts. The Issue's Verification section is manual `curl`, which catches those.

## Summary

Wires four Tower layers into the Axum router with config knobs sourced from env vars (tunable from Unraid without redeploy):

- `tower_http::timeout::TimeoutLayer` — `REQUEST_TIMEOUT_SECONDS` (default 30)
- `tower::limit::ConcurrencyLimitLayer` — `REQUEST_CONCURRENCY_LIMIT` (default 100)
- `tower_http::limit::RequestBodyLimitLayer` — `MAX_REQUEST_BODY_BYTES` (default 10 MiB)
- `tower_governor::GovernorLayer` — `RATE_LIMIT_PER_MINUTE` (default 60), per-peer-IP, with a background `retain_recent()` cleanup loop

Server binding switches to `into_make_service_with_connect_info::<SocketAddr>` so `ConnectInfo<SocketAddr>` is populated for the governor key extractor.

## Linked work

- Closes #132
- Per [`docs/compliance-plan.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/compliance-plan.md) § PR-F3
- Standards refs: [`docs/coding-standards/tokio.md`](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/tokio.md) § 12 (rule corrected in this PR)

## How to verify

```bash
cd backend
cargo test --no-fail-fast
cargo clippy --all-targets -- -D warnings
```

- [x] All test suites green. Test counts after this PR: lib 173, api_integration 27, auth_integration 21, auth_middleware 8, schema_drift 1, session_integration 19, **middleware_limits 1 (new)**.
- [ ] The new middleware_limits test exercises the body-limit boundary:
```bash
cd backend
cargo test --test middleware_limits
```

Manual checks per the Issue's Verification section — run with the server up (`cargo run` in `backend/` or via Docker):

- [ ] Body limit returns 413:
```bash
# Default 10 MiB cap. Generate an 11 MiB payload and POST it to any endpoint
# that accepts a body (register is the simplest available today).
head -c 11534336 /dev/urandom > /tmp/big.bin
curl -i -X POST http://localhost:3000/api/v1/auth/register \
  -H 'Content-Type: application/json' \
  --data-binary @/tmp/big.bin
# expected: HTTP/1.1 413 Payload Too Large
```
- [ ] Rate limiter throttles a flood from one IP:
```bash
# 70 quick requests against a public endpoint; with default 60/min, the
# last several should return 429.
for i in $(seq 1 70); do
  curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/api/v1/hello
done | sort | uniq -c
# expected: a mix of 200s and 429s with roughly 60 of the former.
```
- [ ] Tune knobs without rebuild:
```bash
# Set a tight limit, restart, confirm tighter behavior.
RATE_LIMIT_PER_MINUTE=10 cargo run
```

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated — `tests/middleware_limits.rs` (body-limit boundary).
- [x] Docs updated — `tokio.md` § 12 timeout-layer rule corrected; Document history entry added.
- [x] Schema changes: none.
- [x] Tested locally end-to-end (`cargo test` + `cargo build`; manual curl deferred to verification step above).