### PR TITLE
137: ActiveModelBehavior::before_save for managed timestamps

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -269,6 +269,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-trait",
  "axum",
  "axum-test",
  "chrono",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,11 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 argon2 = { version = "0.5", features = ["std"] }
+# `ActiveModelBehavior::before_save` is an async trait method; SeaORM 1.x
+# defines the trait via `#[async_trait]`, so overriding it requires the same
+# macro on our impl. SeaORM doesn't re-export `async_trait`, so we depend on
+# it directly. See `entities/*_behavior.rs`.
+async-trait = "0.1"
 axum = { version = "0.8", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 jsonwebtoken = "9"

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -54,8 +54,8 @@ pub async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
 mod tests {
     use migration::{Migrator, MigratorTrait};
     use sea_orm::{
-        ActiveModelTrait, EntityTrait, FromQueryResult, PaginatorTrait, Set, Statement,
-        TransactionTrait,
+        ActiveModelTrait, ActiveValue::NotSet, EntityTrait, FromQueryResult, PaginatorTrait, Set,
+        Statement, TransactionTrait,
     };
     use uuid::Uuid;
 
@@ -82,7 +82,6 @@ mod tests {
         // only fail if the query happened to land on the connection that ran
         // the startup PRAGMA — flaky and pool-size-dependent.
         let db = shared_memory_db().await;
-        let now = chrono::Utc::now().naive_utc();
         let result = users::ActiveModel {
             id: Set(Uuid::new_v4().to_string()),
             username: Set("alice".to_string()),
@@ -94,8 +93,8 @@ mod tests {
             preferred_glider_id: Set(None),
             preferred_drink_type_id: Set(None),
             refresh_token_version: Set(0),
-            created_at: Set(now),
-            updated_at: Set(now),
+            created_at: NotSet,
+            updated_at: NotSet,
         }
         .insert(&db)
         .await;

--- a/backend/src/entities/drink_types.rs
+++ b/backend/src/entities/drink_types.rs
@@ -39,4 +39,5 @@ impl Related<super::users::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `drink_types_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/drink_types_behavior.rs
+++ b/backend/src/entities/drink_types_behavior.rs
@@ -1,0 +1,21 @@
+//! `ActiveModelBehavior` for [`super::drink_types`]. Stamps `created_at` on
+//! insert. See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::drink_types::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/mod.rs
+++ b/backend/src/entities/mod.rs
@@ -20,3 +20,15 @@ pub mod sessions;
 pub mod tracks;
 pub mod users;
 pub mod wheels;
+
+// Sibling `ActiveModelBehavior` impls for entities with `created_at` /
+// `updated_at` timestamps. Centralizes the timestamp-stamping logic so
+// service code never sets these by hand. See `docs/coding-standards/seaorm.md`
+// § 1 (and PR-E1 / Issue #137 for the migration that introduced this split).
+mod drink_types_behavior;
+mod run_flags_behavior;
+mod runs_behavior;
+mod session_race_participations_behavior;
+mod session_races_behavior;
+mod sessions_behavior;
+mod users_behavior;

--- a/backend/src/entities/run_flags.rs
+++ b/backend/src/entities/run_flags.rs
@@ -35,4 +35,5 @@ impl Related<super::runs::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `run_flags_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/run_flags_behavior.rs
+++ b/backend/src/entities/run_flags_behavior.rs
@@ -1,0 +1,22 @@
+//! `ActiveModelBehavior` for [`super::run_flags`]. Stamps `created_at` on
+//! insert. `resolved_at` is set explicitly when a flag is resolved, not here.
+//! See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::run_flags::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/runs.rs
+++ b/backend/src/entities/runs.rs
@@ -152,4 +152,5 @@ impl Related<super::wheels::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `runs_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/runs_behavior.rs
+++ b/backend/src/entities/runs_behavior.rs
@@ -1,0 +1,21 @@
+//! `ActiveModelBehavior` for [`super::runs`]. Stamps `created_at` on insert.
+//! See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::runs::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/session_race_participations.rs
+++ b/backend/src/entities/session_race_participations.rs
@@ -49,4 +49,5 @@ impl Related<super::users::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `session_race_participations_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/session_race_participations_behavior.rs
+++ b/backend/src/entities/session_race_participations_behavior.rs
@@ -1,0 +1,22 @@
+//! `ActiveModelBehavior` for [`super::session_race_participations`]. Stamps
+//! `created_at` on insert. `skipped_at` is set explicitly by the skip path,
+//! not here. See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::session_race_participations::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/session_races.rs
+++ b/backend/src/entities/session_races.rs
@@ -91,4 +91,5 @@ impl Related<super::users::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `session_races_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/session_races_behavior.rs
+++ b/backend/src/entities/session_races_behavior.rs
@@ -1,0 +1,21 @@
+//! `ActiveModelBehavior` for [`super::session_races`]. Stamps `created_at`
+//! on insert. See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::session_races::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/sessions.rs
+++ b/backend/src/entities/sessions.rs
@@ -51,4 +51,5 @@ impl Related<super::users::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `sessions_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/sessions_behavior.rs
+++ b/backend/src/entities/sessions_behavior.rs
@@ -1,0 +1,27 @@
+//! `ActiveModelBehavior` for [`super::sessions`].
+//!
+//! Stamps `created_at` on insert. `last_activity_at` is *not* touched here —
+//! it's an application-managed activity timestamp, advanced explicitly by
+//! `services::helpers::touch_session` when something happens in the session
+//! (a join, a race transition, etc.). Treating it as a generic `updated_at`
+//! would advance it on every write, which would defeat the stale-session
+//! cleanup loop. See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::sessions::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/users.rs
+++ b/backend/src/entities/users.rs
@@ -164,4 +164,5 @@ impl Related<super::session_races::Entity> for Entity {
     }
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `users_behavior.rs` (it stamps `created_at` / `updated_at`).

--- a/backend/src/entities/users_behavior.rs
+++ b/backend/src/entities/users_behavior.rs
@@ -1,0 +1,103 @@
+//! `ActiveModelBehavior` for [`super::users`].
+//!
+//! Centralizes `created_at` / `updated_at` maintenance so service code never
+//! sets these timestamps by hand. `before_save` runs on insert and update;
+//! `created_at` is only stamped on insert, `updated_at` on both. See
+//! `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::users::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let now = Utc::now().naive_utc();
+        if insert {
+            self.created_at = Set(now);
+        }
+        self.updated_at = Set(now);
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Verifies `before_save` for `users`. The other `*_behavior.rs` files
+    //! share the same shape (stamp `created_at` on insert), differing only in
+    //! which column they touch — exercising the pattern once here is enough.
+
+    use std::time::Duration;
+
+    use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
+
+    use crate::{
+        entities::users,
+        test_helpers::{create_user, setup_db},
+    };
+
+    #[tokio::test]
+    async fn before_save_stamps_created_at_and_updated_at_on_insert() {
+        // `create_user` constructs a `users::ActiveModel` with `created_at`
+        // and `updated_at` left as `NotSet`; `before_save` must populate both.
+        let db = setup_db().await;
+        let user_id = create_user(&db, "alice").await;
+
+        let user = users::Entity::find_by_id(user_id.as_str())
+            .one(&db)
+            .await
+            .expect("query user")
+            .expect("user exists");
+
+        // On a fresh insert the two timestamps were stamped in the same
+        // `before_save` call, so they must match exactly.
+        assert_eq!(user.created_at, user.updated_at);
+        let now = chrono::Utc::now().naive_utc();
+        let drift = (now - user.created_at).num_seconds().abs();
+        assert!(drift < 5, "stamped time should be ~now (drift {drift}s)");
+    }
+
+    #[tokio::test]
+    async fn before_save_advances_updated_at_on_update() {
+        let db = setup_db().await;
+        let user_id = create_user(&db, "bob").await;
+
+        let user_t0 = users::Entity::find_by_id(user_id.as_str())
+            .one(&db)
+            .await
+            .expect("query user")
+            .expect("user exists");
+        let created_t0 = user_t0.created_at;
+        let updated_t0 = user_t0.updated_at;
+
+        // Sleep past `NaiveDateTime`'s microsecond resolution so the second
+        // `before_save` call lands on a strictly later timestamp.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Mutate any non-timestamp column. `before_save` runs on update too.
+        let mut active: users::ActiveModel = user_t0.into_active_model();
+        active.refresh_token_version = Set(1);
+        active.update(&db).await.expect("update user");
+
+        let user_t1 = users::Entity::find_by_id(user_id.as_str())
+            .one(&db)
+            .await
+            .expect("query user")
+            .expect("user exists");
+
+        assert_eq!(
+            user_t1.created_at, created_t0,
+            "created_at must not change on update"
+        );
+        assert!(
+            user_t1.updated_at > updated_t0,
+            "updated_at must advance on update (t0={updated_t0}, t1={})",
+            user_t1.updated_at
+        );
+    }
+}

--- a/backend/src/entities/users_behavior.rs
+++ b/backend/src/entities/users_behavior.rs
@@ -42,7 +42,7 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn before_save_stamps_created_at_and_updated_at_on_insert() {
+    async fn test_before_save_stamps_created_at_and_updated_at_on_insert() {
         // `create_user` constructs a `users::ActiveModel` with `created_at`
         // and `updated_at` left as `NotSet`; `before_save` must populate both.
         let db = setup_db().await;
@@ -63,7 +63,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn before_save_advances_updated_at_on_update() {
+    async fn test_before_save_advances_updated_at_on_update() {
         let db = setup_db().await;
         let user_id = create_user(&db, "bob").await;
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -167,7 +167,7 @@ impl From<sea_orm::DbErr> for Error {
 mod tests {
     use std::error::Error as _;
 
-    use sea_orm::{ActiveModelTrait, DbErr, Set};
+    use sea_orm::{ActiveModelTrait, ActiveValue::NotSet, DbErr, Set};
 
     use super::*;
     use crate::{
@@ -206,7 +206,6 @@ mod tests {
         create_user(&db, "alice").await;
 
         // Second insert with the same username triggers UniqueConstraintViolation.
-        let now = chrono::Utc::now().naive_utc();
         let result = users::ActiveModel {
             id: Set(uuid::Uuid::new_v4().to_string()),
             username: Set("alice".to_string()),
@@ -218,8 +217,8 @@ mod tests {
             preferred_glider_id: Set(None),
             preferred_drink_type_id: Set(None),
             refresh_token_version: Set(0),
-            created_at: Set(now),
-            updated_at: Set(now),
+            created_at: NotSet,
+            updated_at: NotSet,
         }
         .insert(&db)
         .await;
@@ -246,7 +245,6 @@ mod tests {
         let db = setup_db().await;
 
         // Insert a user with a preferred_character_id that doesn't exist in characters.
-        let now = chrono::Utc::now().naive_utc();
         let result = users::ActiveModel {
             id: Set(uuid::Uuid::new_v4().to_string()),
             username: Set("bob".to_string()),
@@ -258,8 +256,8 @@ mod tests {
             preferred_glider_id: Set(None),
             preferred_drink_type_id: Set(None),
             refresh_token_version: Set(0),
-            created_at: Set(now),
-            updated_at: Set(now),
+            created_at: NotSet,
+            updated_at: NotSet,
         }
         .insert(&db)
         .await;

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -4,7 +4,10 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    Set,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -119,11 +122,9 @@ pub async fn register(
     // Hash password (offloaded to the blocking pool, capped by argon2_limit)
     let password_hash = auth_service::hash_password(&state.argon2_limit, body.password).await?;
 
-    // Generate user ID and timestamps
     let user_id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().naive_utc();
 
-    // Insert user
+    // Timestamps are populated by `users::ActiveModelBehavior::before_save`.
     let new_user = users::ActiveModel {
         id: Set(user_id.clone()),
         username: Set(username.to_string()),
@@ -135,8 +136,8 @@ pub async fn register(
         preferred_glider_id: Set(None),
         preferred_drink_type_id: Set(None),
         refresh_token_version: Set(0),
-        created_at: Set(now),
-        updated_at: Set(now),
+        created_at: NotSet,
+        updated_at: NotSet,
     };
 
     new_user.insert(&state.db).await?;
@@ -296,11 +297,11 @@ pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl In
             Error::Internal(anyhow::anyhow!("Authenticated user not found in database"))
         })?;
 
-    // Increment version to invalidate all existing refresh tokens
+    // Increment version to invalidate all existing refresh tokens.
+    // `updated_at` is bumped by `users::ActiveModelBehavior::before_save`.
     let new_version = db_user.refresh_token_version + 1;
     let mut active: users::ActiveModel = db_user.into_active_model();
     active.refresh_token_version = Set(new_version);
-    active.updated_at = Set(chrono::Utc::now().naive_utc());
 
     active.update(&state.db).await?;
 
@@ -359,14 +360,14 @@ pub async fn change_password(
     // Hash new password
     let new_hash = auth_service::hash_password(&state.argon2_limit, body.new_password).await?;
 
-    // Update password and bump version (invalidates all other sessions)
+    // Update password and bump version (invalidates all other sessions).
+    // `updated_at` is bumped by `users::ActiveModelBehavior::before_save`.
     let new_version = db_user.refresh_token_version + 1;
     let username = db_user.username.clone();
     let user_id = db_user.id.clone();
     let mut active: users::ActiveModel = db_user.into_active_model();
     active.password_hash = Set(new_hash);
     active.refresh_token_version = Set(new_version);
-    active.updated_at = Set(chrono::Utc::now().naive_utc());
 
     active.update(&state.db).await?;
 

--- a/backend/src/routes/drink_types.rs
+++ b/backend/src/routes/drink_types.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Path, Query, State},
 };
 use chrono::{DateTime, Utc};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveValue::NotSet, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -83,12 +83,12 @@ pub async fn create_drink_type(
         return Ok(Json(existing.into()));
     }
 
-    let now = chrono::Utc::now().naive_utc();
+    // `created_at` is populated by `drink_types::ActiveModelBehavior::before_save`.
     let model = drink_types::ActiveModel {
         id: Set(id),
         name: Set(name),
         alcoholic: Set(req.alcoholic),
-        created_at: Set(now),
+        created_at: NotSet,
         created_by: Set(Some(user.user_id.into_string())),
     };
 

--- a/backend/src/seed.rs
+++ b/backend/src/seed.rs
@@ -5,8 +5,8 @@ use beerio_kart::{
     entities::{bodies, characters, cups, drink_types, gliders, tracks, wheels},
 };
 use sea_orm::{
-    ActiveModelBehavior, ActiveModelTrait, DatabaseConnection, EntityTrait, IntoActiveModel, Set,
-    TransactionTrait,
+    ActiveModelBehavior, ActiveModelTrait, ActiveValue::NotSet, DatabaseConnection, EntityTrait,
+    IntoActiveModel, Set, TransactionTrait,
 };
 use serde::Deserialize;
 
@@ -208,15 +208,15 @@ async fn seed_drink_types(db: &DatabaseConnection) -> anyhow::Result<()> {
     let items: Vec<SeedDrinkType> = serde_json::from_str(json_data)?;
     let num_items = items.len();
 
-    let now = chrono::Utc::now().naive_utc();
     let txn = db.begin().await?;
     for item in items {
         let id = drink_type_uuid(&item.name);
+        // `created_at` is populated by `drink_types::ActiveModelBehavior::before_save`.
         let model = drink_types::ActiveModel {
             id: Set(id),
             name: Set(item.name),
             alcoholic: Set(item.alcoholic),
-            created_at: Set(now),
+            created_at: NotSet,
             created_by: Set(None), // Pre-seeded entries have no creator
         };
         model.insert(&txn).await?;

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -101,6 +101,12 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
         return Ok(());
     }
 
+    // `created_at` is set by hand here (rather than left as `NotSet` for
+    // `ActiveModelBehavior::before_save` to fill in) because SeaORM's bulk
+    // `Entity::insert_many(...).exec()` path bypasses `before_save` — only
+    // single-row `ActiveModel::insert` / `update` / `save` invoke it. We use
+    // `insert_many` deliberately to keep the snapshot to one round-trip; the
+    // trade is this one explicit timestamp.
     let rows = present
         .into_iter()
         .map(|p| session_race_participations::ActiveModel {

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
-    FromQueryResult, ModelTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, Condition, ConnectionTrait,
+    DatabaseConnection, EntityTrait, FromQueryResult, ModelTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -280,7 +281,6 @@ async fn insert_run(
     body: CreateRunRequest,
     session_race: &session_races::Model,
 ) -> Result<RunId, Error> {
-    let now = Utc::now().naive_utc();
     let run_id = RunId::new(Uuid::new_v4().to_string());
 
     let txn = db.begin().await?;
@@ -301,7 +301,7 @@ async fn insert_run(
         drink_type_id: Set(body.drink_type_id),
         disqualified: Set(body.disqualified),
         photo_path: Set(None),
-        created_at: Set(now),
+        created_at: NotSet,
         notes: Set(None),
     }
     .insert(&txn)

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait,
-    FromQueryResult, ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
-    sea_query::Expr,
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, Condition, ConnectionTrait,
+    DatabaseConnection, EntityTrait, FromQueryResult, ModelTrait, PaginatorTrait, QueryFilter,
+    QueryOrder, Set, TransactionTrait, sea_query::Expr,
 };
 use uuid::Uuid;
 
@@ -105,6 +105,10 @@ pub async fn create_session(
 
     check_not_in_any_session(db, user_id).await?;
 
+    // `last_activity_at` and `joined_at` are application-managed (not handled
+    // by `before_save` — see `entities/sessions_behavior.rs` for why), so
+    // capture `now` here and stamp them by hand. `sessions.created_at` is
+    // populated by `ActiveModelBehavior::before_save`.
     let now = Utc::now().naive_utc();
     let session_id = SessionId::new(Uuid::new_v4().to_string());
 
@@ -116,7 +120,7 @@ pub async fn create_session(
         ruleset: Set(parsed.to_string()),
         least_played_drink_category: Set(None),
         status: Set(SessionStatus::Active.to_string()),
-        created_at: Set(now),
+        created_at: NotSet,
         last_activity_at: Set(now),
     }
     .insert(&txn)
@@ -980,19 +984,20 @@ pub async fn next_track(
 
     let chosen = helpers::pick_random_track(db, &used_track_ids, &[]).await?;
 
-    let now = Utc::now().naive_utc();
     let race_id = SessionRaceId::new(Uuid::new_v4().to_string());
     let new_race_number = race_count + 1;
 
     let txn = db.begin().await?;
 
-    session_races::ActiveModel {
+    // Capture the inserted row so we can echo its `before_save`-stamped
+    // `created_at` back in the response.
+    let inserted = session_races::ActiveModel {
         id: Set(race_id.as_str().to_string()),
         session_id: Set(session_id.as_str().to_string()),
         race_number: Set(new_race_number),
         track_id: Set(chosen.id),
         chosen_by: Set(None),
-        created_at: Set(now),
+        created_at: NotSet,
     }
     .insert(&txn)
     .await?;
@@ -1021,7 +1026,7 @@ pub async fn next_track(
         track_name: chosen.name.clone(),
         cup_name: cup,
         image_path: chosen.image_path.clone(),
-        created_at: now.and_utc(),
+        created_at: inserted.created_at.and_utc(),
         submissions: Vec::new(),
     })
 }
@@ -1078,7 +1083,6 @@ pub async fn skip_turn(
 
     let chosen = helpers::pick_random_track(db, &exclude_ids, &[skipped_track_id]).await?;
 
-    let now = Utc::now().naive_utc();
     let race_id = SessionRaceId::new(Uuid::new_v4().to_string());
 
     // Delete old race + insert new one + snapshot present users in a single
@@ -1089,13 +1093,15 @@ pub async fn skip_turn(
 
     current_race.delete(&txn).await?;
 
-    session_races::ActiveModel {
+    // Capture the inserted row so we can echo its `before_save`-stamped
+    // `created_at` back in the response.
+    let inserted = session_races::ActiveModel {
         id: Set(race_id.as_str().to_string()),
         session_id: Set(session_id.as_str().to_string()),
         race_number: Set(keep_race_number),
         track_id: Set(chosen.id),
         chosen_by: Set(None),
-        created_at: Set(now),
+        created_at: NotSet,
     }
     .insert(&txn)
     .await?;
@@ -1123,7 +1129,7 @@ pub async fn skip_turn(
         track_name: chosen.name.clone(),
         cup_name: cup,
         image_path: chosen.image_path.clone(),
-        created_at: now.and_utc(),
+        created_at: inserted.created_at.and_utc(),
         submissions: Vec::new(),
     })
 }
@@ -1892,7 +1898,6 @@ mod tests {
 
         let txn = db.begin().await.unwrap();
         let race_id = Uuid::new_v4().to_string();
-        let now = Utc::now().naive_utc();
 
         session_races::ActiveModel {
             id: Set(race_id.clone()),
@@ -1900,7 +1905,7 @@ mod tests {
             race_number: Set(1),
             track_id: Set(1),
             chosen_by: Set(None),
-            created_at: Set(now),
+            created_at: NotSet,
         }
         .insert(&txn)
         .await
@@ -1910,7 +1915,7 @@ mod tests {
         let bad = session_race_participations::ActiveModel {
             session_race_id: Set(race_id.clone()),
             user_id: Set("ghost".to_string()),
-            created_at: Set(now),
+            created_at: NotSet,
             skipped_at: Set(None),
         }
         .insert(&txn)
@@ -1991,7 +1996,7 @@ mod tests {
             drink_type_id: Set(drink_id),
             disqualified: Set(false),
             photo_path: Set(None),
-            created_at: Set(Utc::now().naive_utc()),
+            created_at: NotSet,
             notes: Set(None),
         }
         .insert(&db)
@@ -2496,7 +2501,7 @@ mod tests {
             drink_type_id: Set(drink_id),
             disqualified: Set(false),
             photo_path: Set(None),
-            created_at: Set(Utc::now().naive_utc()),
+            created_at: NotSet,
             notes: Set(None),
         }
         .insert(&db)

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -113,7 +113,7 @@ pub async fn update_profile(
         active.preferred_drink_type_id = Set(dt_id_option);
     }
 
-    active.updated_at = Set(chrono::Utc::now().naive_utc());
+    // `updated_at` is bumped by `users::ActiveModelBehavior::before_save`.
     let updated = active.update(db).await?;
 
     build_detail_profile(db, updated).await

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -15,7 +15,9 @@
 #![allow(clippy::missing_panics_doc)]
 
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, DatabaseConnection, Set};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::NotSet, ConnectionTrait, Database, DatabaseConnection, Set,
+};
 use uuid::Uuid;
 
 use crate::{
@@ -52,7 +54,6 @@ pub async fn setup_db() -> DatabaseConnection {
 /// hash. Returns the generated user ID.
 pub async fn create_user(db: &DatabaseConnection, username: &str) -> UserId {
     let id = Uuid::new_v4().to_string();
-    let now = Utc::now().naive_utc();
     // Placeholder hash — tests don't verify passwords, but the column is NOT NULL.
     let placeholder_hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
     users::ActiveModel {
@@ -66,8 +67,8 @@ pub async fn create_user(db: &DatabaseConnection, username: &str) -> UserId {
         preferred_glider_id: Set(None),
         preferred_drink_type_id: Set(None),
         refresh_token_version: Set(0),
-        created_at: Set(now),
-        updated_at: Set(now),
+        created_at: NotSet,
+        updated_at: NotSet,
     }
     .insert(db)
     .await
@@ -116,15 +117,14 @@ pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
 /// session ID.
 pub async fn insert_session(db: &DatabaseConnection, host_id: &UserId, status: &str) -> SessionId {
     let id = Uuid::new_v4().to_string();
-    let now = Utc::now().naive_utc();
     sessions::ActiveModel {
         id: Set(id.clone()),
         host_id: Set(host_id.as_str().to_string()),
         ruleset: Set("random".to_string()),
         least_played_drink_category: Set(None),
         status: Set(status.to_string()),
-        created_at: Set(now),
-        last_activity_at: Set(now),
+        created_at: NotSet,
+        last_activity_at: Set(Utc::now().naive_utc()),
     }
     .insert(db)
     .await
@@ -189,7 +189,7 @@ pub async fn insert_race_participation(
     session_race_participations::ActiveModel {
         session_race_id: Set(session_race_id.as_str().to_string()),
         user_id: Set(user_id.as_str().to_string()),
-        created_at: Set(Utc::now().naive_utc()),
+        created_at: NotSet,
         skipped_at: Set(skipped_at),
     }
     .insert(db)
@@ -291,7 +291,7 @@ pub async fn seed_game_data(db: &DatabaseConnection) {
         id: Set(drink_id),
         name: Set("Test Beer".to_string()),
         alcoholic: Set(true),
-        created_at: Set(Utc::now().naive_utc()),
+        created_at: NotSet,
         created_by: Set(None),
     }
     .insert(db)


### PR DESCRIPTION
## Summary

- Adds `ActiveModelBehavior::before_save` for the seven entities with `created_at` / `updated_at` columns, each in a sibling `entities/{entity}_behavior.rs`.
- Service / route call sites now leave timestamp fields as `NotSet`; `before_save` populates them on insert (and update for `users.updated_at`).
- Closes the work for compliance-plan PR-E1 ([#137](https://github.com/brendanbyrne/beerio-kart/issues/137)). Aligns with [`seaorm.md` § 1](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/coding-standards/seaorm.md#1-activemodel-vs-model).

## Behavior shape

- **`users`** — `before_save` stamps `created_at` on insert and `updated_at` on insert + update.
- **`sessions`** — `before_save` stamps `created_at` on insert. `last_activity_at` is *application-managed* (advanced by `helpers::touch_session`, not by every write); it stays explicitly set by hand. Treating it as a generic `updated_at` would defeat the stale-session cleanup loop.
- **`drink_types`, `runs`, `session_races`, `session_race_participations`, `run_flags`** — `before_save` stamps `created_at` on insert. These have no `updated_at` column.

## Why a small dep was added

`async-trait = "0.1"` was added to `backend/Cargo.toml`. SeaORM 1.x defines `ActiveModelBehavior::before_save` via `#[async_trait]`, and SeaORM doesn't re-export the macro. The crate is already in the dependency tree transitively via SeaORM, so this just makes the dep direct.

## Two intentional manual `Set` survivors

A grep for `created_at: Set` / `updated_at: Set` in `backend/src/` returns two results, both intentional:

1. **`services/helpers.rs::insert_race_participations`** — uses `Entity::insert_many(...).exec()`, which bypasses `before_save` (only single-row `ActiveModel::insert` / `update` / `save` invoke it; verified against `sea-orm-1.1.19/src/entity/active_model.rs:280`). The bulk path is used deliberately to keep the per-race participant snapshot to one round-trip; the trade is one explicit timestamp, documented inline.
2. **`test_helpers::insert_session_race`** — accepts an explicit `created_at: NaiveDateTime` parameter so backdated-race tests (e.g. stale-session cleanup) can construct races at a chosen point in the past. This is the one helper whose contract is "control the timestamp."

Everything else in `backend/src/services/` is timestamp-Set-free (the Issue's strict verification target).

## Tests

Two new tests in `backend/src/entities/users_behavior.rs::tests` (users is the only entity with both timestamps, so it covers both verification criteria):

- `before_save_stamps_created_at_and_updated_at_on_insert` — inserts a user with `NotSet` timestamps, reads back, asserts both columns are populated and equal (same `before_save` call).
- `before_save_advances_updated_at_on_update` — sleeps 10 ms, mutates a non-timestamp column, asserts `updated_at` advances and `created_at` stays unchanged.

The other `*_behavior.rs` files share the same shape (single-line `created_at`-on-insert), so per-entity duplication wouldn't add coverage.

## Test plan

- [ ] `cd backend && cargo build` succeeds.
- [ ] `cd backend && cargo clippy --all-targets` is clean.
- [ ] `cd backend && cargo test` — full suite green (268+ tests). The two new tests live at `entities::users_behavior::tests::before_save_*`; `cargo test before_save -- --nocapture` runs just them.
- [ ] `grep -rn 'created_at: Set\|updated_at: Set' backend/src/` returns the two documented exceptions and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)