### PR TITLE
122: PR-D1 — introduce nutype, define ID newtypes

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -279,6 +279,8 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "migration",
+ "nutype",
+ "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rstest",
@@ -310,6 +312,21 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -538,6 +555,15 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1486,6 +1512,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "kinded"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c48b3aa70f02a317f180f7d4e0834bbd2ffa293e352a132bb2ac9351736635"
+dependencies = [
+ "kinded_macros",
+]
+
+[[package]]
+name = "kinded_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feeb717349480c3d8125f84afdd78e9d7128004d8e2a561c35b3bbd76363d085"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1795,30 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "nutype"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ae01f500e59a27e8c868297e15e268105d30ae06dee1ca194e025be29dee2a"
+dependencies = [
+ "nutype_macros",
+]
+
+[[package]]
+name = "nutype_macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a6a6ddc63e6d0cd6b77af9aabae24601b39ad543d29bff88c4761c1fc34700"
+dependencies = [
+ "cfg-if",
+ "kinded",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2038,6 +2109,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2161,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2174,6 +2270,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -2441,6 +2546,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3516,6 +3633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,6 +3672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3700,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3614,6 +3749,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -70,6 +70,12 @@ dotenvy = "0.15"
 rand = "0.8"
 rand_core = { version = "0.6", features = ["getrandom"] }
 migration = { path = "migration" }
+# Newtype wrapper for domain IDs (rust.md § 2 — type-driven design). Wrapping
+# `uuid::Uuid` / `i32` in distinct types makes wrong-id-in-this-arg a
+# compile-time error and validates UUID-shaped wire input once at the boundary.
+# `serde` feature enables the Serialize/Deserialize derives, which delegate
+# transparently to the inner type so the wire format is unchanged.
+nutype = { version = "0.7", default-features = false, features = ["std", "serde"] }
 # Direct sqlx for SqliteConnectOptions / SqlitePoolOptions — needed for
 # per-connection PRAGMA control (see src/db.rs and seaorm.md § 8). Version
 # pinned to the sqlx that sea-orm 1.x bundles internally.
@@ -88,6 +94,9 @@ tower = "0.5.3"
 # error.rs tests to assert the client/detail split: driver-string detail must
 # reach `tracing::warn!` but must not reach the response body. See Issue #84.
 tracing-test = "0.2"
+# Property-based tests (rust.md § 7). First consumer is the UUID round-trip
+# test on `UserId` in `domain/ids.rs`; broad adoption stays organic.
+proptest = "1"
 # Table-driven test cases (rust.md § 7). Reach for it when the same logic
 # runs over half-a-dozen inputs.
 rstest = "0.23"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use anyhow::Context;
 
+use crate::domain::UserId;
+
 /// Shared application configuration loaded from environment variables.
 ///
 /// Wrapped in `Arc` and stored in Axum's state so all handlers can access it
@@ -18,7 +20,7 @@ pub struct Config {
     /// by bumping `refresh_token_version` in the database. Stored as `i64`
     /// because `chrono::TimeDelta::days` takes `i64`.
     pub jwt_refresh_expiry_days: i64,
-    pub admin_user_id: Option<String>,
+    pub admin_user_id: Option<UserId>,
     /// Controls the `Secure` flag on the refresh cookie. Must be `false` for
     /// local `http://localhost` development, `true` in production behind HTTPS.
     pub cookie_secure: bool,
@@ -68,7 +70,16 @@ impl Config {
             .filter(|&v| v > 0)
             .unwrap_or(7);
 
-        let admin_user_id = std::env::var("ADMIN_USER_ID").ok();
+        // `ADMIN_USER_ID` must be a UUID — parsing it at load time means a
+        // misconfigured value fails fast at startup rather than silently
+        // refusing admin access to whatever user-id was meant.
+        let admin_user_id = std::env::var("ADMIN_USER_ID")
+            .ok()
+            .map(|raw| {
+                raw.parse::<UserId>()
+                    .context("ADMIN_USER_ID must be a valid UUID")
+            })
+            .transpose()?;
 
         let cookie_secure = std::env::var("COOKIE_SECURE")
             .ok()

--- a/backend/src/domain/ids.rs
+++ b/backend/src/domain/ids.rs
@@ -1,171 +1,337 @@
-use sea_orm::Value;
-use serde::{Deserialize, Serialize};
+//! Domain ID newtypes.
+//!
+//! Each ID column on the database has a corresponding newtype here so the
+//! compiler can catch "wrong-id-in-this-arg" bugs. UUID-backed columns wrap
+//! [`uuid::Uuid`]; integer-backed columns wrap [`i32`]. Per
+//! `docs/coding-standards/seaorm.md` § 6, entities keep SeaORM-default
+//! primitives (`String` / `i32`) and conversion happens at the entity↔service
+//! boundary inside the service layer.
+//!
+//! The [`nutype`] macro provides the derives. The `Serialize` / `Deserialize`
+//! derives delegate transparently to the inner type, so the wire format is
+//! unchanged: a UUID-backed ID serializes as the canonical hyphenated UUID
+//! string, an integer-backed ID as a JSON number. Deserialize is the parsing
+//! step the standards (`rust.md` § 2) describe as "parse, don't validate" —
+//! a malformed UUID at the HTTP boundary becomes a 422 from axum's JSON
+//! extractor before the handler runs.
+//!
+//! The manual [`From`] impls let `UserId` (etc.) flow through `SeaORM` call
+//! sites without explicit unwrapping. Both owned and borrowed forms are
+//! covered so callers can pick whichever reads best at the use site:
+//!
+//! - `From<Self>` / `From<&Self> for sea_orm::Value` — for
+//!   `Column::Foo.eq(id)` filter expressions and parameter slots in
+//!   `find_by_statement` raw SQL.
+//! - `From<Self>` / `From<&Self> for String` (UUID newtypes) and
+//!   `for i32` (integer newtypes) — for `find_by_id(id)` on entities whose
+//!   primary-key `ValueType` is the matching primitive.
+//!
+//! UUID newtypes also carry a [`new_v4`](UserId::new_v4) constructor that
+//! generates a fresh random UUID, and [`parse_db_id`] is the boundary helper
+//! that reads an entity's `String` ID column into a newtype, mapping a bad
+//! UUID in the database to [`Error::Internal`] (corruption — should never
+//! happen, but we'd rather surface a clear 500 than silently return wrong
+//! data).
+//!
+//! [`new_v4`]: UserId::new_v4
 
-/// Generate a string-backed newtype for an ID.
+use nutype::nutype;
+use sea_orm::Value;
+
+use crate::error::Error;
+
+/// Parse a UUID column read from the database into a typed newtype.
 ///
-/// The newtype is transparent for serde (so it serializes as a bare string),
-/// implements `Display`, `AsRef<str>`, `Deref<Target = str>`, and conversion
-/// from `String` / `&str`. `Deref` lets call sites treat the newtype as a
-/// `&str` for read-only operations (e.g. passing into `SeaORM` filters that
-/// expect `&str`). `From<&Self> for sea_orm::Value` is provided so call
-/// sites can pass `&UserId` (etc.) directly to `Column::Foo.eq(...)` and
-/// `find_by_id(...)` without an explicit `.as_str()` conversion.
-macro_rules! string_id_newtype {
-    ($name:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(transparent)]
-        pub struct $name(String);
+/// Used at the entity↔service boundary when materializing a domain object
+/// from a `SeaORM` `Model`. A failure here means a malformed UUID slipped into
+/// the database (data corruption or hand-edited rows), so it surfaces as
+/// [`Error::Internal`] with the column name in the context.
+///
+/// # Errors
+///
+/// Returns [`Error::Internal`] if `s` is not a valid UUID string. The
+/// resulting `anyhow::Error` chain carries the uuid parse error as its source
+/// plus a static context naming the column (e.g. `"Invalid UUID in users.id"`).
+pub(crate) fn parse_db_id<T>(s: &str, column: &'static str) -> Result<T, Error>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    s.parse::<T>().map_err(|e| {
+        Error::Internal(anyhow::Error::new(e).context(format!("Invalid UUID in {column}")))
+    })
+}
+
+// ── UUID-backed ID newtypes ─────────────────────────────────────────────
+//
+// Stored on disk as TEXT (canonical hyphenated form). The `nutype` macro
+// gives us the standard set of derives — see the module docs for what each
+// brings. The manual `From` impls below adapt the type to SeaORM's
+// primary-key and filter-value APIs.
+
+macro_rules! uuid_id_newtype {
+    ($name:ident, $column_label:literal) => {
+        #[nutype(derive(
+            Debug,
+            Clone,
+            Copy,
+            PartialEq,
+            Eq,
+            Hash,
+            Display,
+            AsRef,
+            Serialize,
+            Deserialize,
+            FromStr,
+            From,
+        ))]
+        pub struct $name(uuid::Uuid);
 
         impl $name {
-            pub fn new(s: impl Into<String>) -> Self {
-                Self(s.into())
+            /// Generate a fresh random ID (UUID v4).
+            #[must_use]
+            pub fn new_v4() -> Self {
+                Self::new(uuid::Uuid::new_v4())
             }
 
-            pub fn as_str(&self) -> &str {
-                &self.0
-            }
-
-            pub fn into_string(self) -> String {
-                self.0
-            }
-        }
-
-        impl std::ops::Deref for $name {
-            type Target = str;
-
-            fn deref(&self) -> &str {
-                &self.0
-            }
-        }
-
-        impl AsRef<str> for $name {
-            fn as_ref(&self) -> &str {
-                &self.0
-            }
-        }
-
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str(&self.0)
-            }
-        }
-
-        impl From<String> for $name {
-            fn from(s: String) -> Self {
-                Self(s)
-            }
-        }
-
-        impl From<&str> for $name {
-            fn from(s: &str) -> Self {
-                Self(s.to_string())
+            /// Parse a UUID column from a `SeaORM` entity model.
+            ///
+            /// Convenience wrapper around [`parse_db_id`] that names the
+            /// column for the error message.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`Error::Internal`] if the stored string isn't a
+            /// valid UUID. Data corruption only — should never fire in
+            /// normal operation.
+            pub fn from_db(s: &str) -> Result<Self, Error> {
+                parse_db_id(s, $column_label)
             }
         }
 
         impl From<&$name> for Value {
             fn from(id: &$name) -> Self {
-                Value::from(id.0.as_str())
+                Value::String(Some(Box::new(id.as_ref().to_string())))
             }
         }
 
         impl From<$name> for Value {
             fn from(id: $name) -> Self {
-                Value::from(id.0)
-            }
-        }
-
-        impl From<$name> for String {
-            fn from(id: $name) -> Self {
-                id.0
+                Value::from(&id)
             }
         }
 
         impl From<&$name> for String {
             fn from(id: &$name) -> Self {
-                id.0.clone()
+                id.as_ref().to_string()
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(id: $name) -> Self {
+                id.as_ref().to_string()
             }
         }
     };
 }
 
-string_id_newtype!(UserId);
-string_id_newtype!(SessionId);
-string_id_newtype!(RunId);
-string_id_newtype!(SessionRaceId);
+uuid_id_newtype!(UserId, "users.id");
+uuid_id_newtype!(SessionId, "sessions.id");
+uuid_id_newtype!(RunId, "runs.id");
+uuid_id_newtype!(SessionRaceId, "session_races.id");
+uuid_id_newtype!(SessionParticipantId, "session_participants.id");
+uuid_id_newtype!(RunFlagId, "run_flags.id");
+uuid_id_newtype!(DrinkTypeId, "drink_types.id");
+
+// ── Integer-backed ID newtypes ──────────────────────────────────────────
+//
+// Stored on disk as INTEGER. Lookup-table IDs (tracks, characters, etc.)
+// are pre-seeded small integers (1..=N), not auto-incremented surrogates —
+// see `data-model.md` and ADR 0002.
+
+macro_rules! i32_id_newtype {
+    ($name:ident) => {
+        #[nutype(derive(
+            Debug,
+            Clone,
+            Copy,
+            PartialEq,
+            Eq,
+            Hash,
+            Display,
+            AsRef,
+            Serialize,
+            Deserialize,
+            FromStr,
+            From,
+        ))]
+        pub struct $name(i32);
+
+        impl From<&$name> for Value {
+            fn from(id: &$name) -> Self {
+                Value::Int(Some(*id.as_ref()))
+            }
+        }
+
+        impl From<$name> for Value {
+            fn from(id: $name) -> Self {
+                Value::Int(Some(*id.as_ref()))
+            }
+        }
+
+        impl From<&$name> for i32 {
+            fn from(id: &$name) -> Self {
+                *id.as_ref()
+            }
+        }
+
+        impl From<$name> for i32 {
+            fn from(id: $name) -> Self {
+                *id.as_ref()
+            }
+        }
+    };
+}
+
+i32_id_newtype!(TrackId);
+i32_id_newtype!(CharacterId);
+i32_id_newtype!(BodyId);
+i32_id_newtype!(WheelId);
+i32_id_newtype!(GliderId);
+i32_id_newtype!(CupId);
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+    use uuid::Uuid;
+
     use super::*;
 
     #[test]
-    fn user_id_round_trip() {
-        let id = UserId::new("abc");
-        assert_eq!(id.as_str(), "abc");
-        assert_eq!(id.to_string(), "abc");
-        assert_eq!(id.into_string(), "abc".to_string());
-    }
-
-    #[test]
-    fn session_id_deref_to_str() {
-        let id = SessionId::new("xyz-123");
-        // Deref<Target = str> lets us use &str methods directly.
-        assert_eq!(id.len(), 7);
-        assert!(id.starts_with("xyz"));
-        // AsRef<str> for API ergonomics.
-        let as_ref: &str = id.as_ref();
-        assert_eq!(as_ref, "xyz-123");
-    }
-
-    #[test]
-    fn from_string_and_str() {
-        let a: RunId = "r1".into();
-        let b: RunId = String::from("r1").into();
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn serde_is_transparent() {
-        let id = UserId::new("u-9");
+    fn test_user_id_serializes_as_bare_uuid_string() {
+        let raw = Uuid::new_v4();
+        let id = UserId::new(raw);
         let json = serde_json::to_string(&id).unwrap();
-        assert_eq!(json, "\"u-9\"");
-        let parsed: UserId = serde_json::from_str("\"u-9\"").unwrap();
-        assert_eq!(parsed, id);
+        assert_eq!(json, format!("\"{raw}\""));
     }
 
     #[test]
-    fn different_newtypes_are_not_interchangeable() {
-        // Compile-time property: UserId and SessionId do not unify. Documented
-        // here so future refactors don't unknowingly reach for `From<UserId>
-        // for SessionId` or similar. If you need to convert between them,
-        // it should be deliberate via `.as_str()` or `.into_string()`.
-        let user = UserId::new("u");
-        let session: SessionId = SessionId::new(user.as_str());
-        assert_eq!(session.as_str(), "u");
+    fn test_user_id_deserializes_from_bare_uuid_string() {
+        let raw = Uuid::new_v4();
+        let json = format!("\"{raw}\"");
+        let id: UserId = serde_json::from_str(&json).unwrap();
+        assert_eq!(*id.as_ref(), raw);
     }
 
     #[test]
-    fn hash_and_eq_work() {
+    fn test_user_id_deserialize_rejects_non_uuid_string() {
+        // The whole point of wrapping `Uuid` instead of `String` is that the
+        // boundary deserializer parses; a non-UUID payload must fail.
+        let json = "\"not-a-uuid\"";
+        let result: Result<UserId, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "non-UUID string must fail deserialization");
+    }
+
+    #[test]
+    fn test_distinct_id_types_do_not_unify() {
+        // Documented compile-time property: `UserId` and `SessionId` share
+        // the same inner type (`Uuid`) but are distinct types — passing one
+        // where the other is expected is a compile error. The runtime
+        // check below confirms `Self::new` exists per type and rejects
+        // cross-construction without an explicit detour through the inner.
+        let raw = Uuid::new_v4();
+        let user_id = UserId::new(raw);
+        let session_id = SessionId::new(*user_id.as_ref());
+        assert_eq!(user_id.as_ref(), session_id.as_ref());
+    }
+
+    #[test]
+    fn test_user_id_hash_and_eq() {
         use std::collections::HashSet;
+
+        let raw = Uuid::new_v4();
         let mut set = HashSet::new();
-        set.insert(SessionRaceId::new("sr-1"));
-        assert!(set.contains(&SessionRaceId::new("sr-1")));
-        assert!(!set.contains(&SessionRaceId::new("sr-2")));
+        set.insert(UserId::new(raw));
+        assert!(set.contains(&UserId::new(raw)));
+        assert!(!set.contains(&UserId::new(Uuid::new_v4())));
     }
 
     #[test]
-    fn into_sea_orm_value() {
-        // `&UserId` and `UserId` both convert into `sea_orm::Value` so that
-        // `Column::Foo.eq(...)` and `find_by_id(...)` accept newtype IDs
-        // directly. Verifies both ref and owned conversions land on the
-        // string variant.
-        let owned = UserId::new("u-1");
-        let ref_value: Value = (&owned).into();
-        assert_eq!(ref_value, Value::String(Some(Box::new("u-1".to_string()))));
+    fn test_user_id_into_sea_orm_value() {
+        // `&UserId` and `UserId` both convert to `sea_orm::Value::String`
+        // so `Column::Foo.eq(...)` and `find_by_id(...)` accept newtypes
+        // without ceremony. The textual form is the canonical hyphenated
+        // UUID — matching the column type (`Text`) on disk.
+        let raw = Uuid::new_v4();
+        let owned = UserId::new(raw);
 
-        let owned_value: Value = owned.into();
-        assert_eq!(
-            owned_value,
-            Value::String(Some(Box::new("u-1".to_string())))
+        let by_ref: Value = (&owned).into();
+        let by_value: Value = owned.into();
+
+        let expected = Value::String(Some(Box::new(raw.to_string())));
+        assert_eq!(by_ref, expected);
+        assert_eq!(by_value, expected);
+    }
+
+    #[test]
+    fn test_track_id_into_sea_orm_value() {
+        let id = TrackId::new(42);
+
+        let by_ref: Value = (&id).into();
+        let by_value: Value = id.into();
+
+        assert_eq!(by_ref, Value::Int(Some(42)));
+        assert_eq!(by_value, Value::Int(Some(42)));
+    }
+
+    #[test]
+    fn test_user_id_into_string_canonical_form() {
+        let raw = Uuid::new_v4();
+        let id = UserId::new(raw);
+        let s: String = (&id).into();
+        assert_eq!(s, raw.to_string());
+    }
+
+    #[test]
+    fn test_track_id_into_i32() {
+        let id = TrackId::new(7);
+        let n: i32 = (&id).into();
+        assert_eq!(n, 7);
+    }
+
+    #[test]
+    fn test_user_id_from_db_round_trip() {
+        let raw = Uuid::new_v4();
+        let stored: String = UserId::new(raw).into();
+        let recovered = UserId::from_db(&stored).expect("valid UUID parses");
+        assert_eq!(*recovered.as_ref(), raw);
+    }
+
+    #[test]
+    fn test_user_id_from_db_rejects_malformed_uuid() {
+        let err = UserId::from_db("not-a-uuid").unwrap_err();
+        let Error::Internal(chain) = err else {
+            panic!("expected Internal, got something else");
+        };
+        let rendered = format!("{chain:#}");
+        assert!(
+            rendered.contains("users.id"),
+            "context should name the column: {rendered}"
         );
+    }
+
+    // Property test: UserId round-trips through serde JSON for any UUID input.
+    // The whole "parse, don't validate" story rests on this being lossless —
+    // if a deserialize-then-serialize cycle ever differs, the wire contract
+    // has silently broken. proptest generates 256 random UUIDs by default.
+    proptest! {
+        #[test]
+        fn test_user_id_serde_round_trip(bytes in any::<[u8; 16]>()) {
+            let raw = Uuid::from_bytes(bytes);
+            let id = UserId::new(raw);
+            let json = serde_json::to_string(&id).unwrap();
+            let recovered: UserId = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(id, recovered);
+        }
     }
 }

--- a/backend/src/domain/mod.rs
+++ b/backend/src/domain/mod.rs
@@ -2,4 +2,7 @@ pub mod enums;
 pub mod ids;
 pub mod race_setup;
 
-pub use ids::{RunId, SessionId, SessionRaceId, UserId};
+pub use ids::{
+    BodyId, CharacterId, CupId, DrinkTypeId, GliderId, RunFlagId, RunId, SessionId,
+    SessionParticipantId, SessionRaceId, TrackId, UserId, WheelId,
+};

--- a/backend/src/domain/race_setup.rs
+++ b/backend/src/domain/race_setup.rs
@@ -1,4 +1,7 @@
-use crate::error::Error;
+use crate::{
+    domain::{BodyId, CharacterId, GliderId, WheelId},
+    error::Error,
+};
 
 /// A fully-specified race setup update (all four IDs required together).
 ///
@@ -8,10 +11,10 @@ use crate::error::Error;
 /// compile time so call sites can't read only some of the fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Update {
-    pub character_id: i32,
-    pub body_id: i32,
-    pub wheel_id: i32,
-    pub glider_id: i32,
+    pub character_id: CharacterId,
+    pub body_id: BodyId,
+    pub wheel_id: WheelId,
+    pub glider_id: GliderId,
 }
 
 impl Update {
@@ -26,10 +29,10 @@ impl Update {
     /// Returns `Error::BadRequest` if the four arguments are a mix of `Some`
     /// and `None` — race setup is all-or-nothing.
     pub fn try_from_optional(
-        character_id: Option<i32>,
-        body_id: Option<i32>,
-        wheel_id: Option<i32>,
-        glider_id: Option<i32>,
+        character_id: Option<CharacterId>,
+        body_id: Option<BodyId>,
+        wheel_id: Option<WheelId>,
+        glider_id: Option<GliderId>,
     ) -> Result<Option<Self>, Error> {
         match (character_id, body_id, wheel_id, glider_id) {
             (None, None, None, None) => Ok(None),
@@ -60,16 +63,21 @@ mod tests {
 
     #[test]
     fn all_some_returns_ok_some() {
-        let result = Update::try_from_optional(Some(1), Some(2), Some(3), Some(4))
-            .unwrap()
-            .unwrap();
+        let result = Update::try_from_optional(
+            Some(CharacterId::new(1)),
+            Some(BodyId::new(2)),
+            Some(WheelId::new(3)),
+            Some(GliderId::new(4)),
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(
             result,
             Update {
-                character_id: 1,
-                body_id: 2,
-                wheel_id: 3,
-                glider_id: 4,
+                character_id: CharacterId::new(1),
+                body_id: BodyId::new(2),
+                wheel_id: WheelId::new(3),
+                glider_id: GliderId::new(4),
             }
         );
     }
@@ -85,16 +93,31 @@ mod tests {
 
     #[test]
     fn single_some_is_bad_request() {
-        assert_bad_request(Update::try_from_optional(Some(1), None, None, None));
+        assert_bad_request(Update::try_from_optional(
+            Some(CharacterId::new(1)),
+            None,
+            None,
+            None,
+        ));
     }
 
     #[test]
     fn three_some_one_none_is_bad_request() {
-        assert_bad_request(Update::try_from_optional(Some(1), Some(2), Some(3), None));
+        assert_bad_request(Update::try_from_optional(
+            Some(CharacterId::new(1)),
+            Some(BodyId::new(2)),
+            Some(WheelId::new(3)),
+            None,
+        ));
     }
 
     #[test]
     fn interior_none_is_bad_request() {
-        assert_bad_request(Update::try_from_optional(Some(1), None, Some(3), Some(4)));
+        assert_bad_request(Update::try_from_optional(
+            Some(CharacterId::new(1)),
+            None,
+            Some(WheelId::new(3)),
+            Some(GliderId::new(4)),
+        ));
     }
 }

--- a/backend/src/drink_type_id.rs
+++ b/backend/src/drink_type_id.rs
@@ -1,16 +1,23 @@
 use uuid::Uuid;
 
+use crate::domain::DrinkTypeId;
+
 /// Namespace UUID for deterministic drink type IDs.
 /// Generated once, never changes. Used in both seed logic and API endpoints.
 const DRINK_TYPE_NAMESPACE: Uuid = Uuid::from_bytes([
     0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
 ]);
 
-/// Compute a deterministic UUID for a drink type name (case-insensitive).
-/// `uuid_v5(DRINK_TYPE_NAMESPACE, UPPERCASE(name))`
+/// Compute a deterministic [`DrinkTypeId`] for a drink type name (case-insensitive).
+///
+/// Equivalent to `uuid_v5(DRINK_TYPE_NAMESPACE, UPPERCASE(name))` wrapped in the
+/// newtype.
 #[must_use]
-pub fn drink_type_uuid(name: &str) -> String {
-    Uuid::new_v5(&DRINK_TYPE_NAMESPACE, name.to_uppercase().as_bytes()).to_string()
+pub fn drink_type_uuid(name: &str) -> DrinkTypeId {
+    DrinkTypeId::new(Uuid::new_v5(
+        &DRINK_TYPE_NAMESPACE,
+        name.to_uppercase().as_bytes(),
+    ))
 }
 
 #[cfg(test)]

--- a/backend/src/entities/users_behavior.rs
+++ b/backend/src/entities/users_behavior.rs
@@ -48,7 +48,7 @@ mod tests {
         let db = setup_db().await;
         let user_id = create_user(&db, "alice").await;
 
-        let user = users::Entity::find_by_id(user_id.as_str())
+        let user = users::Entity::find_by_id(user_id)
             .one(&db)
             .await
             .expect("query user")
@@ -67,7 +67,7 @@ mod tests {
         let db = setup_db().await;
         let user_id = create_user(&db, "bob").await;
 
-        let user_t0 = users::Entity::find_by_id(user_id.as_str())
+        let user_t0 = users::Entity::find_by_id(user_id)
             .one(&db)
             .await
             .expect("query user")
@@ -84,7 +84,7 @@ mod tests {
         active.refresh_token_version = Set(1);
         active.update(&db).await.expect("update user");
 
-        let user_t1 = users::Entity::find_by_id(user_id.as_str())
+        let user_t1 = users::Entity::find_by_id(user_id)
             .one(&db)
             .await
             .expect("query user")

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -1,9 +1,6 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
 
-use crate::{
-    domain::{UserId, ids::parse_db_id},
-    error::Error,
-};
+use crate::{domain::UserId, error::Error};
 
 /// Extractor that validates the JWT from the `Authorization: Bearer <token>`
 /// header and makes the authenticated user's info available to handlers.
@@ -58,7 +55,12 @@ impl FromRequestParts<crate::AppState> for User {
         // serializes a real `UserId`. A non-UUID `sub` here means a forged or
         // foreign-issued token slipped past signature validation — treat it
         // as unauthorized, not internal, so we don't leak corruption details.
-        let user_id = parse_db_id::<UserId>(&claims.sub, "access token sub claim")
+        // Goes through the typed `FromStr` surface (nutype-derived) rather
+        // than the internal `parse_db_id` helper, which is for entity-column
+        // reads where the error context should name the column.
+        let user_id: UserId = claims
+            .sub
+            .parse()
             .map_err(|_| Error::Unauthorized("Invalid user id in token".to_string()))?;
 
         Ok(Self {

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -1,6 +1,9 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
 
-use crate::{domain::UserId, error::Error};
+use crate::{
+    domain::{UserId, ids::parse_db_id},
+    error::Error,
+};
 
 /// Extractor that validates the JWT from the `Authorization: Bearer <token>`
 /// header and makes the authenticated user's info available to handlers.
@@ -51,8 +54,15 @@ impl FromRequestParts<crate::AppState> for User {
             return Err(Error::Unauthorized("Invalid token type".to_string()));
         }
 
+        // `sub` is mint-controlled by `create_access_token`, which always
+        // serializes a real `UserId`. A non-UUID `sub` here means a forged or
+        // foreign-issued token slipped past signature validation — treat it
+        // as unauthorized, not internal, so we don't leak corruption details.
+        let user_id = parse_db_id::<UserId>(&claims.sub, "access token sub claim")
+            .map_err(|_| Error::Unauthorized("Invalid user id in token".to_string()))?;
+
         Ok(Self {
-            user_id: UserId::new(claims.sub),
+            user_id,
             username: claims.username,
         })
     }
@@ -86,7 +96,7 @@ impl FromRequestParts<crate::AppState> for AdminUser {
             .as_ref()
             .ok_or_else(|| Error::Forbidden("Admin access not configured".to_string()))?;
 
-        if auth_user.user_id.as_str() != admin_id {
+        if auth_user.user_id != *admin_id {
             return Err(Error::Forbidden("Admin access required".to_string()));
         }
 

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -126,12 +126,12 @@ pub async fn register(
     // Hash password (offloaded to the blocking pool, capped by argon2_limit)
     let password_hash = auth_service::hash_password(&state.argon2_limit, body.password).await?;
 
-    let user_id = uuid::Uuid::new_v4().to_string();
+    let user_id = UserId::new_v4();
     tracing::Span::current().record("user_id", tracing::field::display(&user_id));
 
     // Timestamps are populated by `users::ActiveModelBehavior::before_save`.
     let new_user = users::ActiveModel {
-        id: Set(user_id.clone()),
+        id: Set((&user_id).into()),
         username: Set(username.to_string()),
         email: Set(None),
         password_hash: Set(password_hash),
@@ -158,7 +158,7 @@ pub async fn register(
         Json(Response {
             access_token,
             user: UserInfo {
-                id: UserId::new(user_id),
+                id: user_id,
                 username: username.to_string(),
             },
         }),
@@ -201,7 +201,8 @@ pub async fn login(
         .await;
         return Err(Error::Unauthorized("Invalid username or password".into()));
     };
-    tracing::Span::current().record("user_id", tracing::field::display(&user.id));
+    let user_id = UserId::from_db(&user.id)?;
+    tracing::Span::current().record("user_id", tracing::field::display(&user_id));
 
     // Verify password (offloaded to the blocking pool, capped by argon2_limit)
     let password_ok = auth_service::verify_password(
@@ -215,9 +216,9 @@ pub async fn login(
     }
 
     // Generate tokens
-    let access_token = auth_service::create_access_token(&user.id, &user.username, &state.config)?;
+    let access_token = auth_service::create_access_token(&user_id, &user.username, &state.config)?;
     let refresh_token =
-        auth_service::create_refresh_token(&user.id, user.refresh_token_version, &state.config)?;
+        auth_service::create_refresh_token(&user_id, user.refresh_token_version, &state.config)?;
     let headers = make_refresh_headers(&refresh_token, &state.config)?;
 
     Ok((
@@ -225,7 +226,7 @@ pub async fn login(
         Json(Response {
             access_token,
             user: UserInfo {
-                id: UserId::new(user.id),
+                id: user_id,
                 username: user.username,
             },
         }),
@@ -277,6 +278,7 @@ pub async fn refresh(
         .one(&state.db)
         .await?
         .ok_or_else(|| Error::Unauthorized("User not found".into()))?;
+    let user_id = UserId::from_db(&user.id)?;
 
     // Version mismatch means the token was revoked (logout or password change)
     if claims.refresh_token_version != user.refresh_token_version {
@@ -284,11 +286,11 @@ pub async fn refresh(
     }
 
     // Issue new tokens
-    let access_token = auth_service::create_access_token(&user.id, &user.username, &state.config)?;
+    let access_token = auth_service::create_access_token(&user_id, &user.username, &state.config)?;
 
     // Rotate: issue a fresh refresh token with same version but new expiry
     let new_refresh =
-        auth_service::create_refresh_token(&user.id, user.refresh_token_version, &state.config)?;
+        auth_service::create_refresh_token(&user_id, user.refresh_token_version, &state.config)?;
     let resp_headers = make_refresh_headers(&new_refresh, &state.config)?;
 
     Ok((resp_headers, Json(RefreshResponse { access_token })))
@@ -307,7 +309,7 @@ pub async fn refresh(
 #[tracing::instrument(skip_all, fields(user_id = %user.user_id))]
 pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl IntoResponse, Error> {
     // Look up user to get current version
-    let db_user = users::Entity::find_by_id(&user.user_id)
+    let db_user = users::Entity::find_by_id(String::from(&user.user_id))
         .one(&state.db)
         .await?
         .ok_or_else(|| {
@@ -359,7 +361,7 @@ pub async fn change_password(
     }
 
     // Look up user
-    let db_user = users::Entity::find_by_id(&user.user_id)
+    let db_user = users::Entity::find_by_id(String::from(&user.user_id))
         .one(&state.db)
         .await?
         .ok_or_else(|| Error::NotFound("User not found".into()))?;
@@ -382,7 +384,7 @@ pub async fn change_password(
     // `updated_at` is bumped by `users::ActiveModelBehavior::before_save`.
     let new_version = db_user.refresh_token_version + 1;
     let username = db_user.username.clone();
-    let user_id = db_user.id.clone();
+    let user_id = UserId::from_db(&db_user.id)?;
     let mut active: users::ActiveModel = db_user.into_active_model();
     active.password_hash = Set(new_hash);
     active.refresh_token_version = Set(new_version);

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -309,7 +309,7 @@ pub async fn refresh(
 #[tracing::instrument(skip_all, fields(user_id = %user.user_id))]
 pub async fn logout(State(state): State<AppState>, user: User) -> Result<impl IntoResponse, Error> {
     // Look up user to get current version
-    let db_user = users::Entity::find_by_id(String::from(&user.user_id))
+    let db_user = users::Entity::find_by_id(user.user_id)
         .one(&state.db)
         .await?
         .ok_or_else(|| {
@@ -361,7 +361,7 @@ pub async fn change_password(
     }
 
     // Look up user
-    let db_user = users::Entity::find_by_id(String::from(&user.user_id))
+    let db_user = users::Entity::find_by_id(user.user_id)
         .one(&state.db)
         .await?
         .ok_or_else(|| Error::NotFound("User not found".into()))?;

--- a/backend/src/routes/drink_types.rs
+++ b/backend/src/routes/drink_types.rs
@@ -7,7 +7,11 @@ use sea_orm::{ActiveValue::NotSet, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AppState, drink_type_id::drink_type_uuid, entities::drink_types, error::Error,
+    AppState,
+    domain::{DrinkTypeId, UserId},
+    drink_type_id::drink_type_uuid,
+    entities::drink_types,
+    error::Error,
     middleware::auth::User,
 };
 
@@ -15,22 +19,27 @@ use crate::{
 
 #[derive(Serialize)]
 pub struct DrinkTypeResponse {
-    pub id: String,
+    pub id: DrinkTypeId,
     pub name: String,
     pub alcoholic: bool,
-    pub created_by: Option<String>,
+    pub created_by: Option<UserId>,
     pub created_at: DateTime<Utc>,
 }
 
-impl From<drink_types::Model> for DrinkTypeResponse {
-    fn from(m: drink_types::Model) -> Self {
-        Self {
-            id: m.id,
+impl DrinkTypeResponse {
+    /// Parse a `drink_types::Model` into the wire DTO. Fallible because
+    /// the `id` and (optional) `created_by` columns are stored as UUID
+    /// strings and have to round-trip through `from_db`; a bad UUID in
+    /// either column is data corruption and surfaces as `Internal`.
+    fn try_from_model(m: drink_types::Model) -> Result<Self, Error> {
+        let created_by = m.created_by.as_deref().map(UserId::from_db).transpose()?;
+        Ok(Self {
+            id: DrinkTypeId::from_db(&m.id)?,
             name: m.name,
             alcoholic: m.alcoholic,
-            created_by: m.created_by,
+            created_by,
             created_at: m.created_at.and_utc(),
-        }
+        })
     }
 }
 
@@ -82,23 +91,23 @@ pub async fn create_drink_type(
     let id = drink_type_uuid(&name);
 
     // Check if this drink type already exists (by UUID)
-    if let Some(existing) = drink_types::Entity::find_by_id(&id).one(&state.db).await? {
+    if let Some(existing) = drink_types::Entity::find_by_id(id).one(&state.db).await? {
         // Return the existing entry (200, not 409)
-        return Ok(Json(existing.into()));
+        return Ok(Json(DrinkTypeResponse::try_from_model(existing)?));
     }
 
     // `created_at` is populated by `drink_types::ActiveModelBehavior::before_save`.
     let model = drink_types::ActiveModel {
-        id: Set(id),
+        id: Set((&id).into()),
         name: Set(name),
         alcoholic: Set(req.alcoholic),
         created_at: NotSet,
-        created_by: Set(Some(user.user_id.into_string())),
+        created_by: Set(Some((&user.user_id).into())),
     };
 
     let inserted = sea_orm::ActiveModelTrait::insert(model, &state.db).await?;
 
-    Ok(Json(inserted.into()))
+    Ok(Json(DrinkTypeResponse::try_from_model(inserted)?))
 }
 
 /// GET /api/v1/drink-types — list drink types. Optional `alcoholic` query
@@ -123,7 +132,10 @@ pub async fn list_drink_types(
 
     let items = query.all(&state.db).await?;
     Ok(Json(
-        items.into_iter().map(DrinkTypeResponse::from).collect(),
+        items
+            .into_iter()
+            .map(DrinkTypeResponse::try_from_model)
+            .collect::<Result<Vec<_>, _>>()?,
     ))
 }
 
@@ -137,12 +149,12 @@ pub async fn list_drink_types(
 pub async fn get_drink_type(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id): Path<DrinkTypeId>,
 ) -> Result<Json<DrinkTypeResponse>, Error> {
-    let dt = drink_types::Entity::find_by_id(&id)
+    let dt = drink_types::Entity::find_by_id(id)
         .one(&state.db)
         .await?
         .ok_or_else(|| Error::NotFound(format!("Drink type {id} not found")))?;
 
-    Ok(Json(dt.into()))
+    Ok(Json(DrinkTypeResponse::try_from_model(dt)?))
 }

--- a/backend/src/routes/game_data.rs
+++ b/backend/src/routes/game_data.rs
@@ -16,6 +16,7 @@ use crate::{
 // ── Response types ───────────────────────────────────────────────────
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CharacterResponse {
     pub id: CharacterId,
     pub name: String,
@@ -23,6 +24,7 @@ pub struct CharacterResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct BodyResponse {
     pub id: BodyId,
     pub name: String,
@@ -30,6 +32,7 @@ pub struct BodyResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct WheelResponse {
     pub id: WheelId,
     pub name: String,
@@ -37,6 +40,7 @@ pub struct WheelResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct GliderResponse {
     pub id: GliderId,
     pub name: String,
@@ -44,6 +48,7 @@ pub struct GliderResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CupResponse {
     pub id: CupId,
     pub name: String,
@@ -51,6 +56,7 @@ pub struct CupResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct TrackResponse {
     pub id: TrackId,
     pub name: String,
@@ -60,6 +66,7 @@ pub struct TrackResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CupWithTracksResponse {
     pub id: CupId,
     pub name: String,

--- a/backend/src/routes/game_data.rs
+++ b/backend/src/routes/game_data.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AppState,
+    domain::{BodyId, CharacterId, CupId, GliderId, TrackId, WheelId},
     entities::{bodies, characters, cups, gliders, tracks, wheels},
     error::Error,
     middleware::auth::User,
@@ -15,50 +16,113 @@ use crate::{
 // ── Response types ───────────────────────────────────────────────────
 
 #[derive(Serialize)]
-pub struct SimpleItem {
-    pub id: i32,
+pub struct CharacterResponse {
+    pub id: CharacterId,
+    pub name: String,
+    pub image_path: String,
+}
+
+#[derive(Serialize)]
+pub struct BodyResponse {
+    pub id: BodyId,
+    pub name: String,
+    pub image_path: String,
+}
+
+#[derive(Serialize)]
+pub struct WheelResponse {
+    pub id: WheelId,
+    pub name: String,
+    pub image_path: String,
+}
+
+#[derive(Serialize)]
+pub struct GliderResponse {
+    pub id: GliderId,
+    pub name: String,
+    pub image_path: String,
+}
+
+#[derive(Serialize)]
+pub struct CupResponse {
+    pub id: CupId,
     pub name: String,
     pub image_path: String,
 }
 
 #[derive(Serialize)]
 pub struct TrackResponse {
-    pub id: i32,
+    pub id: TrackId,
     pub name: String,
-    pub cup_id: i32,
+    pub cup_id: CupId,
     pub position: i32,
     pub image_path: String,
 }
 
 #[derive(Serialize)]
 pub struct CupWithTracksResponse {
-    pub id: i32,
+    pub id: CupId,
     pub name: String,
     pub image_path: String,
     pub tracks: Vec<TrackResponse>,
 }
 
-/// Convert any entity Model with (id: i32, name: String, `image_path`: String) to `SimpleItem`.
-macro_rules! impl_into_simple_item {
-    ($($module:ident),+) => {
-        $(
-            impl From<$module::Model> for SimpleItem {
-                fn from(m: $module::Model) -> Self {
-                    Self { id: m.id, name: m.name, image_path: m.image_path }
-                }
-            }
-        )+
-    };
+impl From<characters::Model> for CharacterResponse {
+    fn from(m: characters::Model) -> Self {
+        Self {
+            id: CharacterId::new(m.id),
+            name: m.name,
+            image_path: m.image_path,
+        }
+    }
 }
 
-impl_into_simple_item!(characters, bodies, wheels, gliders, cups);
+impl From<bodies::Model> for BodyResponse {
+    fn from(m: bodies::Model) -> Self {
+        Self {
+            id: BodyId::new(m.id),
+            name: m.name,
+            image_path: m.image_path,
+        }
+    }
+}
+
+impl From<wheels::Model> for WheelResponse {
+    fn from(m: wheels::Model) -> Self {
+        Self {
+            id: WheelId::new(m.id),
+            name: m.name,
+            image_path: m.image_path,
+        }
+    }
+}
+
+impl From<gliders::Model> for GliderResponse {
+    fn from(m: gliders::Model) -> Self {
+        Self {
+            id: GliderId::new(m.id),
+            name: m.name,
+            image_path: m.image_path,
+        }
+    }
+}
+
+impl From<cups::Model> for CupResponse {
+    fn from(m: cups::Model) -> Self {
+        Self {
+            id: CupId::new(m.id),
+            name: m.name,
+            image_path: m.image_path,
+        }
+    }
+}
 
 impl From<tracks::Model> for TrackResponse {
     fn from(t: tracks::Model) -> Self {
         Self {
-            id: t.id,
+            id: TrackId::new(t.id),
             name: t.name,
-            cup_id: t.cup_id,
+            cup_id: CupId::new(t.cup_id),
             position: t.position,
             image_path: t.image_path,
         }
@@ -67,7 +131,7 @@ impl From<tracks::Model> for TrackResponse {
 
 #[derive(Deserialize)]
 pub struct TracksQuery {
-    pub cup_id: Option<i32>,
+    pub cup_id: Option<CupId>,
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────
@@ -81,9 +145,11 @@ pub struct TracksQuery {
 pub async fn list_characters(
     user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, Error> {
+) -> Result<Json<Vec<CharacterResponse>>, Error> {
     let items = characters::Entity::find().all(&state.db).await?;
-    Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
+    Ok(Json(
+        items.into_iter().map(CharacterResponse::from).collect(),
+    ))
 }
 
 /// GET /api/v1/bodies — list all kart bodies.
@@ -95,9 +161,9 @@ pub async fn list_characters(
 pub async fn list_bodies(
     user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, Error> {
+) -> Result<Json<Vec<BodyResponse>>, Error> {
     let items = bodies::Entity::find().all(&state.db).await?;
-    Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
+    Ok(Json(items.into_iter().map(BodyResponse::from).collect()))
 }
 
 /// GET /api/v1/wheels — list all wheels.
@@ -109,9 +175,9 @@ pub async fn list_bodies(
 pub async fn list_wheels(
     user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, Error> {
+) -> Result<Json<Vec<WheelResponse>>, Error> {
     let items = wheels::Entity::find().all(&state.db).await?;
-    Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
+    Ok(Json(items.into_iter().map(WheelResponse::from).collect()))
 }
 
 /// GET /api/v1/gliders — list all gliders.
@@ -123,9 +189,9 @@ pub async fn list_wheels(
 pub async fn list_gliders(
     user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, Error> {
+) -> Result<Json<Vec<GliderResponse>>, Error> {
     let items = gliders::Entity::find().all(&state.db).await?;
-    Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
+    Ok(Json(items.into_iter().map(GliderResponse::from).collect()))
 }
 
 /// GET /api/v1/cups — list all cups.
@@ -137,9 +203,9 @@ pub async fn list_gliders(
 pub async fn list_cups(
     user: User,
     State(state): State<AppState>,
-) -> Result<Json<Vec<SimpleItem>>, Error> {
+) -> Result<Json<Vec<CupResponse>>, Error> {
     let items = cups::Entity::find().all(&state.db).await?;
-    Ok(Json(items.into_iter().map(SimpleItem::from).collect()))
+    Ok(Json(items.into_iter().map(CupResponse::from).collect()))
 }
 
 /// GET /api/v1/cups/:id — get a cup with its tracks.
@@ -148,11 +214,11 @@ pub async fn list_cups(
 ///
 /// Returns `NotFound` if `id` doesn't match a cup; `Internal` for unexpected
 /// DB failures.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, cup_id = id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, cup_id = %id))]
 pub async fn get_cup(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<i32>,
+    Path(id): Path<CupId>,
 ) -> Result<Json<CupWithTracksResponse>, Error> {
     let cup = cups::Entity::find_by_id(id)
         .one(&state.db)
@@ -168,7 +234,7 @@ pub async fn get_cup(
         .collect();
 
     Ok(Json(CupWithTracksResponse {
-        id: cup.id,
+        id: CupId::new(cup.id),
         name: cup.name,
         image_path: cup.image_path,
         tracks: cup_tracks,
@@ -205,11 +271,11 @@ pub async fn list_tracks(
 ///
 /// Returns `NotFound` if `id` doesn't match a track; `Internal` for
 /// unexpected DB failures.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, track_id = id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, track_id = %id))]
 pub async fn get_track(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<i32>,
+    Path(id): Path<TrackId>,
 ) -> Result<Json<TrackResponse>, Error> {
     let track = tracks::Entity::find_by_id(id)
         .one(&state.db)

--- a/backend/src/routes/runs.rs
+++ b/backend/src/routes/runs.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::{
     AppState,
-    domain::{RunId, SessionRaceId, UserId},
+    domain::{RunId, SessionRaceId, TrackId, UserId},
     error::Error,
     middleware::auth::User,
     services::runs,
@@ -38,9 +38,9 @@ pub async fn create_run(
 
 #[derive(Deserialize)]
 pub struct ListRunsQuery {
-    pub session_race_id: Option<String>,
-    pub user_id: Option<String>,
-    pub track_id: Option<i32>,
+    pub session_race_id: Option<SessionRaceId>,
+    pub user_id: Option<UserId>,
+    pub track_id: Option<TrackId>,
 }
 
 /// GET /runs — list runs with optional filters.
@@ -64,8 +64,8 @@ pub async fn list_runs(
     Query(query): Query<ListRunsQuery>,
 ) -> Result<Json<Vec<runs::RunDetail>>, Error> {
     let filters = runs::RunFilters {
-        session_race_id: query.session_race_id.map(SessionRaceId::new),
-        user_id: query.user_id.map(UserId::new),
+        session_race_id: query.session_race_id,
+        user_id: query.user_id,
         track_id: query.track_id,
     };
     let results = runs::list_runs(&state.db, filters).await?;
@@ -93,13 +93,12 @@ pub async fn get_defaults(
 ///
 /// Propagates the errors of [`runs::get_run`]: `NotFound` if the run doesn't
 /// exist.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, run_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, run_id = %run_id))]
 pub async fn get_run(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(run_id): Path<RunId>,
 ) -> Result<Json<runs::RunDetail>, Error> {
-    let run_id = RunId::new(id);
     let detail = runs::get_run(&state.db, &run_id).await?;
     Ok(Json(detail))
 }
@@ -111,13 +110,12 @@ pub async fn get_run(
 /// Propagates the errors of [`runs::delete_run`]: `NotFound` if the run
 /// doesn't exist, `Forbidden` if the caller is not the run's owner,
 /// `Conflict` if the run's session is closed.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, run_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, run_id = %run_id))]
 pub async fn delete_run(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(run_id): Path<RunId>,
 ) -> Result<impl IntoResponse, Error> {
-    let run_id = RunId::new(id);
     runs::delete_run(&state.db, &run_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -76,13 +76,12 @@ pub async fn list_sessions(
 ///
 /// Propagates the errors of [`sessions::get_session_detail`]: `NotFound` if
 /// the session does not exist.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn get_session(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<Json<sessions::SessionDetail>, Error> {
-    let session_id = SessionId::new(id);
     let detail = sessions::get_session_detail(&state.db, &session_id, Some(&user.user_id)).await?;
     Ok(Json(detail))
 }
@@ -94,13 +93,12 @@ pub async fn get_session(
 /// Propagates the errors of [`sessions::join_session`]: `NotFound` if the
 /// session doesn't exist, `Conflict` if the session is closed or the user is
 /// already in another session.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn join_session(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<impl IntoResponse, Error> {
-    let session_id = SessionId::new(id);
     sessions::join_session(&state.db, &session_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -111,13 +109,12 @@ pub async fn join_session(
 ///
 /// Propagates the errors of [`sessions::leave_session`]: `NotFound` if the
 /// session doesn't exist, `BadRequest` if the user is not currently in it.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn leave_session(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<impl IntoResponse, Error> {
-    let session_id = SessionId::new(id);
     sessions::leave_session(&state.db, &session_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -129,13 +126,12 @@ pub async fn leave_session(
 /// Propagates the errors of [`sessions::next_track`]: `NotFound` if the
 /// session doesn't exist, `Conflict` if it's closed, `Forbidden` if the user
 /// is not an active participant.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn next_track(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), Error> {
-    let session_id = SessionId::new(id);
     let race = sessions::next_track(&state.db, &session_id, &user.user_id).await?;
     Ok((StatusCode::CREATED, Json(race)))
 }
@@ -148,13 +144,12 @@ pub async fn next_track(
 /// session doesn't exist, `Conflict` if it's closed or if runs have already
 /// been submitted for the current race, `BadRequest` if there is no track to
 /// skip.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn skip_turn(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<(StatusCode, Json<sessions::SessionRaceInfo>), Error> {
-    let session_id = SessionId::new(id);
     let race = sessions::skip_turn(&state.db, &session_id, &user.user_id).await?;
     Ok((StatusCode::CREATED, Json(race)))
 }
@@ -175,10 +170,8 @@ pub async fn skip_turn(
 pub async fn skip_pending_race(
     user: User,
     State(state): State<AppState>,
-    Path((session_id, race_id)): Path<(String, String)>,
+    Path((session_id, race_id)): Path<(SessionId, SessionRaceId)>,
 ) -> Result<impl IntoResponse, Error> {
-    let session_id = SessionId::new(session_id);
-    let race_id = SessionRaceId::new(race_id);
     sessions::skip_pending_race(&state.db, &session_id, &race_id, &user.user_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -189,13 +182,12 @@ pub async fn skip_pending_race(
 ///
 /// Propagates the errors of [`sessions::list_races`] — currently only
 /// `Internal` for unexpected DB failures.
-#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %id))]
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, session_id = %session_id))]
 pub async fn list_races(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(session_id): Path<SessionId>,
 ) -> Result<Json<Vec<sessions::RaceInfo>>, Error> {
-    let session_id = SessionId::new(id);
     let races = sessions::list_races(&state.db, &session_id).await?;
     Ok(Json(races))
 }

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -7,7 +7,11 @@ use sea_orm::EntityTrait;
 use serde::Serialize;
 
 use crate::{
-    AppState, domain::UserId, entities::users, error::Error, middleware::auth::User,
+    AppState,
+    domain::{BodyId, CharacterId, DrinkTypeId, GliderId, UserId, WheelId},
+    entities::users,
+    error::Error,
+    middleware::auth::User,
     services::users as user_service,
 };
 
@@ -17,11 +21,11 @@ use crate::{
 pub struct UserPublicProfile {
     pub id: UserId,
     pub username: String,
-    pub preferred_character_id: Option<i32>,
-    pub preferred_body_id: Option<i32>,
-    pub preferred_wheel_id: Option<i32>,
-    pub preferred_glider_id: Option<i32>,
-    pub preferred_drink_type_id: Option<String>,
+    pub preferred_character_id: Option<CharacterId>,
+    pub preferred_body_id: Option<BodyId>,
+    pub preferred_wheel_id: Option<WheelId>,
+    pub preferred_glider_id: Option<GliderId>,
+    pub preferred_drink_type_id: Option<DrinkTypeId>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -41,17 +45,23 @@ pub async fn list_users(
     Ok(Json(
         all_users
             .into_iter()
-            .map(|u| UserPublicProfile {
-                id: UserId::new(u.id),
-                username: u.username,
-                preferred_character_id: u.preferred_character_id,
-                preferred_body_id: u.preferred_body_id,
-                preferred_wheel_id: u.preferred_wheel_id,
-                preferred_glider_id: u.preferred_glider_id,
-                preferred_drink_type_id: u.preferred_drink_type_id,
-                created_at: u.created_at.and_utc(),
+            .map(|u| {
+                Ok::<_, Error>(UserPublicProfile {
+                    id: UserId::from_db(&u.id)?,
+                    username: u.username,
+                    preferred_character_id: u.preferred_character_id.map(CharacterId::new),
+                    preferred_body_id: u.preferred_body_id.map(BodyId::new),
+                    preferred_wheel_id: u.preferred_wheel_id.map(WheelId::new),
+                    preferred_glider_id: u.preferred_glider_id.map(GliderId::new),
+                    preferred_drink_type_id: u
+                        .preferred_drink_type_id
+                        .as_deref()
+                        .map(DrinkTypeId::from_db)
+                        .transpose()?,
+                    created_at: u.created_at.and_utc(),
+                })
             })
-            .collect(),
+            .collect::<Result<Vec<_>, _>>()?,
     ))
 }
 
@@ -65,9 +75,9 @@ pub async fn list_users(
 pub async fn get_user(
     user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id): Path<UserId>,
 ) -> Result<Json<user_service::UserDetailProfile>, Error> {
-    let user = users::Entity::find_by_id(&id)
+    let user = users::Entity::find_by_id(id)
         .one(&state.db)
         .await?
         .ok_or_else(|| Error::NotFound(format!("User {id} not found")))?;
@@ -85,15 +95,14 @@ pub async fn get_user(
 /// doesn't exist, `BadRequest` for invalid race-setup or drink-type IDs.
 #[tracing::instrument(
     skip_all,
-    fields(user_id = %auth_user.user_id, target_user_id = %id),
+    fields(user_id = %auth_user.user_id, target_user_id = %target_user_id),
 )]
 pub async fn update_user(
     auth_user: User,
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(target_user_id): Path<UserId>,
     Json(req): Json<user_service::UpdateProfileRequest>,
 ) -> Result<Json<user_service::UserDetailProfile>, Error> {
-    let target_user_id = UserId::new(id);
     let profile =
         user_service::update_profile(&state.db, &auth_user.user_id, &target_user_id, req).await?;
     Ok(Json(profile))

--- a/backend/src/seed.rs
+++ b/backend/src/seed.rs
@@ -213,7 +213,7 @@ async fn seed_drink_types(db: &DatabaseConnection) -> anyhow::Result<()> {
         let id = drink_type_uuid(&item.name);
         // `created_at` is populated by `drink_types::ActiveModelBehavior::before_save`.
         let model = drink_types::ActiveModel {
-            id: Set(id),
+            id: Set((&id).into()),
             name: Set(item.name),
             alcoholic: Set(item.alcoholic),
             created_at: NotSet,

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -7,7 +7,7 @@ use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode}
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
-use crate::{config::Config, error::Error};
+use crate::{config::Config, domain::UserId, error::Error};
 
 /// Claims for short-lived access tokens (sent in response body, stored in JS memory).
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,7 +112,7 @@ pub async fn verify_password(
 /// Returns `jsonwebtoken::errors::Error` if HMAC signing fails — in practice
 /// only possible if `config.jwt_secret` is empty or otherwise unusable.
 pub fn create_access_token(
-    user_id: &str,
+    user_id: &UserId,
     username: &str,
     config: &Config,
 ) -> Result<String, jsonwebtoken::errors::Error> {
@@ -120,7 +120,7 @@ pub fn create_access_token(
     let expiry = now + TimeDelta::minutes(config.jwt_access_expiry_minutes);
 
     let claims = AccessClaims {
-        sub: user_id.to_string(),
+        sub: user_id.into(),
         username: username.to_string(),
         exp: expiry.timestamp(),
         iat: now.timestamp(),
@@ -141,7 +141,7 @@ pub fn create_access_token(
 /// Returns `jsonwebtoken::errors::Error` if HMAC signing fails — in practice
 /// only possible if `config.jwt_secret` is empty or otherwise unusable.
 pub fn create_refresh_token(
-    user_id: &str,
+    user_id: &UserId,
     refresh_token_version: i32,
     config: &Config,
 ) -> Result<String, jsonwebtoken::errors::Error> {
@@ -149,7 +149,7 @@ pub fn create_refresh_token(
     let expiry = now + TimeDelta::days(config.jwt_refresh_expiry_days);
 
     let claims = RefreshClaims {
-        sub: user_id.to_string(),
+        sub: user_id.into(),
         refresh_token_version,
         exp: expiry.timestamp(),
         iat: now.timestamp(),
@@ -224,6 +224,8 @@ mod tests {
         },
         time::{Duration, Instant},
     };
+
+    use uuid::Uuid;
 
     use super::*;
     use crate::ARGON2_MAX_CONCURRENT;
@@ -371,10 +373,11 @@ mod tests {
     #[test]
     fn test_create_and_validate_access_token() {
         let config = test_config();
-        let token = create_access_token("user-123", "testuser", &config).unwrap();
+        let user_id = UserId::new(Uuid::new_v4());
+        let token = create_access_token(&user_id, "testuser", &config).unwrap();
         let claims = validate_access_token(&token, &config).unwrap();
 
-        assert_eq!(claims.sub, "user-123");
+        assert_eq!(claims.sub, user_id.as_ref().to_string());
         assert_eq!(claims.username, "testuser");
         assert_eq!(claims.token_type, "access");
         assert!(claims.exp > claims.iat);
@@ -383,10 +386,11 @@ mod tests {
     #[test]
     fn test_create_and_validate_refresh_token() {
         let config = test_config();
-        let token = create_refresh_token("user-123", 0, &config).unwrap();
+        let user_id = UserId::new(Uuid::new_v4());
+        let token = create_refresh_token(&user_id, 0, &config).unwrap();
         let claims = validate_refresh_token(&token, &config).unwrap();
 
-        assert_eq!(claims.sub, "user-123");
+        assert_eq!(claims.sub, user_id.as_ref().to_string());
         assert_eq!(claims.refresh_token_version, 0);
         assert_eq!(claims.token_type, "refresh");
         assert!(claims.exp > claims.iat);
@@ -395,7 +399,8 @@ mod tests {
     #[test]
     fn test_validate_access_token_with_wrong_secret() {
         let config = test_config();
-        let token = create_access_token("user-123", "testuser", &config).unwrap();
+        let user_id = UserId::new(Uuid::new_v4());
+        let token = create_access_token(&user_id, "testuser", &config).unwrap();
 
         let wrong_config = Arc::new(Config {
             jwt_secret: "wrong-secret".to_string(),
@@ -431,7 +436,8 @@ mod tests {
             max_request_body_bytes: 10 * 1024 * 1024,
             rate_limit_per_minute: 60,
         });
-        let token = create_access_token("user-1", "alice", &config).unwrap();
+        let user_id = UserId::new(Uuid::new_v4());
+        let token = create_access_token(&user_id, "alice", &config).unwrap();
         let claims = validate_access_token(&token, &config).unwrap();
 
         let duration_secs = claims.exp - claims.iat;

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -121,7 +121,7 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
     let rows = present
         .into_iter()
         .map(|p| session_race_participations::ActiveModel {
-            session_race_id: Set(session_race_id.as_str().to_string()),
+            session_race_id: Set(session_race_id.into()),
             user_id: Set(p.user_id),
             created_at: Set(now),
             skipped_at: Set(None),
@@ -262,14 +262,14 @@ mod tests {
         let session_id = insert_session(&db, &host, "active").await;
 
         let model = load_active_session(&db, &session_id).await.unwrap();
-        assert_eq!(model.id, session_id.as_str());
+        assert_eq!(model.id, session_id.to_string());
         assert_eq!(model.status, "active");
     }
 
     #[tokio::test]
     async fn load_active_session_missing_is_not_found() {
         let db = setup_db().await;
-        let err = load_active_session(&db, &SessionId::new("does-not-exist"))
+        let err = load_active_session(&db, &SessionId::new_v4())
             .await
             .unwrap_err();
         assert!(matches!(err, Error::NotFound(_)));
@@ -297,7 +297,7 @@ mod tests {
         let row = require_active_participant(&db, &session_id, &user)
             .await
             .unwrap();
-        assert_eq!(row.user_id, user.as_str());
+        assert_eq!(row.user_id, user.to_string());
         assert!(row.left_at.is_none());
     }
 
@@ -334,7 +334,7 @@ mod tests {
         let host = create_user(&db, "host").await;
         let session_id = insert_session(&db, &host, "active").await;
 
-        let before = sessions::Entity::find_by_id(&session_id)
+        let before = sessions::Entity::find_by_id(session_id)
             .one(&db)
             .await
             .unwrap()
@@ -348,7 +348,7 @@ mod tests {
 
         touch_session(&db, &session_id).await.unwrap();
 
-        let after = sessions::Entity::find_by_id(&session_id)
+        let after = sessions::Entity::find_by_id(session_id)
             .one(&db)
             .await
             .unwrap()
@@ -492,7 +492,7 @@ mod tests {
             .expect("snapshot succeeds");
 
         let rows = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::SessionRaceId.eq(&race_id))
+            .filter(session_race_participations::Column::SessionRaceId.eq(race_id))
             .all(&db)
             .await
             .unwrap();
@@ -501,12 +501,12 @@ mod tests {
             2,
             "only the two left_at IS NULL users are snapshotted"
         );
-        let users: std::collections::HashSet<&str> =
-            rows.iter().map(|r| r.user_id.as_str()).collect();
-        assert!(users.contains(host.as_str()));
-        assert!(users.contains(active.as_str()));
+        let users: std::collections::HashSet<String> =
+            rows.iter().map(|r| r.user_id.clone()).collect();
+        assert!(users.contains(&host.to_string()));
+        assert!(users.contains(&active.to_string()));
         assert!(
-            !users.contains(left.as_str()),
+            !users.contains(&left.to_string()),
             "user with left_at set must not be snapshotted"
         );
     }
@@ -532,7 +532,7 @@ mod tests {
             .expect("empty snapshot must not error");
 
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::SessionRaceId.eq(&race_id))
+            .filter(session_race_participations::Column::SessionRaceId.eq(race_id))
             .count(&db)
             .await
             .unwrap();

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -157,13 +157,15 @@ pub async fn touch_session<C: ConnectionTrait>(
 /// Assert that a row with the given primary key exists in entity `E`.
 ///
 /// The generic bounds mirror `EntityTrait::find_by_id` — the primary key's
-/// `ValueType` is what the caller must pass in.
+/// `ValueType` is what the caller must pass in. The PK value is also surfaced
+/// on the span (parked in PR #144 review until the newtype-Display landed in
+/// PR-D1 / #122 made this caller-churn-free).
 ///
 /// # Errors
 ///
 /// Returns `BadRequest` with a formatted message on miss (e.g., "Invalid
 /// `character_id`"); `Internal` for unexpected DB failures.
-#[tracing::instrument(level = "debug", skip(db, id), fields(entity = %entity_label))]
+#[tracing::instrument(level = "debug", skip(db, id), fields(entity = %entity_label, id = %id))]
 pub async fn require_exists<E, C>(
     db: &C,
     id: <<E as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType,
@@ -172,6 +174,7 @@ pub async fn require_exists<E, C>(
 where
     E: EntityTrait,
     C: ConnectionTrait,
+    <<E as EntityTrait>::PrimaryKey as PrimaryKeyTrait>::ValueType: std::fmt::Display,
 {
     if E::find_by_id(id).one(db).await?.is_none() {
         return Err(Error::bad_request(format!("Invalid {entity_label}_id")));

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -449,7 +449,13 @@ pub async fn delete_run(
         .await?
         .ok_or_else(|| Error::NotFound("Run not found".to_string()))?;
 
-    if run.user_id != user_id.to_string() {
+    // Lift the entity-layer `String` to a typed `UserId` and compare in the
+    // domain. Stays consistent with `session_context.rs::require_host` and
+    // surfaces a corrupt-UUID-in-DB as 500 instead of a silent false-negative
+    // compare (FK-protected so it should never fire, but the failure mode is
+    // worth surfacing if it ever does).
+    let owner = UserId::from_db(&run.user_id)?;
+    if owner != *user_id {
         return Err(Error::Forbidden(
             "Only the run's owner can delete it".to_string(),
         ));

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -5,10 +5,12 @@ use sea_orm::{
     TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::{
-    domain::{RunId, SessionId, SessionRaceId, UserId},
+    domain::{
+        BodyId, CharacterId, DrinkTypeId, GliderId, RunId, SessionId, SessionRaceId, TrackId,
+        UserId, WheelId,
+    },
     entities::{
         bodies, characters, drink_types, gliders, runs, session_race_participations, session_races,
         users, wheels,
@@ -22,16 +24,16 @@ const MAX_TRACK_TIME_MS: i32 = 600_000;
 
 #[derive(Deserialize)]
 pub struct CreateRunRequest {
-    pub session_race_id: String,
+    pub session_race_id: SessionRaceId,
     pub track_time: i32,
     pub lap1_time: i32,
     pub lap2_time: i32,
     pub lap3_time: i32,
-    pub character_id: i32,
-    pub body_id: i32,
-    pub wheel_id: i32,
-    pub glider_id: i32,
-    pub drink_type_id: String,
+    pub character_id: CharacterId,
+    pub body_id: BodyId,
+    pub wheel_id: WheelId,
+    pub glider_id: GliderId,
+    pub drink_type_id: DrinkTypeId,
     pub disqualified: bool,
 }
 
@@ -41,16 +43,16 @@ pub struct RunDetail {
     pub user_id: UserId,
     pub username: String,
     pub session_race_id: SessionRaceId,
-    pub track_id: i32,
+    pub track_id: TrackId,
     pub track_time: i32,
     pub lap1_time: i32,
     pub lap2_time: i32,
     pub lap3_time: i32,
-    pub character_id: i32,
-    pub body_id: i32,
-    pub wheel_id: i32,
-    pub glider_id: i32,
-    pub drink_type_id: String,
+    pub character_id: CharacterId,
+    pub body_id: BodyId,
+    pub wheel_id: WheelId,
+    pub glider_id: GliderId,
+    pub drink_type_id: DrinkTypeId,
     pub drink_type_name: String,
     pub disqualified: bool,
     pub created_at: DateTime<Utc>,
@@ -78,44 +80,47 @@ struct RunDetailRow {
     created_at: NaiveDateTime,
 }
 
-impl From<RunDetailRow> for RunDetail {
-    fn from(r: RunDetailRow) -> Self {
-        Self {
-            id: RunId::new(r.id),
-            user_id: UserId::new(r.user_id),
-            username: r.username,
-            session_race_id: SessionRaceId::new(r.session_race_id),
-            track_id: r.track_id,
-            track_time: r.track_time,
-            lap1_time: r.lap1_time,
-            lap2_time: r.lap2_time,
-            lap3_time: r.lap3_time,
-            character_id: r.character_id,
-            body_id: r.body_id,
-            wheel_id: r.wheel_id,
-            glider_id: r.glider_id,
-            drink_type_id: r.drink_type_id,
-            drink_type_name: r.drink_type_name,
-            disqualified: r.disqualified,
-            created_at: r.created_at.and_utc(),
-        }
+impl RunDetailRow {
+    /// Parse a row into a typed [`RunDetail`]. Fallible because every UUID
+    /// column has to round-trip through `from_db`; an invalid UUID in any of
+    /// those columns is data corruption and surfaces as `Internal`.
+    fn try_into_detail(self) -> Result<RunDetail, Error> {
+        Ok(RunDetail {
+            id: RunId::from_db(&self.id)?,
+            user_id: UserId::from_db(&self.user_id)?,
+            username: self.username,
+            session_race_id: SessionRaceId::from_db(&self.session_race_id)?,
+            track_id: TrackId::new(self.track_id),
+            track_time: self.track_time,
+            lap1_time: self.lap1_time,
+            lap2_time: self.lap2_time,
+            lap3_time: self.lap3_time,
+            character_id: CharacterId::new(self.character_id),
+            body_id: BodyId::new(self.body_id),
+            wheel_id: WheelId::new(self.wheel_id),
+            glider_id: GliderId::new(self.glider_id),
+            drink_type_id: DrinkTypeId::from_db(&self.drink_type_id)?,
+            drink_type_name: self.drink_type_name,
+            disqualified: self.disqualified,
+            created_at: self.created_at.and_utc(),
+        })
     }
 }
 
 #[derive(Serialize)]
 pub struct RunDefaults {
-    pub drink_type_id: Option<String>,
-    pub character_id: Option<i32>,
-    pub body_id: Option<i32>,
-    pub wheel_id: Option<i32>,
-    pub glider_id: Option<i32>,
+    pub drink_type_id: Option<DrinkTypeId>,
+    pub character_id: Option<CharacterId>,
+    pub body_id: Option<BodyId>,
+    pub wheel_id: Option<WheelId>,
+    pub glider_id: Option<GliderId>,
     pub source: String,
 }
 
 pub struct RunFilters {
     pub session_race_id: Option<SessionRaceId>,
     pub user_id: Option<UserId>,
-    pub track_id: Option<i32>,
+    pub track_id: Option<TrackId>,
 }
 
 /// Validate time fields on a run submission: `track_time` range, lap times
@@ -193,12 +198,12 @@ async fn validate_run_request(
 ) -> Result<session_races::Model, Error> {
     validate_time_fields(body)?;
 
-    let session_race = session_races::Entity::find_by_id(&body.session_race_id)
+    let session_race = session_races::Entity::find_by_id(body.session_race_id)
         .one(db)
         .await?
         .ok_or_else(|| Error::NotFound("Session race not found".to_string()))?;
 
-    let session_id = SessionId::new(session_race.session_id.clone());
+    let session_id = SessionId::from_db(&session_race.session_id)?;
     helpers::load_active_session(db, &session_id)
         .await
         .map_err(|e| match e {
@@ -211,7 +216,7 @@ async fn validate_run_request(
     let existing = runs::Entity::find()
         .filter(
             Condition::all()
-                .add(runs::Column::SessionRaceId.eq(&body.session_race_id))
+                .add(runs::Column::SessionRaceId.eq(body.session_race_id))
                 .add(runs::Column::UserId.eq(user_id)),
         )
         .one(db)
@@ -229,7 +234,7 @@ async fn validate_run_request(
     let participation = session_race_participations::Entity::find()
         .filter(
             Condition::all()
-                .add(session_race_participations::Column::SessionRaceId.eq(&body.session_race_id))
+                .add(session_race_participations::Column::SessionRaceId.eq(body.session_race_id))
                 .add(session_race_participations::Column::UserId.eq(user_id)),
         )
         .one(db)
@@ -266,12 +271,17 @@ async fn validate_run_request(
     }
 
     // Validate FK references exist
-    helpers::require_exists::<characters::Entity, _>(db, body.character_id, "character").await?;
-    helpers::require_exists::<bodies::Entity, _>(db, body.body_id, "body").await?;
-    helpers::require_exists::<wheels::Entity, _>(db, body.wheel_id, "wheel").await?;
-    helpers::require_exists::<gliders::Entity, _>(db, body.glider_id, "glider").await?;
-    helpers::require_exists::<drink_types::Entity, _>(db, body.drink_type_id.clone(), "drink_type")
+    helpers::require_exists::<characters::Entity, _>(db, body.character_id.into(), "character")
         .await?;
+    helpers::require_exists::<bodies::Entity, _>(db, body.body_id.into(), "body").await?;
+    helpers::require_exists::<wheels::Entity, _>(db, body.wheel_id.into(), "wheel").await?;
+    helpers::require_exists::<gliders::Entity, _>(db, body.glider_id.into(), "glider").await?;
+    helpers::require_exists::<drink_types::Entity, _>(
+        db,
+        (&body.drink_type_id).into(),
+        "drink_type",
+    )
+    .await?;
 
     Ok(session_race)
 }
@@ -285,24 +295,24 @@ async fn insert_run(
     body: CreateRunRequest,
     session_race: &session_races::Model,
 ) -> Result<RunId, Error> {
-    let run_id = RunId::new(Uuid::new_v4().to_string());
+    let run_id = RunId::new_v4();
 
     let txn = db.begin().await?;
 
     runs::ActiveModel {
-        id: Set(run_id.as_str().to_string()),
-        user_id: Set(user_id.as_str().to_string()),
-        session_race_id: Set(body.session_race_id),
+        id: Set((&run_id).into()),
+        user_id: Set(user_id.into()),
+        session_race_id: Set((&body.session_race_id).into()),
         track_id: Set(session_race.track_id),
-        character_id: Set(body.character_id),
-        body_id: Set(body.body_id),
-        wheel_id: Set(body.wheel_id),
-        glider_id: Set(body.glider_id),
+        character_id: Set(body.character_id.into()),
+        body_id: Set(body.body_id.into()),
+        wheel_id: Set(body.wheel_id.into()),
+        glider_id: Set(body.glider_id.into()),
         track_time: Set(body.track_time),
         lap1_time: Set(body.lap1_time),
         lap2_time: Set(body.lap2_time),
         lap3_time: Set(body.lap3_time),
-        drink_type_id: Set(body.drink_type_id),
+        drink_type_id: Set((&body.drink_type_id).into()),
         disqualified: Set(body.disqualified),
         photo_path: Set(None),
         created_at: NotSet,
@@ -311,7 +321,7 @@ async fn insert_run(
     .insert(&txn)
     .await?;
 
-    let session_id = SessionId::new(session_race.session_id.clone());
+    let session_id = SessionId::from_db(&session_race.session_id)?;
     helpers::touch_session(&txn, &session_id).await?;
 
     txn.commit().await?;
@@ -346,7 +356,7 @@ pub async fn get_run(db: &impl ConnectionTrait, run_id: &RunId) -> Result<RunDet
     .await?
     .ok_or_else(|| Error::NotFound("Run not found".to_string()))?;
 
-    Ok(row.into())
+    row.try_into_detail()
 }
 
 /// List runs with optional filters, ordered by `track_time` ASC.
@@ -375,11 +385,11 @@ pub async fn list_runs(
         params.push(value);
     };
 
-    if let Some(ref sr_id) = filters.session_race_id {
-        add_filter("r.session_race_id", sr_id.clone().into());
+    if let Some(sr_id) = filters.session_race_id {
+        add_filter("r.session_race_id", sr_id.into());
     }
-    if let Some(ref uid) = filters.user_id {
-        add_filter("r.user_id", uid.clone().into());
+    if let Some(uid) = filters.user_id {
+        add_filter("r.user_id", uid.into());
     }
     if let Some(tid) = filters.track_id {
         add_filter("r.track_id", tid.into());
@@ -415,7 +425,9 @@ pub async fn list_runs(
     .all(db)
     .await?;
 
-    Ok(rows.into_iter().map(RunDetail::from).collect())
+    rows.into_iter()
+        .map(RunDetailRow::try_into_detail)
+        .collect()
 }
 
 /// Delete a run. Only the run's owner can delete, and the session must be active.
@@ -437,7 +449,7 @@ pub async fn delete_run(
         .await?
         .ok_or_else(|| Error::NotFound("Run not found".to_string()))?;
 
-    if run.user_id.as_str() != user_id.as_str() {
+    if run.user_id != user_id.to_string() {
         return Err(Error::Forbidden(
             "Only the run's owner can delete it".to_string(),
         ));
@@ -449,7 +461,7 @@ pub async fn delete_run(
         .await?
         .ok_or_else(|| Error::Internal(anyhow::anyhow!("Session race not found for run")))?;
 
-    let session_id = SessionId::new(session_race.session_id.clone());
+    let session_id = SessionId::from_db(&session_race.session_id)?;
     // FK guarantees the session exists; NotFound here signals data corruption.
     helpers::load_active_session(db, &session_id)
         .await
@@ -493,11 +505,11 @@ pub async fn get_run_defaults(
 
     if let Some(run) = latest_run {
         return Ok(RunDefaults {
-            drink_type_id: Some(run.drink_type_id),
-            character_id: Some(run.character_id),
-            body_id: Some(run.body_id),
-            wheel_id: Some(run.wheel_id),
-            glider_id: Some(run.glider_id),
+            drink_type_id: Some(DrinkTypeId::from_db(&run.drink_type_id)?),
+            character_id: Some(CharacterId::new(run.character_id)),
+            body_id: Some(BodyId::new(run.body_id)),
+            wheel_id: Some(WheelId::new(run.wheel_id)),
+            glider_id: Some(GliderId::new(run.glider_id)),
             source: "previous_run".to_string(),
         });
     }
@@ -510,11 +522,15 @@ pub async fn get_run_defaults(
 
     if user.preferred_character_id.is_some() || user.preferred_drink_type_id.is_some() {
         return Ok(RunDefaults {
-            drink_type_id: user.preferred_drink_type_id,
-            character_id: user.preferred_character_id,
-            body_id: user.preferred_body_id,
-            wheel_id: user.preferred_wheel_id,
-            glider_id: user.preferred_glider_id,
+            drink_type_id: user
+                .preferred_drink_type_id
+                .as_deref()
+                .map(DrinkTypeId::from_db)
+                .transpose()?,
+            character_id: user.preferred_character_id.map(CharacterId::new),
+            body_id: user.preferred_body_id.map(BodyId::new),
+            wheel_id: user.preferred_wheel_id.map(WheelId::new),
+            glider_id: user.preferred_glider_id.map(GliderId::new),
             source: "preferences".to_string(),
         });
     }
@@ -538,7 +554,7 @@ mod tests {
         test_helpers::{create_user, seed_game_data, setup_db},
     };
 
-    fn test_drink_id() -> String {
+    fn test_drink_id() -> DrinkTypeId {
         crate::drink_type_id::drink_type_uuid("Test Beer")
     }
 
@@ -546,16 +562,16 @@ mod tests {
 
     fn valid_time_request() -> CreateRunRequest {
         CreateRunRequest {
-            session_race_id: String::new(),
+            session_race_id: SessionRaceId::new_v4(),
             track_time: 120_000,
             lap1_time: 40_000,
             lap2_time: 39_000,
             lap3_time: 41_000,
-            character_id: 1,
-            body_id: 1,
-            wheel_id: 1,
-            glider_id: 1,
-            drink_type_id: String::new(),
+            character_id: CharacterId::new(1),
+            body_id: BodyId::new(1),
+            wheel_id: WheelId::new(1),
+            glider_id: GliderId::new(1),
+            drink_type_id: DrinkTypeId::new_v4(),
             disqualified: false,
         }
     }
@@ -622,15 +638,15 @@ mod tests {
 
     fn valid_run_request(session_race_id: &SessionRaceId) -> CreateRunRequest {
         CreateRunRequest {
-            session_race_id: session_race_id.as_str().to_string(),
+            session_race_id: *session_race_id,
             track_time: 120_000,
             lap1_time: 40_000,
             lap2_time: 39_000,
             lap3_time: 41_000,
-            character_id: 1,
-            body_id: 1,
-            wheel_id: 1,
-            glider_id: 1,
+            character_id: CharacterId::new(1),
+            body_id: BodyId::new(1),
+            wheel_id: WheelId::new(1),
+            glider_id: GliderId::new(1),
             drink_type_id: test_drink_id(),
             disqualified: false,
         }
@@ -661,7 +677,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(run.user_id.as_str(), host_id.as_str());
+        assert_eq!(run.user_id, host_id);
         assert_eq!(run.track_time, 120_000);
         assert_eq!(run.lap1_time, 40_000);
         assert_eq!(run.username, "host");
@@ -767,7 +783,7 @@ mod tests {
         let (_, race_id) = setup_session_with_race(&db, &host_id).await;
 
         let mut req = valid_run_request(&race_id);
-        req.character_id = 999;
+        req.character_id = CharacterId::new(999);
         assert!(create_run(&db, &host_id, req).await.is_err());
     }
 
@@ -779,7 +795,9 @@ mod tests {
         let (_, race_id) = setup_session_with_race(&db, &host_id).await;
 
         let mut req = valid_run_request(&race_id);
-        req.drink_type_id = "nonexistent-uuid".to_string();
+        // Valid UUID shape but no matching row — exercises the FK check, not
+        // the type-level parse (which a non-UUID string would short-circuit).
+        req.drink_type_id = DrinkTypeId::new_v4();
         assert!(create_run(&db, &host_id, req).await.is_err());
     }
 
@@ -841,7 +859,7 @@ mod tests {
             .ok();
 
         // Force-close in case leave order was wrong
-        let s = sessions_entity::Entity::find_by_id(&session_id)
+        let s = sessions_entity::Entity::find_by_id(session_id)
             .one(&db)
             .await
             .unwrap();
@@ -945,7 +963,7 @@ mod tests {
 
         let defaults = get_run_defaults(&db, &host_id).await.unwrap();
         assert_eq!(defaults.source, "previous_run");
-        assert_eq!(defaults.character_id, Some(1));
+        assert_eq!(defaults.character_id, Some(CharacterId::new(1)));
         assert_eq!(defaults.drink_type_id, Some(test_drink_id()));
     }
 
@@ -956,7 +974,7 @@ mod tests {
         let host_id = create_user(&db, "host").await;
 
         // Set preferences on the user
-        let user = users::Entity::find_by_id(&host_id)
+        let user = users::Entity::find_by_id(host_id)
             .one(&db)
             .await
             .unwrap()
@@ -966,12 +984,12 @@ mod tests {
         active.preferred_body_id = Set(Some(1));
         active.preferred_wheel_id = Set(Some(1));
         active.preferred_glider_id = Set(Some(1));
-        active.preferred_drink_type_id = Set(Some(test_drink_id()));
+        active.preferred_drink_type_id = Set(Some(test_drink_id().into()));
         active.update(&db).await.unwrap();
 
         let defaults = get_run_defaults(&db, &host_id).await.unwrap();
         assert_eq!(defaults.source, "preferences");
-        assert_eq!(defaults.character_id, Some(1));
+        assert_eq!(defaults.character_id, Some(CharacterId::new(1)));
     }
 
     #[tokio::test]

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -13,16 +13,19 @@ use crate::{
     services::helpers,
 };
 
-/// A loaded session plus its ID in typed form.
+/// A loaded session plus its IDs in typed form.
 ///
-/// `session_id` mirrors `session.id` as a typed `SessionId` so the helper
-/// methods can borrow `&self.session_id` instead of allocating a fresh wrapper
-/// on every call. Both fields hold the same UUID; the typed copy is the one
-/// callers borrow when they need a `&SessionId`.
+/// `session_id` mirrors `session.id` and `host_id` mirrors `session.host_id`
+/// — both parsed once in [`load_active`](SessionContext::load_active) so
+/// helper methods can borrow them instead of reparsing on every call. The
+/// entity-side `String` fields stay authoritative for serialization; the
+/// typed copies are what callers reach for when they need a `&SessionId` /
+/// `&UserId`.
 #[derive(Debug, Clone)]
 pub struct SessionContext {
     pub session: sessions::Model,
     pub session_id: SessionId,
+    pub host_id: UserId,
 }
 
 impl SessionContext {
@@ -32,6 +35,9 @@ impl SessionContext {
     ///
     /// Propagates the errors of [`helpers::load_active_session`]: `NotFound`
     /// if the session doesn't exist, `Conflict` if it's not active.
+    /// Returns `Internal` if the stored `session.id` or `session.host_id` is
+    /// not a valid UUID — both are FK-protected, so this only fires on data
+    /// corruption.
     #[tracing::instrument(level = "debug", skip(db), fields(session_id = %session_id))]
     pub async fn load_active<C: ConnectionTrait>(
         db: &C,
@@ -39,9 +45,11 @@ impl SessionContext {
     ) -> Result<Self, Error> {
         let session = helpers::load_active_session(db, session_id).await?;
         let session_id = SessionId::from_db(&session.id)?;
+        let host_id = UserId::from_db(&session.host_id)?;
         Ok(Self {
             session,
             session_id,
+            host_id,
         })
     }
 
@@ -51,8 +59,7 @@ impl SessionContext {
     ///
     /// Returns `Forbidden` if `user_id` is not the host.
     pub fn require_host(&self, user_id: &UserId) -> Result<(), Error> {
-        let host_id = UserId::from_db(&self.session.host_id)?;
-        if host_id != *user_id {
+        if self.host_id != *user_id {
             return Err(Error::Forbidden("Only the host can do that".into()));
         }
         Ok(())

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -38,7 +38,7 @@ impl SessionContext {
         session_id: &SessionId,
     ) -> Result<Self, Error> {
         let session = helpers::load_active_session(db, session_id).await?;
-        let session_id = SessionId::new(session.id.clone());
+        let session_id = SessionId::from_db(&session.id)?;
         Ok(Self {
             session,
             session_id,
@@ -51,7 +51,8 @@ impl SessionContext {
     ///
     /// Returns `Forbidden` if `user_id` is not the host.
     pub fn require_host(&self, user_id: &UserId) -> Result<(), Error> {
-        if self.session.host_id.as_str() != user_id.as_str() {
+        let host_id = UserId::from_db(&self.session.host_id)?;
+        if host_id != *user_id {
             return Err(Error::Forbidden("Only the host can do that".into()));
         }
         Ok(())
@@ -111,14 +112,14 @@ mod tests {
         let session_id = insert_session(&db, &host, "active").await;
 
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
-        assert_eq!(ctx.session.id, session_id.as_str());
-        assert_eq!(ctx.session.host_id, host.as_str());
+        assert_eq!(ctx.session.id, session_id.to_string());
+        assert_eq!(ctx.session.host_id, host.to_string());
     }
 
     #[tokio::test]
     async fn load_active_missing_propagates_not_found() {
         let db = setup_db().await;
-        let err = SessionContext::load_active(&db, &SessionId::new("missing"))
+        let err = SessionContext::load_active(&db, &SessionId::new_v4())
             .await
             .unwrap_err();
         assert!(matches!(err, Error::NotFound(_)));
@@ -168,7 +169,7 @@ mod tests {
 
         // Happy path: host is a participant.
         let row = ctx.require_participant(&db, &host).await.unwrap();
-        assert_eq!(row.user_id, host.as_str());
+        assert_eq!(row.user_id, host.to_string());
 
         // Forbidden path: another user isn't.
         let outsider = create_user(&db, "outsider").await;
@@ -195,7 +196,7 @@ mod tests {
         );
 
         // DB is also updated.
-        let db_value = sessions::Entity::find_by_id(&session_id)
+        let db_value = sessions::Entity::find_by_id(session_id)
             .one(&db)
             .await
             .unwrap()

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -86,7 +86,7 @@ pub async fn get_active_session_id(
     .one(db)
     .await?;
 
-    Ok(row.map(|r| SessionId::new(r.session_id)))
+    row.map(|r| SessionId::from_db(&r.session_id)).transpose()
 }
 
 /// Create a new session. The creator becomes both the host and the first
@@ -112,13 +112,13 @@ pub async fn create_session(
     // capture `now` here and stamp them by hand. `sessions.created_at` is
     // populated by `ActiveModelBehavior::before_save`.
     let now = Utc::now().naive_utc();
-    let session_id = SessionId::new(Uuid::new_v4().to_string());
+    let session_id = SessionId::new_v4();
 
     let txn = db.begin().await?;
 
     sessions::ActiveModel {
-        id: Set(session_id.as_str().to_string()),
-        host_id: Set(user_id.as_str().to_string()),
+        id: Set(session_id.into()),
+        host_id: Set(user_id.into()),
         ruleset: Set(parsed.to_string()),
         least_played_drink_category: Set(None),
         status: Set(SessionStatus::Active.to_string()),
@@ -130,8 +130,8 @@ pub async fn create_session(
 
     session_participants::ActiveModel {
         id: Set(Uuid::new_v4().to_string()),
-        session_id: Set(session_id.as_str().to_string()),
-        user_id: Set(user_id.as_str().to_string()),
+        session_id: Set(session_id.into()),
+        user_id: Set(user_id.into()),
         joined_at: Set(now),
         left_at: Set(None),
     }
@@ -196,17 +196,18 @@ pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<Sessi
     .all(db)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| SessionSummary {
-            id: SessionId::new(r.id),
-            host_username: r.host_username,
-            participant_count: r.participant_count,
-            race_number: r.race_count.max(1),
-            ruleset: r.ruleset,
-            last_activity_at: r.last_activity_at.and_utc(),
+    rows.into_iter()
+        .map(|r| {
+            Ok(SessionSummary {
+                id: SessionId::from_db(&r.id)?,
+                host_username: r.host_username,
+                participant_count: r.participant_count,
+                race_number: r.race_count.max(1),
+                ruleset: r.ruleset,
+                last_activity_at: r.last_activity_at.and_utc(),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// Participant info for the detail response.
@@ -348,15 +349,16 @@ async fn load_participants(
     .all(db)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| ParticipantInfo {
-            user_id: UserId::new(r.user_id),
-            username: r.username,
-            joined_at: r.joined_at.and_utc(),
-            left_at: r.left_at.map(|t| t.and_utc()),
+    rows.into_iter()
+        .map(|r| {
+            Ok(ParticipantInfo {
+                user_id: UserId::from_db(&r.user_id)?,
+                username: r.username,
+                joined_at: r.joined_at.and_utc(),
+                left_at: r.left_at.map(|t| t.and_utc()),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// Fetch the most recent race with its submissions. Returns `None` if
@@ -387,30 +389,33 @@ async fn load_current_race_with_submissions(
         return Ok(None);
     };
 
-    let submissions = SubmissionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
-        db.get_database_backend(),
-        r#"
-        SELECT r.user_id, u.username, r.track_time, r.disqualified
-        FROM runs r
-        JOIN users u ON r.user_id = u.id
-        WHERE r.session_race_id = $1
-        ORDER BY r.track_time ASC
-        "#,
-        [row.id.clone().into()],
-    ))
-    .all(db)
-    .await?
-    .into_iter()
-    .map(|s| RaceSubmission {
-        user_id: UserId::new(s.user_id),
-        username: s.username,
-        track_time: s.track_time,
-        disqualified: s.disqualified,
-    })
-    .collect();
+    let submissions: Vec<RaceSubmission> =
+        SubmissionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            db.get_database_backend(),
+            r#"
+            SELECT r.user_id, u.username, r.track_time, r.disqualified
+            FROM runs r
+            JOIN users u ON r.user_id = u.id
+            WHERE r.session_race_id = $1
+            ORDER BY r.track_time ASC
+            "#,
+            [row.id.clone().into()],
+        ))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|s| {
+            Ok::<_, Error>(RaceSubmission {
+                user_id: UserId::from_db(&s.user_id)?,
+                username: s.username,
+                track_time: s.track_time,
+                disqualified: s.disqualified,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(Some(SessionRaceInfo {
-        id: SessionRaceId::new(row.id),
+        id: SessionRaceId::from_db(&row.id)?,
         race_number: row.race_number,
         track_id: row.track_id,
         track_name: row.track_name,
@@ -445,18 +450,19 @@ async fn load_race_history(
     .all(db)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| RaceInfo {
-            id: SessionRaceId::new(r.id),
-            race_number: r.race_number,
-            track_id: r.track_id,
-            track_name: r.track_name,
-            cup_name: r.cup_name,
-            run_count: r.run_count,
-            created_at: r.created_at.and_utc(),
+    rows.into_iter()
+        .map(|r| {
+            Ok(RaceInfo {
+                id: SessionRaceId::from_db(&r.id)?,
+                race_number: r.race_number,
+                track_id: r.track_id,
+                track_name: r.track_name,
+                cup_name: r.cup_name,
+                run_count: r.run_count,
+                created_at: r.created_at.and_utc(),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// Row shape for the pending-races query.
@@ -549,19 +555,20 @@ pub async fn get_pending_races(
     .all(db)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| SessionRaceInfo {
-            id: SessionRaceId::new(r.id),
-            race_number: r.race_number,
-            track_id: r.track_id,
-            track_name: r.track_name,
-            cup_name: r.cup_name,
-            image_path: r.image_path,
-            created_at: r.created_at.and_utc(),
-            submissions: Vec::new(),
+    rows.into_iter()
+        .map(|r| {
+            Ok(SessionRaceInfo {
+                id: SessionRaceId::from_db(&r.id)?,
+                race_number: r.race_number,
+                track_id: r.track_id,
+                track_name: r.track_name,
+                cup_name: r.cup_name,
+                image_path: r.image_path,
+                created_at: r.created_at.and_utc(),
+                submissions: Vec::new(),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// Mark a pending race as skipped for the requesting user.
@@ -632,7 +639,8 @@ pub async fn skip_pending_race(
     let race = session_races::Entity::find_by_id(session_race_id)
         .one(db)
         .await?;
-    let Some(race) = race.filter(|r| r.session_id == session_id.as_str()) else {
+    let session_id_str = session_id.to_string();
+    let Some(race) = race.filter(|r| r.session_id == session_id_str) else {
         return Err(Error::NotFound(
             "Race not found in this session".to_string(),
         ));
@@ -707,7 +715,7 @@ pub async fn get_session_detail(
         .await?
         .ok_or_else(|| Error::NotFound("Session not found".to_string()))?;
 
-    let host_id = UserId::new(session.host_id);
+    let host_id = UserId::from_db(&session.host_id)?;
     let host_username = load_host_username(db, &host_id).await?;
     let participants = load_participants(db, session_id).await?;
     let current_race = load_current_race_with_submissions(db, session_id).await?;
@@ -733,7 +741,7 @@ pub async fn get_session_detail(
     };
 
     Ok(SessionDetail {
-        id: SessionId::new(session.id),
+        id: SessionId::from_db(&session.id)?,
         host_id,
         host_username,
         ruleset: session.ruleset,
@@ -803,8 +811,8 @@ pub async fn join_session(
         None => {
             session_participants::ActiveModel {
                 id: Set(Uuid::new_v4().to_string()),
-                session_id: Set(session_id.as_str().to_string()),
-                user_id: Set(user_id.as_str().to_string()),
+                session_id: Set(session_id.into()),
+                user_id: Set(user_id.into()),
                 joined_at: Set(now),
                 left_at: Set(None),
             }
@@ -894,9 +902,9 @@ async fn transfer_host_or_close(
             .await?;
 
         match next_host {
-            Some(new_host) => Ok(HostDisposition::TransferredTo(UserId::new(
-                new_host.user_id,
-            ))),
+            Some(new_host) => Ok(HostDisposition::TransferredTo(UserId::from_db(
+                &new_host.user_id,
+            )?)),
             None => Ok(HostDisposition::SessionClosed),
         }
     } else {
@@ -949,13 +957,13 @@ pub async fn leave_session(
     active_participant.left_at = Set(Some(now));
     active_participant.update(&txn).await?;
 
-    let is_host_leaving = session.host_id.as_str() == user_id.as_str();
+    let is_host_leaving = session.host_id == user_id.to_string();
     let mut active_session: sessions::ActiveModel = session.into();
     let disposition = transfer_host_or_close(&txn, session_id, user_id, is_host_leaving).await?;
 
     match disposition {
         HostDisposition::TransferredTo(new_host_id) => {
-            active_session.host_id = Set(new_host_id.into_string());
+            active_session.host_id = Set((&new_host_id).into());
         }
         HostDisposition::SessionClosed => {
             active_session.status = Set(SessionStatus::Closed.to_string());
@@ -1006,7 +1014,7 @@ pub async fn next_track(
 
     let chosen = helpers::pick_random_track(db, &used_track_ids, &[]).await?;
 
-    let race_id = SessionRaceId::new(Uuid::new_v4().to_string());
+    let race_id = SessionRaceId::new_v4();
     let new_race_number = race_count + 1;
 
     let txn = db.begin().await?;
@@ -1014,8 +1022,8 @@ pub async fn next_track(
     // Capture the inserted row so we can echo its `before_save`-stamped
     // `created_at` back in the response.
     let inserted = session_races::ActiveModel {
-        id: Set(race_id.as_str().to_string()),
-        session_id: Set(session_id.as_str().to_string()),
+        id: Set((&race_id).into()),
+        session_id: Set(session_id.into()),
         race_number: Set(new_race_number),
         track_id: Set(chosen.id),
         chosen_by: Set(None),
@@ -1109,7 +1117,7 @@ pub async fn skip_turn(
 
     let chosen = helpers::pick_random_track(db, &exclude_ids, &[skipped_track_id]).await?;
 
-    let race_id = SessionRaceId::new(Uuid::new_v4().to_string());
+    let race_id = SessionRaceId::new_v4();
 
     // Delete old race + insert new one + snapshot present users in a single
     // transaction. The old race's `session_race_participations` rows cascade
@@ -1122,8 +1130,8 @@ pub async fn skip_turn(
     // Capture the inserted row so we can echo its `before_save`-stamped
     // `created_at` back in the response.
     let inserted = session_races::ActiveModel {
-        id: Set(race_id.as_str().to_string()),
-        session_id: Set(session_id.as_str().to_string()),
+        id: Set((&race_id).into()),
+        session_id: Set(session_id.into()),
         race_number: Set(keep_race_number),
         track_id: Set(chosen.id),
         chosen_by: Set(None),
@@ -1196,18 +1204,19 @@ pub async fn list_races(
     .all(db)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| RaceInfo {
-            id: SessionRaceId::new(r.id),
-            race_number: r.race_number,
-            track_id: r.track_id,
-            track_name: r.track_name,
-            cup_name: r.cup_name,
-            run_count: r.run_count,
-            created_at: r.created_at.and_utc(),
+    rows.into_iter()
+        .map(|r| {
+            Ok(RaceInfo {
+                id: SessionRaceId::from_db(&r.id)?,
+                race_number: r.race_number,
+                track_id: r.track_id,
+                track_name: r.track_name,
+                cup_name: r.cup_name,
+                run_count: r.run_count,
+                created_at: r.created_at.and_utc(),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// Close sessions that have had no activity for over an hour.
@@ -1284,7 +1293,7 @@ mod tests {
     #[tokio::test]
     async fn test_load_host_username_missing_user_returns_internal() {
         let db = setup_db().await;
-        let err = load_host_username(&db, &UserId::new("nonexistent-id"))
+        let err = load_host_username(&db, &UserId::new_v4())
             .await
             .unwrap_err();
         assert!(matches!(err, Error::Internal(_)));
@@ -1370,12 +1379,12 @@ mod tests {
 
         leave_session(&db, &session.id, &host_id).await.unwrap();
 
-        let updated = sessions::Entity::find_by_id(&session.id)
+        let updated = sessions::Entity::find_by_id(session.id)
             .one(&db)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(updated.host_id, user2_id.as_str());
+        assert_eq!(updated.host_id, user2_id.to_string());
         assert_eq!(updated.status, "active");
     }
 
@@ -1388,7 +1397,7 @@ mod tests {
 
         leave_session(&db, &session.id, &host_id).await.unwrap();
 
-        let updated = sessions::Entity::find_by_id(&session.id)
+        let updated = sessions::Entity::find_by_id(session.id)
             .one(&db)
             .await
             .unwrap()
@@ -1450,8 +1459,8 @@ mod tests {
         let user2_row = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&user2_id)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(user2_id)),
             )
             .one(&db)
             .await
@@ -1462,8 +1471,8 @@ mod tests {
         let host_row = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&host_id)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(host_id)),
             )
             .one(&db)
             .await
@@ -1600,7 +1609,7 @@ mod tests {
 
         // Verify session_race row was created
         let rows = session_races::Entity::find()
-            .filter(session_races::Column::SessionId.eq(&session.id))
+            .filter(session_races::Column::SessionId.eq(session.id))
             .all(&db)
             .await
             .unwrap();
@@ -1681,14 +1690,14 @@ mod tests {
         let rerolled = skip_turn(&db, &session.id, &host_id).await.unwrap();
 
         // The old race should be gone and a new one should exist
-        let old_race = session_races::Entity::find_by_id(&original.id)
+        let old_race = session_races::Entity::find_by_id(original.id)
             .one(&db)
             .await
             .unwrap();
         assert!(old_race.is_none(), "Old race should be deleted");
 
         // New race should exist
-        let new_race = session_races::Entity::find_by_id(&rerolled.id)
+        let new_race = session_races::Entity::find_by_id(rerolled.id)
             .one(&db)
             .await
             .unwrap();
@@ -1831,7 +1840,7 @@ mod tests {
 
         // Backdate last_activity_at past the stale threshold
         let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
-        let s = sessions::Entity::find_by_id(&session.id)
+        let s = sessions::Entity::find_by_id(session.id)
             .one(&db)
             .await
             .unwrap()
@@ -1867,15 +1876,15 @@ mod tests {
         let race = next_track(&db, &session.id, &host_id).await.unwrap();
 
         let parts = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::SessionRaceId.eq(&race.id))
+            .filter(session_race_participations::Column::SessionRaceId.eq(race.id))
             .all(&db)
             .await
             .unwrap();
         assert_eq!(parts.len(), 2, "one row per currently-present user");
-        let user_ids: std::collections::HashSet<&str> =
-            parts.iter().map(|p| p.user_id.as_str()).collect();
-        assert!(user_ids.contains(host_id.as_str()));
-        assert!(user_ids.contains(user2_id.as_str()));
+        let user_ids: std::collections::HashSet<String> =
+            parts.iter().map(|p| p.user_id.clone()).collect();
+        assert!(user_ids.contains(&host_id.to_string()));
+        assert!(user_ids.contains(&user2_id.to_string()));
         for p in &parts {
             assert!(
                 p.skipped_at.is_none(),
@@ -1897,7 +1906,7 @@ mod tests {
         let race = next_track(&db, &session.id, &host_id).await.unwrap();
 
         let parts = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::SessionRaceId.eq(&race.id))
+            .filter(session_race_participations::Column::SessionRaceId.eq(race.id))
             .all(&db)
             .await
             .unwrap();
@@ -1906,7 +1915,7 @@ mod tests {
             1,
             "only the still-present host should be snapshotted"
         );
-        assert_eq!(parts[0].user_id, host_id.as_str());
+        assert_eq!(parts[0].user_id, host_id.to_string());
     }
 
     #[tokio::test]
@@ -1929,7 +1938,7 @@ mod tests {
 
         session_races::ActiveModel {
             id: Set(race_id.clone()),
-            session_id: Set(session_id.as_str().to_string()),
+            session_id: Set(session_id.into()),
             race_number: Set(1),
             track_id: Set(1),
             chosen_by: Set(None),
@@ -2003,15 +2012,15 @@ mod tests {
 
         // Insert a run row for this (race, user)
         let drink_id = drink_type_uuid("Test Beer");
-        let _drink = drink_types::Entity::find_by_id(&drink_id)
+        let _drink = drink_types::Entity::find_by_id(drink_id)
             .one(&db)
             .await
             .unwrap()
             .expect("seed_game_data inserts Test Beer");
         runs::ActiveModel {
             id: Set(Uuid::new_v4().to_string()),
-            user_id: Set(host_id.as_str().to_string()),
-            session_race_id: Set(race_id.as_str().to_string()),
+            user_id: Set((&host_id).into()),
+            session_race_id: Set((&race_id).into()),
             track_id: Set(1),
             character_id: Set(1),
             body_id: Set(1),
@@ -2021,7 +2030,7 @@ mod tests {
             lap1_time: Set(40_000),
             lap2_time: Set(40_000),
             lap3_time: Set(40_000),
-            drink_type_id: Set(drink_id),
+            drink_type_id: Set((&drink_id).into()),
             disqualified: Set(false),
             photo_path: Set(None),
             created_at: NotSet,
@@ -2182,7 +2191,7 @@ mod tests {
 
         // The row still exists in the DB (lazy check, no cleanup).
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(&user_b))
+            .filter(session_race_participations::Column::UserId.eq(user_b))
             .count(&db)
             .await
             .unwrap();
@@ -2203,8 +2212,8 @@ mod tests {
         let original_joined = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&user_b)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(user_b)),
             )
             .one(&db)
             .await
@@ -2220,8 +2229,8 @@ mod tests {
         let row = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&user_b)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(user_b)),
             )
             .one(&db)
             .await
@@ -2254,8 +2263,8 @@ mod tests {
         let original_joined = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&user_b)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(user_b)),
             )
             .one(&db)
             .await
@@ -2273,8 +2282,8 @@ mod tests {
         let row = session_participants::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_participants::Column::SessionId.eq(&session.id))
-                    .add(session_participants::Column::UserId.eq(&user_b)),
+                    .add(session_participants::Column::SessionId.eq(session.id))
+                    .add(session_participants::Column::UserId.eq(user_b)),
             )
             .one(&db)
             .await
@@ -2296,7 +2305,7 @@ mod tests {
 
         // The participation row itself stays for history.
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(&user_b))
+            .filter(session_race_participations::Column::UserId.eq(user_b))
             .count(&db)
             .await
             .unwrap();
@@ -2367,7 +2376,7 @@ mod tests {
         // close_stale_sessions catches it; this mirrors the production path
         // (sets left_at = NOW() and status = 'closed' atomically).
         let two_hours_ago = Utc::now().naive_utc() - chrono::Duration::hours(2);
-        let s = sessions::Entity::find_by_id(&session.id)
+        let s = sessions::Entity::find_by_id(session.id)
             .one(&db)
             .await
             .unwrap()
@@ -2387,7 +2396,7 @@ mod tests {
 
         // The participation row itself stays in the DB for history.
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(&host_id))
+            .filter(session_race_participations::Column::UserId.eq(host_id))
             .count(&db)
             .await
             .unwrap();
@@ -2411,8 +2420,8 @@ mod tests {
         let row = session_race_participations::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
-                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+                    .add(session_race_participations::Column::SessionRaceId.eq(race.id))
+                    .add(session_race_participations::Column::UserId.eq(host_id)),
             )
             .one(&db)
             .await
@@ -2442,8 +2451,8 @@ mod tests {
         let first_skipped_at = session_race_participations::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
-                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+                    .add(session_race_participations::Column::SessionRaceId.eq(race.id))
+                    .add(session_race_participations::Column::UserId.eq(host_id)),
             )
             .one(&db)
             .await
@@ -2460,8 +2469,8 @@ mod tests {
         let second_skipped_at = session_race_participations::Entity::find()
             .filter(
                 Condition::all()
-                    .add(session_race_participations::Column::SessionRaceId.eq(&race.id))
-                    .add(session_race_participations::Column::UserId.eq(&host_id)),
+                    .add(session_race_participations::Column::SessionRaceId.eq(race.id))
+                    .add(session_race_participations::Column::UserId.eq(host_id)),
             )
             .one(&db)
             .await
@@ -2483,7 +2492,7 @@ mod tests {
         let session = create_session(&db, &host_id, "random").await.unwrap();
 
         // No race exists for this session.
-        let bogus_race_id = SessionRaceId::new(Uuid::new_v4().to_string());
+        let bogus_race_id = SessionRaceId::new_v4();
         let err = skip_pending_race(&db, &session.id, &bogus_race_id, &host_id)
             .await
             .unwrap_err();
@@ -2508,15 +2517,15 @@ mod tests {
 
         // Insert a run row to satisfy the "already submitted" precondition.
         let drink_id = drink_type_uuid("Test Beer");
-        drink_types::Entity::find_by_id(&drink_id)
+        drink_types::Entity::find_by_id(drink_id)
             .one(&db)
             .await
             .unwrap()
             .expect("seed_game_data inserts Test Beer");
         runs::ActiveModel {
             id: Set(Uuid::new_v4().to_string()),
-            user_id: Set(host_id.as_str().to_string()),
-            session_race_id: Set(race.id.as_str().to_string()),
+            user_id: Set((&host_id).into()),
+            session_race_id: Set((&race.id).into()),
             track_id: Set(race.track_id),
             character_id: Set(1),
             body_id: Set(1),
@@ -2526,7 +2535,7 @@ mod tests {
             lap1_time: Set(40_000),
             lap2_time: Set(40_000),
             lap3_time: Set(40_000),
-            drink_type_id: Set(drink_id),
+            drink_type_id: Set((&drink_id).into()),
             disqualified: Set(false),
             photo_path: Set(None),
             created_at: NotSet,

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -957,7 +957,11 @@ pub async fn leave_session(
     active_participant.left_at = Set(Some(now));
     active_participant.update(&txn).await?;
 
-    let is_host_leaving = session.host_id == user_id.to_string();
+    // Lift to typed before comparing — matches the pattern in
+    // `session_context.rs::require_host` and surfaces a malformed UUID in
+    // `sessions.host_id` as 500 rather than a silent false-negative compare.
+    let host_id = UserId::from_db(&session.host_id)?;
+    let is_host_leaving = host_id == *user_id;
     let mut active_session: sessions::ActiveModel = session.into();
     let disposition = transfer_host_or_close(&txn, session_id, user_id, is_host_leaving).await?;
 

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -2,7 +2,7 @@ use sea_orm::{ActiveModelTrait, ConnectionTrait, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    domain::{UserId, race_setup},
+    domain::{BodyId, CharacterId, DrinkTypeId, GliderId, UserId, WheelId, race_setup},
     entities::{bodies, characters, drink_types, gliders, users, wheels},
     error::Error,
     services::helpers,
@@ -12,7 +12,7 @@ use crate::{
 
 #[derive(Serialize)]
 pub struct DrinkTypeInfo {
-    pub id: String,
+    pub id: DrinkTypeId,
     pub name: String,
     pub alcoholic: bool,
 }
@@ -21,27 +21,27 @@ pub struct DrinkTypeInfo {
 pub struct UserDetailProfile {
     pub id: UserId,
     pub username: String,
-    pub preferred_character_id: Option<i32>,
-    pub preferred_body_id: Option<i32>,
-    pub preferred_wheel_id: Option<i32>,
-    pub preferred_glider_id: Option<i32>,
+    pub preferred_character_id: Option<CharacterId>,
+    pub preferred_body_id: Option<BodyId>,
+    pub preferred_wheel_id: Option<WheelId>,
+    pub preferred_glider_id: Option<GliderId>,
     pub preferred_drink_type: Option<DrinkTypeInfo>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Request body for `PUT /users/:id`.
 ///
-/// `preferred_drink_type_id` uses `Option<Option<String>>` to distinguish
-/// three states: key absent (don't change), key present with null (clear),
-/// key present with value (set).
+/// `preferred_drink_type_id` uses `Option<Option<DrinkTypeId>>` to
+/// distinguish three states: key absent (don't change), key present with
+/// null (clear), key present with value (set).
 #[derive(Deserialize)]
 pub struct UpdateProfileRequest {
-    pub preferred_character_id: Option<i32>,
-    pub preferred_body_id: Option<i32>,
-    pub preferred_wheel_id: Option<i32>,
-    pub preferred_glider_id: Option<i32>,
+    pub preferred_character_id: Option<CharacterId>,
+    pub preferred_body_id: Option<BodyId>,
+    pub preferred_wheel_id: Option<WheelId>,
+    pub preferred_glider_id: Option<GliderId>,
     #[serde(default, deserialize_with = "deserialize_optional_field")]
-    pub preferred_drink_type_id: Option<Option<String>>,
+    pub preferred_drink_type_id: Option<Option<DrinkTypeId>>,
 }
 
 /// Deserializer that distinguishes between "key absent" (None) and
@@ -76,7 +76,7 @@ pub async fn update_profile(
     target_user_id: &UserId,
     req: UpdateProfileRequest,
 ) -> Result<UserDetailProfile, Error> {
-    if actor_user_id.as_str() != target_user_id.as_str() {
+    if actor_user_id != target_user_id {
         return Err(Error::Forbidden(
             "You can only update your own profile".to_string(),
         ));
@@ -96,25 +96,29 @@ pub async fn update_profile(
         req.preferred_wheel_id,
         req.preferred_glider_id,
     )? {
-        helpers::require_exists::<characters::Entity, _>(db, setup.character_id, "character")
-            .await?;
-        helpers::require_exists::<bodies::Entity, _>(db, setup.body_id, "body").await?;
-        helpers::require_exists::<wheels::Entity, _>(db, setup.wheel_id, "wheel").await?;
-        helpers::require_exists::<gliders::Entity, _>(db, setup.glider_id, "glider").await?;
+        helpers::require_exists::<characters::Entity, _>(
+            db,
+            setup.character_id.into(),
+            "character",
+        )
+        .await?;
+        helpers::require_exists::<bodies::Entity, _>(db, setup.body_id.into(), "body").await?;
+        helpers::require_exists::<wheels::Entity, _>(db, setup.wheel_id.into(), "wheel").await?;
+        helpers::require_exists::<gliders::Entity, _>(db, setup.glider_id.into(), "glider").await?;
 
-        active.preferred_character_id = Set(Some(setup.character_id));
-        active.preferred_body_id = Set(Some(setup.body_id));
-        active.preferred_wheel_id = Set(Some(setup.wheel_id));
-        active.preferred_glider_id = Set(Some(setup.glider_id));
+        active.preferred_character_id = Set(Some(setup.character_id.into()));
+        active.preferred_body_id = Set(Some(setup.body_id.into()));
+        active.preferred_wheel_id = Set(Some(setup.wheel_id.into()));
+        active.preferred_glider_id = Set(Some(setup.glider_id.into()));
     }
 
     // Drink type: independent, can be set or cleared
     if let Some(dt_id_option) = req.preferred_drink_type_id {
         if let Some(ref dt_id) = dt_id_option {
-            helpers::require_exists::<drink_types::Entity, _>(db, dt_id.clone(), "drink_type")
+            helpers::require_exists::<drink_types::Entity, _>(db, dt_id.into(), "drink_type")
                 .await?;
         }
-        active.preferred_drink_type_id = Set(dt_id_option);
+        active.preferred_drink_type_id = Set(dt_id_option.as_ref().map(Into::into));
     }
 
     // `updated_at` is bumped by `users::ActiveModelBehavior::before_save`.
@@ -137,25 +141,26 @@ pub async fn build_detail_profile(
     user: users::Model,
 ) -> Result<UserDetailProfile, Error> {
     let drink_type = if let Some(ref dt_id) = user.preferred_drink_type_id {
-        drink_types::Entity::find_by_id(dt_id)
-            .one(db)
-            .await?
-            .map(|dt| DrinkTypeInfo {
-                id: dt.id,
+        let row = drink_types::Entity::find_by_id(dt_id).one(db).await?;
+        row.map(|dt| {
+            Ok::<_, Error>(DrinkTypeInfo {
+                id: DrinkTypeId::from_db(&dt.id)?,
                 name: dt.name,
                 alcoholic: dt.alcoholic,
             })
+        })
+        .transpose()?
     } else {
         None
     };
 
     Ok(UserDetailProfile {
-        id: UserId::new(user.id),
+        id: UserId::from_db(&user.id)?,
         username: user.username,
-        preferred_character_id: user.preferred_character_id,
-        preferred_body_id: user.preferred_body_id,
-        preferred_wheel_id: user.preferred_wheel_id,
-        preferred_glider_id: user.preferred_glider_id,
+        preferred_character_id: user.preferred_character_id.map(CharacterId::new),
+        preferred_body_id: user.preferred_body_id.map(BodyId::new),
+        preferred_wheel_id: user.preferred_wheel_id.map(WheelId::new),
+        preferred_glider_id: user.preferred_glider_id.map(GliderId::new),
         preferred_drink_type: drink_type,
         created_at: user.created_at.and_utc(),
     })
@@ -163,10 +168,12 @@ pub async fn build_detail_profile(
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
     use crate::test_helpers::{create_user, seed_game_data, setup_db};
 
-    fn drink_id() -> String {
+    fn drink_id() -> DrinkTypeId {
         crate::drink_type_id::drink_type_uuid("Test Beer")
     }
 
@@ -197,7 +204,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_profile_user_not_found() {
         let db = setup_db().await;
-        let nonexistent = UserId::new("nonexistent");
+        let nonexistent = UserId::new(Uuid::new_v4());
 
         let result = update_profile(
             &db,
@@ -227,20 +234,20 @@ mod tests {
             &user_id,
             &user_id,
             UpdateProfileRequest {
-                preferred_character_id: Some(1),
-                preferred_body_id: Some(1),
-                preferred_wheel_id: Some(1),
-                preferred_glider_id: Some(1),
+                preferred_character_id: Some(CharacterId::new(1)),
+                preferred_body_id: Some(BodyId::new(1)),
+                preferred_wheel_id: Some(WheelId::new(1)),
+                preferred_glider_id: Some(GliderId::new(1)),
                 preferred_drink_type_id: None,
             },
         )
         .await
         .unwrap();
 
-        assert_eq!(profile.preferred_character_id, Some(1));
-        assert_eq!(profile.preferred_body_id, Some(1));
-        assert_eq!(profile.preferred_wheel_id, Some(1));
-        assert_eq!(profile.preferred_glider_id, Some(1));
+        assert_eq!(profile.preferred_character_id, Some(CharacterId::new(1)));
+        assert_eq!(profile.preferred_body_id, Some(BodyId::new(1)));
+        assert_eq!(profile.preferred_wheel_id, Some(WheelId::new(1)));
+        assert_eq!(profile.preferred_glider_id, Some(GliderId::new(1)));
     }
 
     #[tokio::test]
@@ -254,7 +261,7 @@ mod tests {
             &user_id,
             &user_id,
             UpdateProfileRequest {
-                preferred_character_id: Some(1),
+                preferred_character_id: Some(CharacterId::new(1)),
                 preferred_body_id: None,
                 preferred_wheel_id: None,
                 preferred_glider_id: None,
@@ -277,10 +284,10 @@ mod tests {
             &user_id,
             &user_id,
             UpdateProfileRequest {
-                preferred_character_id: Some(999),
-                preferred_body_id: Some(1),
-                preferred_wheel_id: Some(1),
-                preferred_glider_id: Some(1),
+                preferred_character_id: Some(CharacterId::new(999)),
+                preferred_body_id: Some(BodyId::new(1)),
+                preferred_wheel_id: Some(WheelId::new(1)),
+                preferred_glider_id: Some(GliderId::new(1)),
                 preferred_drink_type_id: None,
             },
         )
@@ -304,7 +311,9 @@ mod tests {
                 preferred_body_id: None,
                 preferred_wheel_id: None,
                 preferred_glider_id: None,
-                preferred_drink_type_id: Some(Some("bad-uuid".to_string())),
+                // Random unrelated UUID — passes the type-level parse but
+                // misses the FK in the database, so the boundary returns 400.
+                preferred_drink_type_id: Some(Some(DrinkTypeId::new_v4())),
             },
         )
         .await;
@@ -406,10 +415,10 @@ mod tests {
             &user_id,
             &user_id,
             UpdateProfileRequest {
-                preferred_character_id: Some(1),
-                preferred_body_id: Some(1),
-                preferred_wheel_id: Some(1),
-                preferred_glider_id: Some(1),
+                preferred_character_id: Some(CharacterId::new(1)),
+                preferred_body_id: Some(BodyId::new(1)),
+                preferred_wheel_id: Some(WheelId::new(1)),
+                preferred_glider_id: Some(GliderId::new(1)),
                 preferred_drink_type_id: None, // absent = don't change
             },
         )

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -53,11 +53,11 @@ pub async fn setup_db() -> DatabaseConnection {
 /// Insert a user with the given username and a fixed placeholder password
 /// hash. Returns the generated user ID.
 pub async fn create_user(db: &DatabaseConnection, username: &str) -> UserId {
-    let id = Uuid::new_v4().to_string();
+    let id = UserId::new_v4();
     // Placeholder hash — tests don't verify passwords, but the column is NOT NULL.
     let placeholder_hash = "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$abc123";
     users::ActiveModel {
-        id: Set(id.clone()),
+        id: Set((&id).into()),
         username: Set(username.to_string()),
         email: Set(None),
         password_hash: Set(placeholder_hash.to_string()),
@@ -73,7 +73,7 @@ pub async fn create_user(db: &DatabaseConnection, username: &str) -> UserId {
     .insert(db)
     .await
     .expect("insert user");
-    UserId::new(id)
+    id
 }
 
 /// Seed 3 cups × 2 tracks each (6 tracks total) for tests that exercise
@@ -116,10 +116,10 @@ pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
 /// Insert a session with the given host and status. Returns the generated
 /// session ID.
 pub async fn insert_session(db: &DatabaseConnection, host_id: &UserId, status: &str) -> SessionId {
-    let id = Uuid::new_v4().to_string();
+    let id = SessionId::new_v4();
     sessions::ActiveModel {
-        id: Set(id.clone()),
-        host_id: Set(host_id.as_str().to_string()),
+        id: Set((&id).into()),
+        host_id: Set(host_id.into()),
         ruleset: Set("random".to_string()),
         least_played_drink_category: Set(None),
         status: Set(status.to_string()),
@@ -129,7 +129,7 @@ pub async fn insert_session(db: &DatabaseConnection, host_id: &UserId, status: &
     .insert(db)
     .await
     .expect("insert session");
-    SessionId::new(id)
+    id
 }
 
 /// Insert a participant into a session. Pass `None` for `left_at` to create
@@ -143,8 +143,8 @@ pub async fn insert_participant(
     let now = Utc::now().naive_utc();
     session_participants::ActiveModel {
         id: Set(Uuid::new_v4().to_string()),
-        session_id: Set(session_id.as_str().to_string()),
-        user_id: Set(user_id.as_str().to_string()),
+        session_id: Set(session_id.into()),
+        user_id: Set(user_id.into()),
         joined_at: Set(now),
         left_at: Set(left_at),
     }
@@ -163,10 +163,10 @@ pub async fn insert_session_race(
     track_id: i32,
     created_at: chrono::NaiveDateTime,
 ) -> SessionRaceId {
-    let id = Uuid::new_v4().to_string();
+    let id = SessionRaceId::new_v4();
     session_races::ActiveModel {
-        id: Set(id.clone()),
-        session_id: Set(session_id.as_str().to_string()),
+        id: Set((&id).into()),
+        session_id: Set(session_id.into()),
         race_number: Set(race_number),
         track_id: Set(track_id),
         chosen_by: Set(None),
@@ -175,7 +175,7 @@ pub async fn insert_session_race(
     .insert(db)
     .await
     .expect("insert session race");
-    SessionRaceId::new(id)
+    id
 }
 
 /// Insert a `session_race_participations` row directly. Use this in tests
@@ -187,8 +187,8 @@ pub async fn insert_race_participation(
     skipped_at: Option<chrono::NaiveDateTime>,
 ) {
     session_race_participations::ActiveModel {
-        session_race_id: Set(session_race_id.as_str().to_string()),
-        user_id: Set(user_id.as_str().to_string()),
+        session_race_id: Set(session_race_id.into()),
+        user_id: Set(user_id.into()),
         created_at: NotSet,
         skipped_at: Set(skipped_at),
     }
@@ -288,7 +288,7 @@ pub async fn seed_game_data(db: &DatabaseConnection) {
 
     let drink_id = drink_type_uuid("Test Beer");
     drink_types::ActiveModel {
-        id: Set(drink_id),
+        id: Set((&drink_id).into()),
         name: Set("Test Beer".to_string()),
         alcoholic: Set(true),
         created_at: NotSet,

--- a/backend/tests/api_integration.rs
+++ b/backend/tests/api_integration.rs
@@ -237,7 +237,7 @@ async fn seed_test_data(db: &sea_orm::DatabaseConnection) {
     for item in &dt_json {
         let id = drink_type_uuid(&item.name);
         drink_types::ActiveModel {
-            id: Set(id),
+            id: Set((&id).into()),
             name: Set(item.name.clone()),
             alcoholic: Set(item.alcoholic),
             created_at: Set(now),
@@ -430,8 +430,13 @@ async fn test_get_nonexistent_user_returns_404() {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "alice").await;
 
+    // Valid UUID shape but no matching row — the Path extractor's UUID
+    // validation is satisfied, so the handler runs and produces 404.
+    // A non-UUID path segment is now a 400 from the extractor itself,
+    // which is a different (also-correct) class of error not exercised here.
+    let missing = uuid::Uuid::new_v4();
     let res = server
-        .get("/api/v1/users/nonexistent-id")
+        .get(&format!("/api/v1/users/{missing}"))
         .add_header(AUTH_HEADER, auth_value(&token))
         .await;
     res.assert_status(axum::http::StatusCode::NOT_FOUND);
@@ -659,8 +664,11 @@ async fn test_get_nonexistent_drink_type_returns_404() {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "testuser").await;
 
+    // Valid UUID shape but no matching row — see `test_get_nonexistent_user_returns_404`
+    // for the rationale on the shape vs. non-UUID-path-segment split.
+    let missing = uuid::Uuid::new_v4();
     let res = server
-        .get("/api/v1/drink-types/nonexistent-uuid")
+        .get(&format!("/api/v1/drink-types/{missing}"))
         .add_header(AUTH_HEADER, auth_value(&token))
         .await;
     res.assert_status(axum::http::StatusCode::NOT_FOUND);

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -316,8 +316,12 @@ async fn test_refresh_token_in_authorization_header_rejected_by_middleware() {
 
     // Create a refresh token directly
     let config = test_config();
-    let refresh_jwt =
-        beerio_kart::services::auth::create_refresh_token("fake-user-id", 0, &config).unwrap();
+    let refresh_jwt = beerio_kart::services::auth::create_refresh_token(
+        &beerio_kart::domain::UserId::new_v4(),
+        0,
+        &config,
+    )
+    .unwrap();
 
     // Try to use it as a Bearer token on a protected endpoint
     let response = server
@@ -335,8 +339,12 @@ async fn test_access_token_with_type_refresh_rejected_by_middleware() {
     // Create a refresh token and try to pass it off as an access token.
     // The middleware should check token_type and reject it.
     let config = test_config();
-    let refresh_jwt =
-        beerio_kart::services::auth::create_refresh_token("fake-user-id", 0, &config).unwrap();
+    let refresh_jwt = beerio_kart::services::auth::create_refresh_token(
+        &beerio_kart::domain::UserId::new_v4(),
+        0,
+        &config,
+    )
+    .unwrap();
 
     let response = server
         .get("/api/v1/protected")

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -8,6 +8,7 @@ use axum_test::TestServer;
 use beerio_kart::{
     ARGON2_MAX_CONCURRENT, AppState,
     config::Config,
+    domain::UserId,
     middleware::auth::{AdminUser, User},
 };
 use migration::{Migrator, MigratorTrait};
@@ -28,12 +29,12 @@ async fn admin_handler(admin: AdminUser) -> axum::Json<Value> {
     axum::Json(serde_json::json!({ "admin_id": admin.user_id }))
 }
 
-fn make_config(admin_user_id: Option<&str>) -> Arc<Config> {
+fn make_config(admin_user_id: Option<UserId>) -> Arc<Config> {
     Arc::new(Config {
         jwt_secret: TEST_SECRET.to_string(),
         jwt_access_expiry_minutes: 15,
         jwt_refresh_expiry_days: 7,
-        admin_user_id: admin_user_id.map(ToString::to_string),
+        admin_user_id,
         cookie_secure: false,
         request_timeout_seconds: 30,
         request_concurrency_limit: 100,
@@ -42,7 +43,7 @@ fn make_config(admin_user_id: Option<&str>) -> Arc<Config> {
     })
 }
 
-async fn setup_server(admin_user_id: Option<&str>) -> TestServer {
+async fn setup_server(admin_user_id: Option<UserId>) -> TestServer {
     let url = format!("sqlite:file:{}?mode=memory&cache=shared", Uuid::new_v4());
     let db = Database::connect(&url).await.expect("connect");
     db.execute_unprepared("PRAGMA foreign_keys = ON")
@@ -65,12 +66,12 @@ async fn setup_server(admin_user_id: Option<&str>) -> TestServer {
     TestServer::new(app)
 }
 
-fn create_access_token(user_id: &str, username: &str) -> String {
+fn create_access_token(user_id: &UserId, username: &str) -> String {
     let config = make_config(None);
     beerio_kart::services::auth::create_access_token(user_id, username, &config).unwrap()
 }
 
-fn create_refresh_token(user_id: &str) -> String {
+fn create_refresh_token(user_id: &UserId) -> String {
     let config = make_config(None);
     beerio_kart::services::auth::create_refresh_token(user_id, 0, &config).unwrap()
 }
@@ -107,7 +108,8 @@ async fn test_auth_user_empty_token_returns_401() {
 #[tokio::test]
 async fn test_auth_user_refresh_token_as_access_returns_401() {
     let server = setup_server(None).await;
-    let refresh = create_refresh_token("user-1");
+    let user_id = UserId::new_v4();
+    let refresh = create_refresh_token(&user_id);
     let response = server
         .get("/auth-only")
         .add_header("Authorization", format!("Bearer {refresh}"))
@@ -118,22 +120,25 @@ async fn test_auth_user_refresh_token_as_access_returns_401() {
 #[tokio::test]
 async fn test_auth_user_valid_access_token_succeeds() {
     let server = setup_server(None).await;
-    let token = create_access_token("user-1", "alice");
+    let user_id = UserId::new_v4();
+    let token = create_access_token(&user_id, "alice");
     let response = server
         .get("/auth-only")
         .add_header("Authorization", format!("Bearer {token}"))
         .await;
     response.assert_status(StatusCode::OK);
     let body: Value = response.json();
-    assert_eq!(body["user_id"], "user-1");
+    assert_eq!(body["user_id"], user_id.to_string());
 }
 
 // ── AdminUser extractor tests ───────────────────────────────────────
 
 #[tokio::test]
 async fn test_admin_user_non_admin_returns_403() {
-    let server = setup_server(Some("admin-id")).await;
-    let token = create_access_token("not-admin", "bob");
+    let admin_id = UserId::new_v4();
+    let server = setup_server(Some(admin_id)).await;
+    let other = UserId::new_v4();
+    let token = create_access_token(&other, "bob");
     let response = server
         .get("/admin-only")
         .add_header("Authorization", format!("Bearer {token}"))
@@ -143,21 +148,23 @@ async fn test_admin_user_non_admin_returns_403() {
 
 #[tokio::test]
 async fn test_admin_user_correct_admin_succeeds() {
-    let server = setup_server(Some("admin-id")).await;
-    let token = create_access_token("admin-id", "admin");
+    let admin_id = UserId::new_v4();
+    let server = setup_server(Some(admin_id)).await;
+    let token = create_access_token(&admin_id, "admin");
     let response = server
         .get("/admin-only")
         .add_header("Authorization", format!("Bearer {token}"))
         .await;
     response.assert_status(StatusCode::OK);
     let body: Value = response.json();
-    assert_eq!(body["admin_id"], "admin-id");
+    assert_eq!(body["admin_id"], admin_id.to_string());
 }
 
 #[tokio::test]
 async fn test_admin_user_no_admin_configured_returns_403() {
     let server = setup_server(None).await; // no ADMIN_USER_ID set
-    let token = create_access_token("some-user", "alice");
+    let user_id = UserId::new_v4();
+    let token = create_access_token(&user_id, "alice");
     let response = server
         .get("/admin-only")
         .add_header("Authorization", format!("Bearer {token}"))

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -157,7 +157,7 @@ async fn seed_minimal_game_data(db: &sea_orm::DatabaseConnection) {
     .expect("insert glider");
 
     drink_types::ActiveModel {
-        id: Set(drink_type_uuid("Test Beer")),
+        id: Set(drink_type_uuid("Test Beer").into()),
         name: Set("Test Beer".to_string()),
         alcoholic: Set(true),
         created_at: Set(Utc::now().naive_utc()),
@@ -462,8 +462,11 @@ async fn test_get_nonexistent_session_returns_404() {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "host").await;
 
+    // Valid UUID shape but no matching row. A non-UUID path segment now
+    // produces a 400 from axum's Path extractor before reaching the handler.
+    let missing = uuid::Uuid::new_v4();
     let res = server
-        .get("/api/v1/sessions/nonexistent-id")
+        .get(&format!("/api/v1/sessions/{missing}"))
         .add_header(AUTH_HEADER, auth_value(&token))
         .await;
     res.assert_status(axum::http::StatusCode::NOT_FOUND);


### PR DESCRIPTION
## Summary

- Wrap every primitive ID column in a `nutype`-backed newtype so the compiler catches "wrong-id-in-this-arg" bugs and UUID-shaped wire input is validated once at the boundary.
- UUID-backed: `UserId`, `SessionId`, `RunId`, `SessionRaceId`, `SessionParticipantId`, `RunFlagId`, `DrinkTypeId` (wrap `uuid::Uuid`).
- Integer-backed: `TrackId`, `CharacterId`, `BodyId`, `WheelId`, `GliderId`, `CupId` (wrap `i32`).
- Entities keep SeaORM-default primitives per `seaorm.md` § 6 — conversion happens at the entity↔service boundary via `Type::from_db(&col_str)` (UUIDs, returns `Internal` on bad UUID) and `Type::new(int)` (integers).
- Wire format unchanged: nutype's transparent `Serialize`/`Deserialize` delegate to the inner type, so UUID newtypes still serialize as the canonical hyphenated string and integer newtypes as JSON numbers.
- `proptest` added as a dev-dep alongside its first consumer (a 256-case `UserId` serde round-trip in `domain::ids::tests`). Lineage: bundled into PR-G2 (#136); moved here per the issue body so the dep lands with real coverage.
- `Config::admin_user_id` is now typed (`Option<UserId>`), so a malformed `ADMIN_USER_ID` env var fails fast at startup with `"ADMIN_USER_ID must be a valid UUID"` instead of silently refusing admin access.

## Behavior change worth noting

A non-UUID path segment on routes like `GET /sessions/:id` now returns **400** from axum's `Path<SessionId>` extractor before the handler runs (previously returned 404 from a DB miss). Two `test_get_nonexistent_*_returns_404` integration tests were updated to use valid-shape-but-not-in-DB UUIDs to exercise the original FK-miss path; the type-extractor 400 is a strict improvement and is captured by the unit test `test_user_id_deserialize_rejects_non_uuid_string` in `domain/ids.rs`.

API contract for valid inputs is unchanged. Verified by running the full test suite (264 tests across lib + 6 integration files, all passing).

## Test plan

- [ ] `cargo test` — all 264 tests pass (187 lib + 27 + 21 + 8 + 1 + 1 + 19 integration).
- [ ] `cargo clippy --all-targets --all-features` — clean.
- [ ] `cargo +nightly fmt --check` — clean.
- [ ] Smoke test the running server: `POST /api/v1/auth/register`, log in, `GET /api/v1/users/me`, create a session, pick a track, submit a run. All payloads should look identical to before this PR.
- [ ] Hit `GET /api/v1/sessions/not-a-uuid` and confirm the response is 400 (was 404). Hit `GET /api/v1/sessions/<random-valid-uuid>` and confirm 404.

## Note on G3 interaction

PR-G3 (#114) deliberately landed ahead of D1; `# Errors` doc-sections that referenced `i32` / `String` IDs have been swept in this PR alongside the function-signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)