### PR TITLE
120: PR-D3 — DeriveActiveEnum for status / ruleset / drink category / run flag reason

### DIFF
--- a/backend/src/domain/enums.rs
+++ b/backend/src/domain/enums.rs
@@ -1,121 +1,163 @@
-use std::{fmt, str::FromStr};
+//! String-valued domain enums backed by [`sea_orm::DeriveActiveEnum`].
+//!
+//! Each variant carries a `string_value` that is what the DB column stores
+//! (TEXT) and what serde emits on the wire (a bare lowercase / `snake_case`
+//! string — matching what the frontend already sends and reads). The
+//! [`sea_orm::DeriveActiveEnum`] derive lets these types be used directly
+//! as the column type on an entity ([`crate::entities::sessions`],
+//! [`crate::entities::run_flags`]), so the entity↔service boundary keeps
+//! its newtype-on-the-Rust-side, primitive-in-the-DB shape — without the
+//! ad-hoc `as_str` / `to_string` plumbing the previous string-typed model
+//! needed at every call site.
+//!
+//! See `coding-standards/rust.md` § 2 (parse-don't-validate) and § 14
+//! (`snake_case` wire format), and `coding-standards/seaorm.md` § 5
+//! (enumerations).
 
+use std::str::FromStr;
+
+use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
 /// Lifecycle state of a session.
 ///
-/// Stored in the DB as the strings returned by `as_str`. An unknown value read
-/// from the DB is treated as `Internal` (corruption or schema drift), not user
-/// input, so it bubbles up as a 500.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Stored in `sessions.status` as the lowercase strings declared below.
+/// Wire shape mirrors the storage shape via `#[serde(rename_all = "lowercase")]`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "Text")]
 #[serde(rename_all = "lowercase")]
 pub enum SessionStatus {
+    #[sea_orm(string_value = "active")]
     Active,
+    #[sea_orm(string_value = "closed")]
     Closed,
 }
 
-impl SessionStatus {
-    #[must_use]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Active => "active",
-            Self::Closed => "closed",
-        }
-    }
-}
-
-impl fmt::Display for SessionStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for SessionStatus {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "active" => Ok(Self::Active),
-            "closed" => Ok(Self::Closed),
-            other => Err(Error::Internal(anyhow::anyhow!(
-                "Unknown session status: {other}"
-            ))),
-        }
-    }
-}
-
-/// Session scheduling ruleset. Only `Random` is supported in Phase 3; future
-/// variants (e.g. `RoundRobin`) belong here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Ruleset {
+/// How a session selects tracks. Stored in `sessions.ruleset` as the
+/// `snake_case` strings declared below. See `docs/data-model.md` § Session
+/// Rulesets for the per-variant behavior.
+///
+/// Only [`Self::Random`] is wired through `create_session` today — the
+/// other variants are defined so the type is complete (per the
+/// compliance plan), but the service layer rejects them with a
+/// `BadRequest("Ruleset … is not yet supported")` until their product
+/// behavior lands.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "Text")]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRuleset {
+    #[sea_orm(string_value = "random")]
     Random,
+    #[sea_orm(string_value = "default")]
+    Default,
+    #[sea_orm(string_value = "least_played")]
+    LeastPlayed,
+    #[sea_orm(string_value = "round_robin")]
+    RoundRobin,
 }
 
-impl Ruleset {
-    #[must_use]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Random => "random",
-        }
-    }
-}
-
-impl fmt::Display for Ruleset {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for Ruleset {
+impl FromStr for SessionRuleset {
     type Err = Error;
 
+    /// Parse a ruleset string submitted by a client. Unknown values are
+    /// `Error::BadRequest` (client-input fault), not `Error::Internal`.
+    ///
+    /// Kept as a manual impl rather than going through serde because the
+    /// route DTO holds `ruleset: String` — see issue [#146] for the typed
+    /// Json extractor error-envelope mismatch this currently avoids.
+    ///
+    /// [#146]: https://github.com/brendanbyrne/beerio-kart/issues/146
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "random" => Ok(Self::Random),
+            "default" => Ok(Self::Default),
+            "least_played" => Ok(Self::LeastPlayed),
+            "round_robin" => Ok(Self::RoundRobin),
             other => Err(Error::bad_request(format!("Invalid ruleset: '{other}'"))),
         }
     }
 }
 
+/// Whether a drink contains alcohol.
+///
+/// Stored on `drink_types.alcoholic` as a boolean, *and* on
+/// `sessions.least_played_drink_category` as a TEXT — this enum maps the
+/// latter. The boolean column stays a bool: there are only ever two
+/// values, so the enum-vs-bool trade lands on bool for that case.
+///
+/// See `docs/data-model.md` notes: the frontend renders `non_alcoholic`
+/// as the hyphenated `"non-alcoholic"`; the wire and DB use the
+/// underscored form.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "Text")]
+#[serde(rename_all = "snake_case")]
+pub enum DrinkCategory {
+    #[sea_orm(string_value = "alcoholic")]
+    Alcoholic,
+    #[sea_orm(string_value = "non_alcoholic")]
+    NonAlcoholic,
+}
+
+/// Why a run was flagged. Stored on `run_flags.reason` as the `snake_case`
+/// strings declared below.
+///
+/// Five user-initiated variants (chosen from a dropdown when a user flags
+/// their own run) plus one auto-generated variant emitted by the
+/// record-without-photo detection. See `docs/data-model.md` § `run_flags`
+/// for the spelled-out display text the frontend renders for each.
+///
+/// No write path consumes this yet — the type is defined here so the
+/// `run_flags.reason` column is enum-typed end-to-end the moment the
+/// flag-creation flow lands.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "Text")]
+#[serde(rename_all = "snake_case")]
+pub enum RunFlagReason {
+    #[sea_orm(string_value = "time_is_incorrect")]
+    TimeIsIncorrect,
+    #[sea_orm(string_value = "wrong_track")]
+    WrongTrack,
+    #[sea_orm(string_value = "wrong_race_setup")]
+    WrongRaceSetup,
+    #[sea_orm(string_value = "wrong_drink_type")]
+    WrongDrinkType,
+    #[sea_orm(string_value = "other")]
+    Other,
+    #[sea_orm(string_value = "record_requires_photo_verification")]
+    RecordRequiresPhotoVerification,
+}
+
 #[cfg(test)]
 mod tests {
+    use sea_orm::{ActiveEnum, Iterable};
+
     use super::*;
 
     #[test]
-    fn session_status_parses_known_values() {
-        assert_eq!(
-            SessionStatus::from_str("active").unwrap(),
-            SessionStatus::Active
-        );
-        assert_eq!(
-            SessionStatus::from_str("closed").unwrap(),
-            SessionStatus::Closed
-        );
-    }
-
-    #[test]
-    fn session_status_unknown_is_internal_error() {
-        let err = SessionStatus::from_str("nonsense").unwrap_err();
-        match &err {
-            Error::Internal(inner) => assert!(inner.to_string().contains("nonsense")),
-            other => panic!("expected Internal, got {other:?}"),
+    fn test_session_status_string_values_round_trip_through_sea_orm() {
+        // Spot-check both variants. `to_value()` is the DB-bound form
+        // produced by `DeriveActiveEnum`; `try_from_value` is the parse-
+        // from-DB form. A mismatch here would mean the entity column
+        // would silently fail to load on read.
+        for status in SessionStatus::iter() {
+            let value = status.to_value();
+            let parsed = SessionStatus::try_from_value(&value).expect("round-trip");
+            assert_eq!(parsed, status);
         }
     }
 
     #[test]
-    fn session_status_round_trip() {
-        for status in [SessionStatus::Active, SessionStatus::Closed] {
-            let s = status.as_str();
-            assert_eq!(SessionStatus::from_str(s).unwrap(), status);
-            assert_eq!(status.to_string(), s);
-        }
-    }
-
-    #[test]
-    fn session_status_serde_lowercase() {
+    fn test_session_status_serde_uses_lowercase_string() {
         let json = serde_json::to_string(&SessionStatus::Active).unwrap();
         assert_eq!(json, "\"active\"");
         let parsed: SessionStatus = serde_json::from_str("\"closed\"").unwrap();
@@ -123,15 +165,31 @@ mod tests {
     }
 
     #[test]
-    fn ruleset_parses_known_values() {
-        assert_eq!(Ruleset::from_str("random").unwrap(), Ruleset::Random);
+    fn test_session_ruleset_parses_each_known_variant() {
+        assert_eq!(
+            SessionRuleset::from_str("random").unwrap(),
+            SessionRuleset::Random,
+        );
+        assert_eq!(
+            SessionRuleset::from_str("default").unwrap(),
+            SessionRuleset::Default,
+        );
+        assert_eq!(
+            SessionRuleset::from_str("least_played").unwrap(),
+            SessionRuleset::LeastPlayed,
+        );
+        assert_eq!(
+            SessionRuleset::from_str("round_robin").unwrap(),
+            SessionRuleset::RoundRobin,
+        );
     }
 
     #[test]
-    fn ruleset_unknown_is_bad_request() {
-        // Unknown ruleset is user input (from API), so it's a 400, not a 500 —
-        // deliberately different from SessionStatus, which is read from the DB.
-        let err = Ruleset::from_str("spiral").unwrap_err();
+    fn test_session_ruleset_unknown_is_bad_request_with_input_value() {
+        // Unknown ruleset is client input (from JSON body), so it surfaces
+        // as a 400 with the offending value in the message — distinct from
+        // a DB-read failure which would be Internal.
+        let err = SessionRuleset::from_str("spiral").unwrap_err();
         match err {
             Error::BadRequest { client, .. } => assert!(client.contains("spiral")),
             other => panic!("expected BadRequest, got {other:?}"),
@@ -139,9 +197,66 @@ mod tests {
     }
 
     #[test]
-    fn ruleset_round_trip() {
-        let s = Ruleset::Random.as_str();
-        assert_eq!(Ruleset::from_str(s).unwrap(), Ruleset::Random);
-        assert_eq!(Ruleset::Random.to_string(), s);
+    fn test_session_ruleset_string_values_round_trip_through_sea_orm() {
+        for ruleset in SessionRuleset::iter() {
+            let value = ruleset.to_value();
+            let parsed = SessionRuleset::try_from_value(&value).expect("round-trip");
+            assert_eq!(parsed, ruleset);
+        }
+    }
+
+    #[test]
+    fn test_session_ruleset_serde_emits_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&SessionRuleset::Random).unwrap(),
+            "\"random\"",
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionRuleset::LeastPlayed).unwrap(),
+            "\"least_played\"",
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionRuleset::RoundRobin).unwrap(),
+            "\"round_robin\"",
+        );
+    }
+
+    #[test]
+    fn test_drink_category_round_trip_through_sea_orm_and_serde() {
+        for category in DrinkCategory::iter() {
+            let value = category.to_value();
+            let parsed = DrinkCategory::try_from_value(&value).expect("round-trip");
+            assert_eq!(parsed, category);
+
+            let json = serde_json::to_string(&category).unwrap();
+            let recovered: DrinkCategory = serde_json::from_str(&json).unwrap();
+            assert_eq!(recovered, category);
+        }
+
+        // Spot-check the snake_case spelling the schema commits to.
+        assert_eq!(
+            serde_json::to_string(&DrinkCategory::NonAlcoholic).unwrap(),
+            "\"non_alcoholic\"",
+        );
+    }
+
+    #[test]
+    fn test_run_flag_reason_round_trip_through_sea_orm_and_serde() {
+        for reason in RunFlagReason::iter() {
+            let value = reason.to_value();
+            let parsed = RunFlagReason::try_from_value(&value).expect("round-trip");
+            assert_eq!(parsed, reason);
+
+            let json = serde_json::to_string(&reason).unwrap();
+            let recovered: RunFlagReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(recovered, reason);
+        }
+
+        // Verify the auto-generated variant's spelling — the only multi-word
+        // reason where a typo would silently break a future feature.
+        assert_eq!(
+            serde_json::to_string(&RunFlagReason::RecordRequiresPhotoVerification).unwrap(),
+            "\"record_requires_photo_verification\"",
+        );
     }
 }

--- a/backend/src/entities/run_flags.rs
+++ b/backend/src/entities/run_flags.rs
@@ -1,5 +1,7 @@
 use sea_orm::entity::prelude::*;
 
+use crate::domain::enums::RunFlagReason;
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "run_flags")]
 pub struct Model {
@@ -7,8 +9,7 @@ pub struct Model {
     pub id: String,
     #[sea_orm(column_type = "Text")]
     pub run_id: String,
-    #[sea_orm(column_type = "Text")]
-    pub reason: String,
+    pub reason: RunFlagReason,
     #[sea_orm(column_type = "Text", nullable)]
     pub note: Option<String>,
     pub hide_while_pending: bool,

--- a/backend/src/entities/sessions.rs
+++ b/backend/src/entities/sessions.rs
@@ -1,5 +1,7 @@
 use sea_orm::entity::prelude::*;
 
+use crate::domain::enums::{DrinkCategory, SessionRuleset, SessionStatus};
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "sessions")]
 pub struct Model {
@@ -7,12 +9,9 @@ pub struct Model {
     pub id: String,
     #[sea_orm(column_type = "Text")]
     pub host_id: String,
-    #[sea_orm(column_type = "Text")]
-    pub ruleset: String,
-    #[sea_orm(column_type = "Text", nullable)]
-    pub least_played_drink_category: Option<String>,
-    #[sea_orm(column_type = "Text")]
-    pub status: String,
+    pub ruleset: SessionRuleset,
+    pub least_played_drink_category: Option<DrinkCategory>,
+    pub status: SessionStatus,
     pub created_at: DateTime,
     pub last_activity_at: DateTime,
 }

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -24,7 +24,9 @@ pub struct CreateSessionRequest {
 /// # Errors
 ///
 /// Propagates the errors of [`sessions::create_session`]: `BadRequest` for an
-/// unknown ruleset, `Conflict` if the user is already in another active session.
+/// unknown ruleset or for a known-but-not-yet-implemented variant of
+/// [`crate::domain::enums::SessionRuleset`]; `Conflict` if the user is already
+/// in another active session.
 #[tracing::instrument(skip_all, fields(user_id = %user.user_id, ruleset = %body.ruleset))]
 pub async fn create_session(
     user: User,

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -32,7 +32,7 @@ pub async fn load_active_session<C: ConnectionTrait>(
         .one(db)
         .await?
         .ok_or_else(|| Error::NotFound("Session not found".into()))?;
-    if session.status != SessionStatus::Active.as_str() {
+    if session.status != SessionStatus::Active {
         return Err(Error::conflict("Session is not active"));
     }
     Ok(session)
@@ -262,11 +262,11 @@ mod tests {
     async fn load_active_session_returns_active() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
 
         let model = load_active_session(&db, &session_id).await.unwrap();
         assert_eq!(model.id, session_id.to_string());
-        assert_eq!(model.status, "active");
+        assert_eq!(model.status, SessionStatus::Active);
     }
 
     #[tokio::test]
@@ -282,7 +282,7 @@ mod tests {
     async fn load_active_session_closed_is_conflict() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "closed").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Closed).await;
 
         let err = load_active_session(&db, &session_id).await.unwrap_err();
         assert!(matches!(err, Error::Conflict { .. }));
@@ -294,7 +294,7 @@ mod tests {
     async fn require_active_participant_returns_row_when_active() {
         let db = setup_db().await;
         let user = create_user(&db, "u1").await;
-        let session_id = insert_session(&db, &user, "active").await;
+        let session_id = insert_session(&db, &user, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &user, None).await;
 
         let row = require_active_participant(&db, &session_id, &user)
@@ -308,7 +308,7 @@ mod tests {
     async fn require_active_participant_no_row_is_forbidden() {
         let db = setup_db().await;
         let user = create_user(&db, "u1").await;
-        let session_id = insert_session(&db, &user, "active").await;
+        let session_id = insert_session(&db, &user, SessionStatus::Active).await;
 
         let err = require_active_participant(&db, &session_id, &user)
             .await
@@ -320,7 +320,7 @@ mod tests {
     async fn require_active_participant_left_is_forbidden() {
         let db = setup_db().await;
         let user = create_user(&db, "u1").await;
-        let session_id = insert_session(&db, &user, "active").await;
+        let session_id = insert_session(&db, &user, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &user, Some(Utc::now().naive_utc())).await;
 
         let err = require_active_participant(&db, &session_id, &user)
@@ -335,7 +335,7 @@ mod tests {
     async fn touch_session_updates_last_activity_at() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
 
         let before = sessions::Entity::find_by_id(session_id)
             .one(&db)
@@ -483,7 +483,7 @@ mod tests {
         let active = create_user(&db, "active").await;
         let left = create_user(&db, "left").await;
 
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host, None).await;
         insert_participant(&db, &session_id, &active, None).await;
         insert_participant(&db, &session_id, &left, Some(Utc::now().naive_utc())).await;
@@ -524,7 +524,7 @@ mod tests {
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         // host has already left
         insert_participant(&db, &session_id, &host, Some(Utc::now().naive_utc())).await;
 

--- a/backend/src/services/runs.rs
+++ b/backend/src/services/runs.rs
@@ -555,6 +555,7 @@ pub async fn get_run_defaults(
 mod tests {
     use super::*;
     use crate::{
+        domain::enums::SessionStatus,
         entities::sessions as sessions_entity,
         services::sessions,
         test_helpers::{create_user, seed_game_data, setup_db},
@@ -871,7 +872,7 @@ mod tests {
             .unwrap();
         if let Some(s) = s {
             let mut active: sessions_entity::ActiveModel = s.into();
-            active.status = Set("closed".to_string());
+            active.status = Set(SessionStatus::Closed);
             active.update(&db).await.unwrap();
         }
 

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -110,13 +110,16 @@ mod tests {
     use sea_orm::EntityTrait;
 
     use super::*;
-    use crate::test_helpers::{create_user, insert_participant, insert_session, setup_db};
+    use crate::{
+        domain::enums::SessionStatus,
+        test_helpers::{create_user, insert_participant, insert_session, setup_db},
+    };
 
     #[tokio::test]
     async fn load_active_populates_session() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
 
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
         assert_eq!(ctx.session.id, session_id.to_string());
@@ -136,7 +139,7 @@ mod tests {
     async fn load_active_closed_propagates_conflict() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "closed").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Closed).await;
 
         let err = SessionContext::load_active(&db, &session_id)
             .await
@@ -148,7 +151,7 @@ mod tests {
     async fn require_host_matches() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         ctx.require_host(&host).expect("host matches");
@@ -159,7 +162,7 @@ mod tests {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let other = create_user(&db, "other").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         let err = ctx.require_host(&other).unwrap_err();
@@ -170,7 +173,7 @@ mod tests {
     async fn require_participant_happy_and_forbidden_paths() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host, None).await;
         let ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
@@ -188,7 +191,7 @@ mod tests {
     async fn touch_bumps_last_activity_at_in_db_and_struct() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         let mut ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
 
         let before = ctx.session.last_activity_at;

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::{
     domain::{
         ImagePath, SessionId, SessionRaceId, UserId, Username,
-        enums::{Ruleset, SessionStatus},
+        enums::{SessionRuleset, SessionStatus},
     },
     entities::{
         cups, runs, session_participants, session_race_participations, session_races, sessions,
@@ -94,16 +94,27 @@ pub async fn get_active_session_id(
 ///
 /// # Errors
 ///
-/// Returns `BadRequest` if `ruleset` doesn't parse as a known `Ruleset`;
-/// `Conflict` if the user is already in another active session; `Internal`
-/// for unexpected DB failures.
+/// Returns `BadRequest` if `ruleset` doesn't parse as a known
+/// [`SessionRuleset`], or if it parses to a variant whose track-selection
+/// logic isn't implemented yet (everything except `Random` — see
+/// [`SessionRuleset`] for the gate); `Conflict` if the user is already in
+/// another active session; `Internal` for unexpected DB failures.
 #[tracing::instrument(skip(db), fields(user_id = %user_id, ruleset = %ruleset))]
 pub async fn create_session(
     db: &DatabaseConnection,
     user_id: &UserId,
     ruleset: &str,
 ) -> Result<SessionDetail, Error> {
-    let parsed: Ruleset = ruleset.parse()?;
+    let parsed: SessionRuleset = ruleset.parse()?;
+    if parsed != SessionRuleset::Random {
+        // The DB column accepts every variant, but the service layer only
+        // knows how to drive `Random` sessions today. Reject the others
+        // here rather than creating a structurally-broken session whose
+        // ruleset the rest of the code has no path to honor.
+        return Err(Error::bad_request(format!(
+            "Ruleset '{ruleset}' is not yet supported",
+        )));
+    }
 
     check_not_in_any_session(db, user_id).await?;
 
@@ -119,9 +130,9 @@ pub async fn create_session(
     sessions::ActiveModel {
         id: Set(session_id.into()),
         host_id: Set(user_id.into()),
-        ruleset: Set(parsed.to_string()),
+        ruleset: Set(parsed),
         least_played_drink_category: Set(None),
-        status: Set(SessionStatus::Active.to_string()),
+        status: Set(SessionStatus::Active),
         created_at: NotSet,
         last_activity_at: Set(now),
     }
@@ -150,7 +161,7 @@ pub struct SessionSummary {
     pub host_username: Username,
     pub participant_count: i64,
     pub race_number: i64,
-    pub ruleset: String,
+    pub ruleset: SessionRuleset,
     pub last_activity_at: DateTime<Utc>,
 }
 
@@ -161,7 +172,7 @@ struct SessionSummaryRow {
     host_username: String,
     participant_count: i64,
     race_count: i64,
-    ruleset: String,
+    ruleset: SessionRuleset,
     last_activity_at: NaiveDateTime,
 }
 
@@ -301,8 +312,8 @@ pub struct SessionDetail {
     pub id: SessionId,
     pub host_id: UserId,
     pub host_username: Username,
-    pub ruleset: String,
-    pub status: String,
+    pub ruleset: SessionRuleset,
+    pub status: SessionStatus,
     pub created_at: DateTime<Utc>,
     pub last_activity_at: DateTime<Utc>,
     pub participants: Vec<ParticipantInfo>,
@@ -974,7 +985,7 @@ pub async fn leave_session(
             active_session.host_id = Set((&new_host_id).into());
         }
         HostDisposition::SessionClosed => {
-            active_session.status = Set(SessionStatus::Closed.to_string());
+            active_session.status = Set(SessionStatus::Closed);
         }
         HostDisposition::NoChange => {}
     }
@@ -1244,7 +1255,7 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
     let stale = sessions::Entity::find()
         .filter(
             Condition::all()
-                .add(sessions::Column::Status.eq(SessionStatus::Active.as_str()))
+                .add(sessions::Column::Status.eq(SessionStatus::Active))
                 .add(sessions::Column::LastActivityAt.lt(one_hour_ago)),
         )
         .all(db)
@@ -1269,7 +1280,7 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
             .await?;
 
         let mut active: sessions::ActiveModel = session.into();
-        active.status = Set(SessionStatus::Closed.to_string());
+        active.status = Set(SessionStatus::Closed);
         active.update(&txn).await?;
     }
     txn.commit().await?;
@@ -1314,7 +1325,7 @@ mod tests {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let user2 = create_user(&db, "user2").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         // host has already left (left_at set in the real flow before this call)
         insert_participant(&db, &session_id, &host, Some(Utc::now().naive_utc())).await;
         insert_participant(&db, &session_id, &user2, None).await;
@@ -1329,7 +1340,7 @@ mod tests {
     async fn test_transfer_host_leaves_alone_closes_session() {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         // host's participant row has left_at set
         insert_participant(&db, &session_id, &host, Some(Utc::now().naive_utc())).await;
 
@@ -1344,7 +1355,7 @@ mod tests {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let user2 = create_user(&db, "user2").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host, None).await;
         // user2 has already left (left_at set in the real flow)
         insert_participant(&db, &session_id, &user2, Some(Utc::now().naive_utc())).await;
@@ -1360,7 +1371,7 @@ mod tests {
         let db = setup_db().await;
         let host = create_user(&db, "host").await;
         let user2 = create_user(&db, "user2").await;
-        let session_id = insert_session(&db, &host, "active").await;
+        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
         // Both have left_at set (host left first, then user2)
         insert_participant(&db, &session_id, &host, Some(Utc::now().naive_utc())).await;
         insert_participant(&db, &session_id, &user2, Some(Utc::now().naive_utc())).await;
@@ -1393,7 +1404,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(updated.host_id, user2_id.to_string());
-        assert_eq!(updated.status, "active");
+        assert_eq!(updated.status, SessionStatus::Active);
     }
 
     #[tokio::test]
@@ -1410,7 +1421,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(updated.status, "closed");
+        assert_eq!(updated.status, SessionStatus::Closed);
     }
 
     #[tokio::test]
@@ -1496,6 +1507,34 @@ mod tests {
 
         let result = create_session(&db, &host_id, "invalid_ruleset").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_with_parseable_but_unsupported_ruleset_is_bad_request() {
+        // `default` / `least_played` / `round_robin` are valid
+        // `SessionRuleset` variants (the enum carries all four per the
+        // compliance plan), but only `Random` is wired through the service.
+        // Until the others land, the service rejects them at the gate with
+        // a 400 carrying the offending name — distinct from the
+        // "Invalid ruleset" message produced by `FromStr` on garbage input.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+
+        for ruleset in ["default", "least_played", "round_robin"] {
+            let result = create_session(&db, &host_id, ruleset).await;
+            let Err(err) = result else {
+                panic!("expected BadRequest for {ruleset}, got Ok(_)");
+            };
+            match err {
+                Error::BadRequest { client, .. } => {
+                    assert!(
+                        client.contains(ruleset) && client.contains("not yet supported"),
+                        "expected gate message for {ruleset}, got {client:?}",
+                    );
+                }
+                other => panic!("expected BadRequest for {ruleset}, got {other:?}"),
+            }
+        }
     }
 
     #[tokio::test]
@@ -1938,7 +1977,7 @@ mod tests {
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host_id, "active").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
 
         let txn = db.begin().await.unwrap();
@@ -2009,7 +2048,7 @@ mod tests {
         let db = setup_db().await;
         seed_game_data(&db).await;
         let host_id = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host_id, "active").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
         let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
         insert_race_participation(&db, &race_id, &host_id, None).await;
@@ -2057,7 +2096,7 @@ mod tests {
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host_id, "active").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
         let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
 

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -21,7 +21,10 @@ use sea_orm::{
 use uuid::Uuid;
 
 use crate::{
-    domain::{SessionId, SessionRaceId, UserId},
+    domain::{
+        SessionId, SessionRaceId, UserId,
+        enums::{SessionRuleset, SessionStatus},
+    },
     drink_type_id::drink_type_uuid,
     entities::{
         bodies, characters, cups, drink_types, gliders, session_participants,
@@ -115,14 +118,18 @@ pub async fn seed_tracks_for_test(db: &DatabaseConnection) {
 
 /// Insert a session with the given host and status. Returns the generated
 /// session ID.
-pub async fn insert_session(db: &DatabaseConnection, host_id: &UserId, status: &str) -> SessionId {
+pub async fn insert_session(
+    db: &DatabaseConnection,
+    host_id: &UserId,
+    status: SessionStatus,
+) -> SessionId {
     let id = SessionId::new_v4();
     sessions::ActiveModel {
         id: Set((&id).into()),
         host_id: Set(host_id.into()),
-        ruleset: Set("random".to_string()),
+        ruleset: Set(SessionRuleset::Random),
         least_played_drink_category: Set(None),
-        status: Set(status.to_string()),
+        status: Set(status),
         created_at: NotSet,
         last_activity_at: Set(Utc::now().naive_utc()),
     }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -302,6 +302,8 @@ Preset flag reasons (user-initiated):
 Auto-generated flag reasons:
 - "Record requires photo verification"
 
+Storage values (snake_case): `time_is_incorrect`, `wrong_track`, `wrong_race_setup`, `wrong_drink_type`, `other`, `record_requires_photo_verification`. The frontend renders the display text shown above; the wire and DB use the snake_case form.
+
 Notes:
 - A run is considered flagged if it has an unresolved entry in `run_flags` (where `resolved_at` is null).
 - Users can only flag their own runs, and only if the run has a photo attached.
@@ -362,3 +364,4 @@ Each session uses one ruleset that determines how tracks are selected. The rules
 ## Document history
 
 - 2026-05-05 — Extracted from `docs/design.md` as part of PR 1 (docs restructure foundation). See `docs/designs/2026-05-04-design-doc-restructure.md` §5.1.
+- 2026-05-13 — § `run_flags` now enumerates the canonical snake_case storage values for `reason` alongside the display text, mirroring the storage-vs-display split already documented for `sessions.{ruleset,status,least_played_drink_category}`. The values are load-bearing as of PR-D3 ([#120](https://github.com/brendanbyrne/beerio-kart/issues/120) / PR [#148](https://github.com/brendanbyrne/beerio-kart/pull/148)), which committed them via `RunFlagReason::string_value` annotations on the `DeriveActiveEnum` backing the column. Review feedback from PR #148.


### PR DESCRIPTION
Closes #120.

## Summary

Stream D step 3 (#122 = D1 / IDs, #133 = D2 / strings, this = D3 / enums). Replaces four string-typed enum columns with `sea_orm::DeriveActiveEnum`-backed Rust enums so the entity column type itself enforces the variant set, matches over them are compiler-checked, and call sites stop juggling `.as_str()` / `.to_string()` between Rust and the DB.

### What changed

- New / rewritten enums in `domain/enums.rs`:
  - `SessionStatus` — `Active` / `Closed`. Was already a hand-rolled enum; now goes through `DeriveActiveEnum` so the column carries the type natively. Dropped `as_str` and `FromStr` (no longer used externally — entity round-trips through SeaORM, JSON round-trips through serde).
  - `SessionRuleset` (renamed from `Ruleset`) — `Random`, `Default`, `LeastPlayed`, `RoundRobin`. `FromStr` is preserved for the service-layer parse from the route DTO's `ruleset: String` — see the note about #146 below.
  - `DrinkCategory` — `Alcoholic` / `NonAlcoholic`. Maps `sessions.least_played_drink_category` (TEXT, nullable). The boolean `drink_types.alcoholic` column stays a bool — only two values, no Rust enum benefit there.
  - `RunFlagReason` — six variants (`time_is_incorrect`, `wrong_track`, `wrong_race_setup`, `wrong_drink_type`, `other`, `record_requires_photo_verification`). No write path consumes it yet; defined here so the column is enum-typed end-to-end the moment the flag-creation flow lands.
- Entity columns are now the enum types directly (`entities/sessions.rs`, `entities/run_flags.rs`). Migration is unchanged because SeaORM maps `DeriveActiveEnum` to TEXT at runtime and the columns are already TEXT. **No dev DB reset needed.**
- `SessionDetail` / `SessionSummary` / `SessionSummaryRow` now carry `SessionRuleset` / `SessionStatus` instead of `String`. Wire shape is unchanged thanks to serde's `rename_all` derives matching the `string_value` mappings.
- `test_helpers::insert_session` takes `SessionStatus` instead of `&str`. Every `insert_session(..., \"active\")` / `\"closed\"` callsite now passes the enum variant.

### Behavior change to flag explicitly

`create_session` now parses to `SessionRuleset` and **rejects parseable-but-not-yet-implemented variants** at the service gate with `BadRequest("Ruleset '…' is not yet supported")`. Today only `random` actually drives a session; the other three variants are defined for type completeness but have no track-selection logic. The gate keeps today's UX (only `random` succeeds) while exposing the full enum to the type system. A new test (`test_create_with_parseable_but_unsupported_ruleset_is_bad_request`) exercises the gate. When `default` / `least_played` / `round_robin` get wired up later, the gate's match arm contracts naturally.

### Decision: route DTO stays `ruleset: String`

The cleanest end-state is `pub ruleset: SessionRuleset` in `CreateSessionRequest`, but switching today would route invalid client input through axum's JSON extractor and produce a 422 with a serde-flavoured error body — exactly the envelope-mismatch tracked in #146. Until #146 lands, keeping the parse at the service layer via `SessionRuleset::from_str` preserves the existing 400 + `{ "error": "Invalid ruleset: '<x>'" }` shape. The `FromStr` impl has a doc-comment pointing at #146 so the reasoning is grep-findable.

### Scope notes

- The handoff mentioned PR-G3 doc-comment sweep for fields touched by D-stream — done for `routes/sessions.rs::create_session` (now references `SessionRuleset` and the "not yet supported" variant).
- Raw SQL queries like `WHERE s.status = 'active'` (3 sites in `services/sessions.rs`) intentionally keep the string literal — DB still stores `'active'`, the enum's `string_value` matches.
- This unblocks #58 (PR-F2 `session_cleanup_loop`), which depends on a typed `SessionStatus`.

## Test plan

- [x] `cd backend && cargo check` — passes
- [x] `cd backend && cargo clippy --all-targets` — passes (no new lints)
- [x] `cd backend && cargo test` — 234 lib tests + 19 session_integration tests + 1 middleware_limits + 1 schema_drift = all pass
- [x] Spot-check the new gate: `cd backend && cargo test test_create_with_parseable_but_unsupported_ruleset_is_bad_request` — passes
- [x] Spot-check existing invalid-ruleset path is unchanged: `cd backend && cargo test test_create_session_with_invalid_ruleset_returns_400` — passes (still returns 400, "Invalid ruleset")
- [x] No migration changes; `tests/schema_drift.rs` (which `SELECT`s every entity from a freshly-migrated DB) passes — proves the new enum column types are wire-compatible with the existing TEXT columns
- [ ] (Manual, optional) Boot the dev server with a stale DB and confirm `GET /sessions` deserializes existing rows' `ruleset` / `status` strings into the new enum types without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)