### PR TITLE
153: Enable rustc missing_docs lint + document ~225 surfaced sites

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,6 +5,11 @@ members = ["migration"]
 warnings = "deny"
 unsafe_code = "forbid"
 rust_2018_idioms = { level = "warn", priority = -1 }
+# Enforces `rust.md` § 6 on `pub` items. Rustc's lint only covers `pub`
+# visibility (not `pub(crate)`), so cross-module-`pub(crate)` regressions
+# still rely on review; the broader `clippy::missing_docs_in_private_items`
+# would also force docs on bare-private items, which § 6 doesn't require.
+missing_docs = "warn"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub use sea_orm_migration::prelude::*;
 
+/// Consolidated initial-schema migration — table, FK, and index DDL.
 pub mod m20260101_000001_initial_schema;
 
 /// Runs the consolidated initial-schema migration.

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -1,6 +1,10 @@
 // PR-A1 scaffolding: rust-2018 idioms cleanup deferred to Phase H per
 // rust.md § 8 ("config and clearing land in separate PRs").
 #![allow(elided_lifetimes_in_paths)]
+// The `Iden` enums below are mechanical SeaORM DDL scaffolding — each
+// variant is a column name, so the variant name itself is the
+// documentation. `rust.md` § 6 doesn't earn its keep here; opt out.
+#![allow(missing_docs)]
 
 use sea_orm_migration::prelude::*;
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -10,6 +10,8 @@ use crate::domain::UserId;
 /// without cloning the inner data on every request.
 #[derive(Clone, Debug)]
 pub struct Config {
+    /// HMAC signing key for access and refresh tokens. Loaded from
+    /// `JWT_SECRET`; absence is a hard startup failure.
     pub jwt_secret: String,
     /// How long access tokens are valid (minutes). Short-lived because they
     /// can't be revoked — if one leaks, it expires quickly. Stored as `i64`
@@ -20,6 +22,8 @@ pub struct Config {
     /// by bumping `refresh_token_version` in the database. Stored as `i64`
     /// because `chrono::TimeDelta::days` takes `i64`.
     pub jwt_refresh_expiry_days: i64,
+    /// Optional admin user ID — only this user can use admin-gated endpoints.
+    /// `None` disables admin features entirely.
     pub admin_user_id: Option<UserId>,
     /// Controls the `Secure` flag on the refresh cookie. Must be `false` for
     /// local `http://localhost` development, `true` in production behind HTTPS.

--- a/backend/src/domain/enums.rs
+++ b/backend/src/domain/enums.rs
@@ -31,8 +31,10 @@ use crate::error::Error;
 #[sea_orm(rs_type = "String", db_type = "Text")]
 #[serde(rename_all = "lowercase")]
 pub enum SessionStatus {
+    /// Session is accepting joins / leaves / race submissions.
     #[sea_orm(string_value = "active")]
     Active,
+    /// Session has ended; no further mutations allowed.
     #[sea_orm(string_value = "closed")]
     Closed,
 }
@@ -52,12 +54,17 @@ pub enum SessionStatus {
 #[sea_orm(rs_type = "String", db_type = "Text")]
 #[serde(rename_all = "snake_case")]
 pub enum SessionRuleset {
+    /// Each race's track is picked uniformly at random.
     #[sea_orm(string_value = "random")]
     Random,
+    /// Host selects each track manually. (Not yet implemented.)
     #[sea_orm(string_value = "default")]
     Default,
+    /// Track selection weighted toward tracks the group has played least.
+    /// (Not yet implemented.)
     #[sea_orm(string_value = "least_played")]
     LeastPlayed,
+    /// Cycles deterministically through a fixed playlist. (Not yet implemented.)
     #[sea_orm(string_value = "round_robin")]
     RoundRobin,
 }
@@ -100,8 +107,10 @@ impl FromStr for SessionRuleset {
 #[sea_orm(rs_type = "String", db_type = "Text")]
 #[serde(rename_all = "snake_case")]
 pub enum DrinkCategory {
+    /// Contains alcohol.
     #[sea_orm(string_value = "alcoholic")]
     Alcoholic,
+    /// Does not contain alcohol.
     #[sea_orm(string_value = "non_alcoholic")]
     NonAlcoholic,
 }
@@ -123,16 +132,22 @@ pub enum DrinkCategory {
 #[sea_orm(rs_type = "String", db_type = "Text")]
 #[serde(rename_all = "snake_case")]
 pub enum RunFlagReason {
+    /// User reports the recorded time doesn't match what they actually ran.
     #[sea_orm(string_value = "time_is_incorrect")]
     TimeIsIncorrect,
+    /// User reports the run was assigned to the wrong track.
     #[sea_orm(string_value = "wrong_track")]
     WrongTrack,
+    /// User reports the recorded character/body/wheel/glider don't match.
     #[sea_orm(string_value = "wrong_race_setup")]
     WrongRaceSetup,
+    /// User reports the recorded drink type doesn't match.
     #[sea_orm(string_value = "wrong_drink_type")]
     WrongDrinkType,
+    /// Catch-all for any other dispute.
     #[sea_orm(string_value = "other")]
     Other,
+    /// Auto-generated when a personal-record-bearing run lacks a photo.
     #[sea_orm(string_value = "record_requires_photo_verification")]
     RecordRequiresPhotoVerification,
 }

--- a/backend/src/domain/mod.rs
+++ b/backend/src/domain/mod.rs
@@ -1,7 +1,12 @@
+/// String-backed game enums (`SessionStatus`, `SessionRuleset`, `DrinkCategory`, `RunFlagReason`).
 pub mod enums;
+/// UUID- and integer-backed ID newtypes per [`rust.md` § 2].
 pub mod ids;
+/// Numeric domain types ([`LapTimeMs`], [`RaceTimeMs`]) with non-zero validation.
 pub mod numeric;
+/// Per-session character/vehicle/glider race setup chosen at session creation.
 pub mod race_setup;
+/// Validated string newtypes (`Username`, `EmailAddress`, etc.).
 pub mod strings;
 
 pub use ids::{

--- a/backend/src/domain/race_setup.rs
+++ b/backend/src/domain/race_setup.rs
@@ -11,9 +11,13 @@ use crate::{
 /// compile time so call sites can't read only some of the fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Update {
+    /// Character the user races as for this session.
     pub character_id: CharacterId,
+    /// Kart body chassis.
     pub body_id: BodyId,
+    /// Wheels mounted on the kart body.
     pub wheel_id: WheelId,
+    /// Glider used during ramp sections.
     pub glider_id: GliderId,
 }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -27,7 +27,11 @@ pub enum Error {
     /// via `Error::bad_request("...")`.
     #[error("{client}")]
     BadRequest {
+        /// User-facing message included in the JSON response body.
         client: String,
+        /// Internal-only context (e.g., a raw `DbErr` driver string) logged
+        /// via `tracing::warn!` at the `IntoResponse` boundary and never
+        /// returned to the client.
         detail: Option<String>,
     },
     /// 401 — wrong credentials, expired/missing token
@@ -44,7 +48,11 @@ pub enum Error {
     /// `BadRequest`; construct via `Error::conflict("...")` for the common case.
     #[error("{client}")]
     Conflict {
+        /// User-facing message included in the JSON response body.
         client: String,
+        /// Internal-only context (e.g., a raw `DbErr` driver string) logged
+        /// via `tracing::warn!` at the `IntoResponse` boundary and never
+        /// returned to the client.
         detail: Option<String>,
     },
     /// 500 — unexpected internal failures (DB, invariant violations, etc.).

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,18 +12,32 @@
 // Tests legitimately want to panic — per rust.md § 8.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+/// Loaded server configuration (JWT secrets, cookie flags, request limits).
 pub mod config;
+/// SeaORM connection-pool setup with per-connection SQLite PRAGMAs.
 pub mod db;
+/// Domain types — IDs, validated strings, numeric newtypes, enums.
 pub mod domain;
+/// Newtype wrapper for drink-type identifiers (currently a plain string).
 pub mod drink_type_id;
-#[allow(unused_imports)]
+// Hand-written SeaORM entities (ADR 0023): every `pub` item in the
+// submodules is a column declaration or relation marker whose name IS
+// the documentation. `rust.md` § 6 doesn't earn its keep here; opt out
+// at the module boundary so we don't need a `#![allow]` in each file.
+#[allow(unused_imports, missing_docs)]
 pub mod entities;
+/// Unified application error type implementing [`axum::response::IntoResponse`].
 pub mod error;
+/// Axum middleware — JWT-based auth extractor and request-limit handlers.
 pub mod middleware;
+/// HTTP route handlers grouped by resource.
 pub mod routes;
+/// Business-logic service layer — orchestrates entities, enforces rules.
 pub mod services;
+/// Graceful-shutdown wiring: signal handling, task supervision, and drain.
 pub mod shutdown;
 
+/// Test fixtures and helpers shared across integration tests.
 #[cfg(test)]
 pub mod test_helpers;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,9 @@
+//! Beerio Kart backend binary entry point.
+//!
+//! Wires config, the `SeaORM` connection pool, migrations, seeded static data,
+//! Tower middleware, and graceful shutdown around `axum::serve`. Library
+//! pieces — handlers, services, entities — live in [`beerio_kart`].
+
 mod seed;
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -19,7 +19,9 @@ use crate::{domain::UserId, error::Error};
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct User {
+    /// Authenticated user's UUID parsed from the access token's `sub` claim.
     pub user_id: UserId,
+    /// Authenticated user's username copied from the token's `username` claim.
     pub username: String,
 }
 
@@ -77,7 +79,9 @@ impl FromRequestParts<crate::AppState> for User {
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AdminUser {
+    /// Authenticated user's UUID, verified to match `Config::admin_user_id`.
     pub user_id: UserId,
+    /// Authenticated user's username copied from the token's `username` claim.
     pub username: String,
 }
 

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,2 +1,4 @@
+/// JWT-bearer auth extractor that materializes an [`auth::User`].
 pub mod auth;
+/// Tower-layer error handlers for the load-shed / concurrency-limit stack.
 pub mod limits;

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -48,7 +48,7 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
-/// Body shape for `POST /auth/login` and `POST /auth/register`.
+/// Success-response body for `POST /auth/login` and `POST /auth/register`.
 #[derive(Serialize)]
 pub struct Response {
     /// Short-lived JWT bearer token to send on subsequent requests.
@@ -57,7 +57,7 @@ pub struct Response {
     pub user: UserInfo,
 }
 
-/// Body shape for `POST /auth/refresh`.
+/// Response body for `POST /auth/refresh`.
 #[derive(Serialize)]
 pub struct RefreshResponse {
     /// Newly-minted short-lived JWT bearer token.

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -21,38 +21,55 @@ use crate::{
 
 // ── Request / Response types ────────────────────────────────────────
 
+/// Body shape for `POST /auth/register`.
 #[derive(Deserialize)]
 pub struct RegisterRequest {
+    /// Desired handle. Subject to `Username` validation at the service boundary.
     pub username: String,
+    /// Plaintext password. Hashed server-side; never stored.
     pub password: String,
 }
 
+/// Body shape for `POST /auth/login`.
 #[derive(Deserialize)]
 pub struct LoginRequest {
+    /// Account handle.
     pub username: String,
+    /// Plaintext password. Verified server-side via Argon2.
     pub password: String,
 }
 
+/// Body shape for `PUT /auth/password`.
 #[derive(Deserialize)]
 pub struct ChangePasswordRequest {
+    /// Plaintext current password. Verified server-side before the rotation.
     pub current_password: String,
+    /// New plaintext password. Hashed server-side; replaces the old hash.
     pub new_password: String,
 }
 
+/// Body shape for `POST /auth/login` and `POST /auth/register`.
 #[derive(Serialize)]
 pub struct Response {
+    /// Short-lived JWT bearer token to send on subsequent requests.
     pub access_token: String,
+    /// Public-facing identity bundle.
     pub user: UserInfo,
 }
 
+/// Body shape for `POST /auth/refresh`.
 #[derive(Serialize)]
 pub struct RefreshResponse {
+    /// Newly-minted short-lived JWT bearer token.
     pub access_token: String,
 }
 
+/// Embedded identity bundle on auth responses.
 #[derive(Serialize)]
 pub struct UserInfo {
+    /// User's stable UUID.
     pub id: UserId,
+    /// Display handle.
     pub username: Username,
 }
 

--- a/backend/src/routes/drink_types.rs
+++ b/backend/src/routes/drink_types.rs
@@ -17,12 +17,19 @@ use crate::{
 
 // ── Response types ───────────────────────────────────────────────────
 
+/// Wire representation of a `drink_types` row.
 #[derive(Serialize)]
 pub struct DrinkTypeResponse {
+    /// Stable UUID. Seeded drinks have known fixed IDs; user-created drinks
+    /// derive theirs from the uppercased name (see `services::drink_types`).
     pub id: DrinkTypeId,
+    /// Display name. Unique case-insensitively.
     pub name: String,
+    /// `true` for alcoholic drinks, `false` for non-alcoholic.
     pub alcoholic: bool,
+    /// User who created this drink. `None` for seeded drinks.
     pub created_by: Option<UserId>,
+    /// Row-creation timestamp, UTC.
     pub created_at: DateTime<Utc>,
 }
 
@@ -45,14 +52,19 @@ impl DrinkTypeResponse {
 
 // ── Request types ────────────────────────────────────────────────────
 
+/// Body shape for `POST /drink-types`.
 #[derive(Deserialize)]
 pub struct CreateDrinkTypeRequest {
+    /// Display name. Case-insensitive uniqueness; existing matches return 200.
     pub name: String,
+    /// `true` for alcoholic drinks, `false` for non-alcoholic.
     pub alcoholic: bool,
 }
 
+/// Query filters for `GET /drink-types`.
 #[derive(Deserialize)]
 pub struct Filters {
+    /// If set, only return drinks matching this alcoholic flag.
     pub alcoholic: Option<bool>,
 }
 

--- a/backend/src/routes/game_data.rs
+++ b/backend/src/routes/game_data.rs
@@ -15,62 +15,93 @@ use crate::{
 
 // ── Response types ───────────────────────────────────────────────────
 
+/// Seeded character row returned by `GET /characters`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CharacterResponse {
+    /// Integer identifier (matches the in-game character id).
     pub id: CharacterId,
+    /// Display name.
     pub name: String,
+    /// Relative path to the character's preview image.
     pub image_path: ImagePath,
 }
 
+/// Seeded kart-body row returned by `GET /bodies`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct BodyResponse {
+    /// Integer identifier (matches the in-game body id).
     pub id: BodyId,
+    /// Display name.
     pub name: String,
+    /// Relative path to the body's preview image.
     pub image_path: ImagePath,
 }
 
+/// Seeded wheel-set row returned by `GET /wheels`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct WheelResponse {
+    /// Integer identifier (matches the in-game wheel id).
     pub id: WheelId,
+    /// Display name.
     pub name: String,
+    /// Relative path to the wheel's preview image.
     pub image_path: ImagePath,
 }
 
+/// Seeded glider row returned by `GET /gliders`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct GliderResponse {
+    /// Integer identifier (matches the in-game glider id).
     pub id: GliderId,
+    /// Display name.
     pub name: String,
+    /// Relative path to the glider's preview image.
     pub image_path: ImagePath,
 }
 
+/// Seeded cup row returned by `GET /cups` (4 tracks per cup).
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CupResponse {
+    /// Integer identifier (matches the in-game cup id).
     pub id: CupId,
+    /// Display name (e.g. `"Mushroom"`, `"Special"`).
     pub name: String,
+    /// Relative path to the cup's preview image.
     pub image_path: ImagePath,
 }
 
+/// Seeded track row returned by `GET /tracks`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct TrackResponse {
+    /// Integer identifier (matches the in-game track id).
     pub id: TrackId,
+    /// Display name.
     pub name: String,
+    /// FK to `cups.id` — which cup this track belongs to.
     pub cup_id: CupId,
+    /// 1-indexed position within its cup (1–4).
     pub position: i32,
+    /// Relative path to the track's preview image.
     pub image_path: ImagePath,
 }
 
+/// Cup row with its 4 tracks expanded inline, returned by `GET /cups/:id`.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CupWithTracksResponse {
+    /// Integer identifier (matches the in-game cup id).
     pub id: CupId,
+    /// Display name.
     pub name: String,
+    /// Relative path to the cup's preview image.
     pub image_path: ImagePath,
+    /// The cup's 4 tracks in `position` order.
     pub tracks: Vec<TrackResponse>,
 }
 
@@ -147,8 +178,10 @@ impl TryFrom<tracks::Model> for TrackResponse {
     }
 }
 
+/// Query-string filter for `GET /tracks`.
 #[derive(Deserialize)]
 pub struct TracksQuery {
+    /// If set, only return tracks belonging to this cup.
     pub cup_id: Option<CupId>,
 }
 

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,6 +1,12 @@
+/// Auth: register, login, refresh, logout, change password.
 pub mod auth;
+/// Drink type CRUD (custom drinks beyond the seeded defaults).
 pub mod drink_types;
+/// Read-only seeded game data: characters, bodies, wheels, gliders, cups, tracks.
 pub mod game_data;
+/// Run recording — create / list / get / delete individual race runs.
 pub mod runs;
+/// Session lifecycle — create, join, leave, list, get, race orchestration.
 pub mod sessions;
+/// User listing and updates.
 pub mod users;

--- a/backend/src/routes/runs.rs
+++ b/backend/src/routes/runs.rs
@@ -36,10 +36,15 @@ pub async fn create_run(
     Ok((StatusCode::CREATED, Json(detail)))
 }
 
+/// Query-string filters for `GET /runs`. All four are independent; omitted
+/// fields don't constrain the result.
 #[derive(Deserialize)]
 pub struct ListRunsQuery {
+    /// If set, only return runs against this session race.
     pub session_race_id: Option<SessionRaceId>,
+    /// If set, only return runs submitted by this user.
     pub user_id: Option<UserId>,
+    /// If set, only return runs on this track (regardless of session).
     pub track_id: Option<TrackId>,
 }
 

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -14,8 +14,12 @@ use crate::{
     services::sessions,
 };
 
+/// Body shape for `POST /sessions`.
 #[derive(Deserialize)]
 pub struct CreateSessionRequest {
+    /// Track-selection ruleset name (e.g. `"random"`, `"least_played"`).
+    /// Validated against [`crate::domain::enums::SessionRuleset`] at the
+    /// service boundary; #146 will move this to the newtype directly.
     pub ruleset: String,
 }
 
@@ -37,8 +41,10 @@ pub async fn create_session(
     Ok((StatusCode::CREATED, Json(detail)))
 }
 
+/// Body shape for `GET /sessions/mine`.
 #[derive(Serialize)]
 pub struct MySessionResponse {
+    /// The user's current active session, or `None` if they're not in one.
     pub session_id: Option<SessionId>,
 }
 

--- a/backend/src/routes/sessions.rs
+++ b/backend/src/routes/sessions.rs
@@ -41,7 +41,7 @@ pub async fn create_session(
     Ok((StatusCode::CREATED, Json(detail)))
 }
 
-/// Body shape for `GET /sessions/mine`.
+/// Response body for `GET /sessions/mine`.
 #[derive(Serialize)]
 pub struct MySessionResponse {
     /// The user's current active session, or `None` if they're not in one.

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -17,15 +17,26 @@ use crate::{
 
 // ── Response types (API contract) ───────────────────────────────────
 
+/// Public-facing user profile shape — what other users see.
+///
+/// Email and password hash are deliberately not included.
 #[derive(Serialize)]
 pub struct UserPublicProfile {
+    /// User's stable UUID.
     pub id: UserId,
+    /// User's chosen handle. Unique case-insensitively.
     pub username: Username,
+    /// User's default character pick, if set.
     pub preferred_character_id: Option<CharacterId>,
+    /// User's default kart body, if set.
     pub preferred_body_id: Option<BodyId>,
+    /// User's default wheel set, if set.
     pub preferred_wheel_id: Option<WheelId>,
+    /// User's default glider, if set.
     pub preferred_glider_id: Option<GliderId>,
+    /// User's default drink choice, if set.
     pub preferred_drink_type_id: Option<DrinkTypeId>,
+    /// Account-creation timestamp, UTC.
     pub created_at: DateTime<Utc>,
 }
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,6 +1,12 @@
+/// Authentication primitives: password hashing/verification, JWT issuance.
 pub mod auth;
+/// Cross-service helpers (lookup-or-404, etc.) that don't fit one resource.
 pub mod helpers;
+/// Run-recording service: submission + read-side queries.
 pub mod runs;
+/// Shared session-context type passed through nested service calls.
 pub mod session_context;
+/// Session-lifecycle, race-orchestration, and detail-read services.
 pub mod sessions;
+/// User-profile reads and updates.
 pub mod users;

--- a/backend/src/services/runs/read.rs
+++ b/backend/src/services/runs/read.rs
@@ -19,24 +19,43 @@ use crate::{
     error::Error,
 };
 
+/// Full wire view of a single run — JOIN-expanded for username and drink-type
+/// name so the frontend doesn't need follow-up requests.
 #[derive(Serialize)]
 pub struct RunDetail {
+    /// Stable UUID of the run row.
     pub id: RunId,
+    /// User who submitted the run.
     pub user_id: UserId,
+    /// Cached username for display (saves a JOIN on the read path).
     pub username: Username,
+    /// Race this run belongs to.
     pub session_race_id: SessionRaceId,
+    /// Track this run was raced on.
     pub track_id: TrackId,
+    /// Total time in milliseconds.
     pub track_time: i32,
+    /// Lap 1 time in milliseconds.
     pub lap1_time: i32,
+    /// Lap 2 time in milliseconds.
     pub lap2_time: i32,
+    /// Lap 3 time in milliseconds.
     pub lap3_time: i32,
+    /// Character used for the run.
     pub character_id: CharacterId,
+    /// Kart body used for the run.
     pub body_id: BodyId,
+    /// Wheels used for the run.
     pub wheel_id: WheelId,
+    /// Glider used for the run.
     pub glider_id: GliderId,
+    /// Drink type consumed during the run.
     pub drink_type_id: DrinkTypeId,
+    /// Cached drink-type display name (saves a JOIN on the read path).
     pub drink_type_name: String,
+    /// `true` if the run was self-reported DQ.
     pub disqualified: bool,
+    /// Submission timestamp, UTC.
     pub created_at: DateTime<Utc>,
 }
 
@@ -89,19 +108,32 @@ impl RunDetailRow {
     }
 }
 
+/// Pre-fill values for the run-recording UI. Tries the user's last run first;
+/// falls back to their saved profile preferences if they've never raced.
 #[derive(Serialize)]
 pub struct RunDefaults {
+    /// Suggested drink type, or `None` if no history and no profile preference.
     pub drink_type_id: Option<DrinkTypeId>,
+    /// Suggested character.
     pub character_id: Option<CharacterId>,
+    /// Suggested kart body.
     pub body_id: Option<BodyId>,
+    /// Suggested wheels.
     pub wheel_id: Option<WheelId>,
+    /// Suggested glider.
     pub glider_id: Option<GliderId>,
+    /// Which source produced these defaults — `"last_run"` or `"profile"`.
     pub source: String,
 }
 
+/// Optional filters passed to [`list_runs`]. All filters AND together;
+/// omitting a field doesn't constrain the result.
 pub struct RunFilters {
+    /// Only runs from this race.
     pub session_race_id: Option<SessionRaceId>,
+    /// Only runs submitted by this user.
     pub user_id: Option<UserId>,
+    /// Only runs on this track.
     pub track_id: Option<TrackId>,
 }
 

--- a/backend/src/services/runs/submission.rs
+++ b/backend/src/services/runs/submission.rs
@@ -24,18 +24,31 @@ use crate::{
     services::{helpers, sessions},
 };
 
+/// Body shape for `POST /runs`.
 #[derive(Deserialize)]
 pub struct CreateRunRequest {
+    /// Race this run is submitted to.
     pub session_race_id: SessionRaceId,
+    /// Total time in ms. Bounds-checked via `RaceTimeMs` in
+    /// [`validate_time_fields`]; #146 will move this to the typed form directly.
     pub track_time: i32,
+    /// Lap 1 time in ms. Bounds-checked via `LapTimeMs`.
     pub lap1_time: i32,
+    /// Lap 2 time in ms. Bounds-checked via `LapTimeMs`.
     pub lap2_time: i32,
+    /// Lap 3 time in ms. Bounds-checked via `LapTimeMs`.
     pub lap3_time: i32,
+    /// Character used for the run.
     pub character_id: CharacterId,
+    /// Kart body used for the run.
     pub body_id: BodyId,
+    /// Wheels used for the run.
     pub wheel_id: WheelId,
+    /// Glider used for the run.
     pub glider_id: GliderId,
+    /// Drink type consumed during the run.
     pub drink_type_id: DrinkTypeId,
+    /// `true` if the run is self-reported DQ.
     pub disqualified: bool,
 }
 

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -23,8 +23,11 @@ use crate::{
 /// `&UserId`.
 #[derive(Debug, Clone)]
 pub struct SessionContext {
+    /// The loaded session row, authoritative for all field access.
     pub session: sessions::Model,
+    /// Typed copy of `session.id` for borrow-friendly access.
     pub session_id: SessionId,
+    /// Typed copy of `session.host_id` for borrow-friendly access.
     pub host_id: UserId,
 }
 

--- a/backend/src/services/sessions/detail.rs
+++ b/backend/src/services/sessions/detail.rs
@@ -28,9 +28,13 @@ use crate::{
 /// Participant info for the detail response.
 #[derive(serde::Serialize)]
 pub struct ParticipantInfo {
+    /// Participant's user ID.
     pub user_id: UserId,
+    /// Cached username for display (saves a JOIN on the read path).
     pub username: Username,
+    /// When this participation row was created (joined or rejoined).
     pub joined_at: DateTime<Utc>,
+    /// When the participant left, or `None` if still active.
     pub left_at: Option<DateTime<Utc>>,
 }
 
@@ -55,12 +59,19 @@ struct SubmissionRow {
 /// Race info for the race history list.
 #[derive(serde::Serialize)]
 pub struct RaceInfo {
+    /// Stable UUID of the race row.
     pub id: SessionRaceId,
+    /// 1-indexed position within the session.
     pub race_number: i32,
+    /// FK to `tracks.id`.
     pub track_id: i32,
+    /// Cached track name (saves a JOIN on the read path).
     pub track_name: String,
+    /// Cached parent-cup name for display.
     pub cup_name: String,
+    /// Number of runs submitted to this race so far.
     pub run_count: i64,
+    /// Race-creation timestamp, UTC.
     pub created_at: DateTime<Utc>,
 }
 
@@ -91,16 +102,27 @@ struct CurrentRaceRow {
 /// Full session detail for polling.
 #[derive(serde::Serialize)]
 pub struct SessionDetail {
+    /// Session's stable UUID.
     pub id: SessionId,
+    /// Current host's user ID.
     pub host_id: UserId,
+    /// Cached host display name (saves a JOIN on the read path).
     pub host_username: Username,
+    /// Track-selection ruleset chosen at session creation.
     pub ruleset: SessionRuleset,
+    /// Lifecycle state — `Active` or `Closed`.
     pub status: SessionStatus,
+    /// Session-creation timestamp, UTC.
     pub created_at: DateTime<Utc>,
+    /// Most recent activity timestamp; used by stale-session cleanup.
     pub last_activity_at: DateTime<Utc>,
+    /// All participants who have ever joined this session, in join order.
     pub participants: Vec<ParticipantInfo>,
+    /// 1-indexed race count: 1 means "no races completed; race 1 is up next".
     pub race_number: usize,
+    /// The current in-progress race, if one exists.
     pub current_race: Option<SessionRaceInfo>,
+    /// All races for this session, oldest first.
     pub races: Vec<RaceInfo>,
     /// Pending races for the requesting user, oldest first. Empty if the
     /// user is not in this session, has no pending races, or is past the

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -164,11 +164,17 @@ pub async fn create_session(
 /// Summary info for listing active sessions.
 #[derive(serde::Serialize)]
 pub struct SessionSummary {
+    /// Session's stable UUID.
     pub id: SessionId,
+    /// Display name of the session host (for showing "Bob's session" in lists).
     pub host_username: Username,
+    /// Count of participants who haven't left (`left_at IS NULL`).
     pub participant_count: i64,
+    /// 1-indexed race count: 1 means "no races completed; race 1 is up next".
     pub race_number: i64,
+    /// Track-selection ruleset chosen at session creation.
     pub ruleset: SessionRuleset,
+    /// Most recent activity timestamp, used by the stale-session cleanup.
     pub last_activity_at: DateTime<Utc>,
 }
 

--- a/backend/src/services/sessions/types.rs
+++ b/backend/src/services/sessions/types.rs
@@ -15,22 +15,34 @@ use crate::domain::{ImagePath, SessionRaceId, UserId, Username};
 /// Submission info for a single participant in a race.
 #[derive(serde::Serialize, Clone)]
 pub struct RaceSubmission {
+    /// Participant whose submission this is.
     pub user_id: UserId,
+    /// Cached username for display (saves a JOIN on the read path).
     pub username: Username,
+    /// Total race time in milliseconds.
     pub track_time: i32,
+    /// `true` if the run was disqualified per the drink rule.
     pub disqualified: bool,
 }
 
 /// Info about a single race in the session (returned on create / skip / poll).
 #[derive(serde::Serialize, Clone)]
 pub struct SessionRaceInfo {
+    /// Stable UUID of the race row.
     pub id: SessionRaceId,
+    /// 1-indexed position of this race within the session.
     pub race_number: i32,
+    /// FK to `tracks.id`.
     pub track_id: i32,
+    /// Cached track name (saves a JOIN on the read path).
     pub track_name: String,
+    /// Cached parent-cup name for display.
     pub cup_name: String,
+    /// Relative image path for the track's preview thumbnail.
     pub image_path: ImagePath,
+    /// Race-creation timestamp (when `next_track` was called), UTC.
     pub created_at: DateTime<Utc>,
+    /// Per-participant submissions; empty until runs come in.
     pub submissions: Vec<RaceSubmission>,
 }
 

--- a/backend/src/services/users.rs
+++ b/backend/src/services/users.rs
@@ -10,22 +10,36 @@ use crate::{
 
 // ── Types ────────────────────────────────────────────────────────────
 
+/// Embedded drink-type summary returned inside [`UserDetailProfile`].
 #[derive(Serialize)]
 pub struct DrinkTypeInfo {
+    /// Drink type's stable UUID.
     pub id: DrinkTypeId,
+    /// Display name.
     pub name: String,
+    /// `true` for alcoholic drinks, `false` for non-alcoholic.
     pub alcoholic: bool,
 }
 
+/// Detail-view user profile — includes the resolved preferred drink type.
 #[derive(Serialize)]
 pub struct UserDetailProfile {
+    /// User's stable UUID.
     pub id: UserId,
+    /// Display handle.
     pub username: Username,
+    /// User's default character pick, if set.
     pub preferred_character_id: Option<CharacterId>,
+    /// User's default kart body, if set.
     pub preferred_body_id: Option<BodyId>,
+    /// User's default wheels, if set.
     pub preferred_wheel_id: Option<WheelId>,
+    /// User's default glider, if set.
     pub preferred_glider_id: Option<GliderId>,
+    /// User's default drink, expanded into the embedded summary (or `None`
+    /// if unset). Saved a round trip vs. returning just the id.
     pub preferred_drink_type: Option<DrinkTypeInfo>,
+    /// Account-creation timestamp, UTC.
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -36,10 +50,17 @@ pub struct UserDetailProfile {
 /// null (clear), key present with value (set).
 #[derive(Deserialize)]
 pub struct UpdateProfileRequest {
+    /// New preferred character. Must accompany the other three race-setup
+    /// fields (or all be absent) — see [`race_setup::Update`].
     pub preferred_character_id: Option<CharacterId>,
+    /// New preferred body. Paired with the rest of the race-setup quartet.
     pub preferred_body_id: Option<BodyId>,
+    /// New preferred wheels. Paired with the rest of the race-setup quartet.
     pub preferred_wheel_id: Option<WheelId>,
+    /// New preferred glider. Paired with the rest of the race-setup quartet.
     pub preferred_glider_id: Option<GliderId>,
+    /// New preferred drink. `None` = field absent (don't change),
+    /// `Some(None)` = explicitly cleared, `Some(Some(id))` = set to id.
     #[serde(default, deserialize_with = "deserialize_optional_field")]
     pub preferred_drink_type_id: Option<Option<DrinkTypeId>>,
 }

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -1,3 +1,5 @@
+//! Integration tests for the auth route handlers (register, login, refresh, logout, change-password).
+
 // Tests legitimately want to panic — per rust.md § 8.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 

--- a/backend/tests/auth_middleware.rs
+++ b/backend/tests/auth_middleware.rs
@@ -1,3 +1,5 @@
+//! Integration tests for the JWT bearer auth middleware.
+
 // Tests legitimately want to panic — per rust.md § 8.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 

--- a/docs/project-workflow.md
+++ b/docs/project-workflow.md
@@ -155,6 +155,14 @@ Exception: chore PRs without a linked Issue can be milestoned if you want them t
 
 Issue number first lets `git checkout 42<TAB>` complete fast and gives tooling a clean lookup key.
 
+### Title
+
+PR title format: `<issue_number>: <Title>` — e.g., `42: Add leaderboard`, `87: Fix lap-time validation off-by-one`.
+
+Mirrors the commit-message convention below; keeps the Issue number visible in the PR list and in merge-commit history on `main`.
+
+For chore PRs without an Issue, omit the prefix (just the title).
+
 ### Linked work
 
 `Closes #NN` mandatory for any PR closing an Issue. Chore PRs without Issues skip the reference (nothing to reference).
@@ -287,3 +295,4 @@ Same pattern as the handoff-as-tag for filed Issues above: the handoff is a tag 
 - 2026-05-05 — Removed the now-stale parenthetical from the workflow-step-blocker rule that gave "handoff to Cowork for project-board mutations Claude Code can't do" as the example. Closes the loop with #44 — Claude Code's `gh` token now has `project` scope, so project mutations are no longer routed through Cowork.
 - 2026-05-08 — Renamed file from `workflow.md` to `project-workflow.md`. The s/no-s distinction with the new sibling `user-workflows.md` (added in PR 4) was too fragile (grep noise, easy typos, tab-completion ambiguity); the rename makes intent explicit and matches the doc's `# Project workflow` title. Cross-references updated in `.claude/CLAUDE.md`, `docs/CLAUDE.md`, `docs/README.md`, `docs/handoffs/README.md`, `docs/roadmap.md`, and `docs/user-workflows.md`.
 - 2026-05-08 — Updated handoff and self-notes path references throughout (`docs/handoffs/` → `.agents/handoffs/`, `.claude/*-notes.md` → `.agents/memory/*.md`) per the AI-state reorg in [#79](https://github.com/brendanbyrne/beerio-kart/issues/79).
+- 2026-05-14 — Added `### Title` subsection under `## PR conventions` documenting the `<issue_number>: <Title>` PR title format (mirrors the existing commit-message convention). Captured so Claude Code applies the format when creating PRs.


### PR DESCRIPTION
## Summary

Filed during PR #152 review after a doc-block merge regression left `pub async fn wait` undocumented (attached to a sibling fn's `///` block). The lint that would have caught that — rustc's `missing_docs` — wasn't enabled. This PR turns it on and documents what it surfaces. Closes #153.

## Changes

- **`backend/Cargo.toml`** — `[workspace.lints.rust]` adds `missing_docs = "warn"` with a comment on why we chose this over `clippy::missing_docs_in_private_items` (the clippy variant covers bare-private items, which `rust.md` § 6 doesn't require). `pub(crate)` regressions remain a known gap that review covers; the rustc lint has no `pub`-and-`pub(crate)`-only knob. With `warnings = "deny"` already at the workspace level, `warn` is effectively an error.

- **Two opt-out boundaries:**
  - `#[allow(missing_docs)]` on `pub mod entities;` in `lib.rs` — the 23 entity files under it are mechanical SeaORM column declarations per ADR 0023; the column name IS the documentation. Same justification as the coverage exclusion in `design.md`.
  - `#![allow(missing_docs)]` at the top of `migration/src/m20260101_000001_initial_schema.rs` — the `Iden` enum variants are column-name scaffolding the migration DSL requires.

- **~225 `///` doc comments added across 23 files:**
  - DTO struct + field docs in `routes/auth.rs`, `routes/drink_types.rs`, `routes/game_data.rs`, `routes/runs.rs`, `routes/sessions.rs`, `routes/users.rs`, `services/runs/{read,submission}.rs`, `services/sessions/{detail,types}.rs`, `services/users.rs`.
  - Enum variant docs in `domain/enums.rs` (`SessionStatus::Active`, `SessionRuleset::Random`, etc.).
  - `pub mod` re-export docs in `lib.rs`, `routes/mod.rs`, `middleware/mod.rs`, `domain/mod.rs`, `services/mod.rs`.
  - Crate-level `//!` on `main.rs` and the two integration-test crates that needed one.
  - Struct field docs on a handful of `pub` items in `config.rs`, `error.rs`, `middleware/auth.rs`, `services/session_context.rs`, `services/sessions/lifecycle.rs`, `domain/race_setup.rs`.

- **`docs/project-workflow.md`** — Cowork-authored addition pulled into this PR per request: documents the `<issue_number>: <Title>` PR title convention (mirrors the existing commit-message convention). This PR's title uses it.

## Test plan

**Automated (in this PR):**

- [x] `cargo build --all-targets` — clean (was 392 `missing_docs` errors before this PR).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo test` — all 335+ tests pass.

**Regression catch verification:**

- [x] Locally stripped `///` from `pub async fn wait` in `shutdown.rs` → `cargo build` produces `error: missing documentation for a function`. Restored the doc; same regression class that slipped past review in PR #152 is now compile-time caught.

**Reviewer manual run:**

- [ ] `cd backend && cargo build --all-targets` — confirm clean.
- [ ] In any `pub fn`/`pub struct`/`pub enum`/field, locally delete the `///` block above it and confirm `cargo build` fails with `error: missing documentation for ...`. (Entity files are intentionally opted out — try a route handler or service DTO instead.)

## Compliance-plan reference

This Issue is its own tracking artifact (filed today during PR #152 review). The work directly enforces `rust.md` § 6 ("Every `pub` and cross-module `pub(crate)` item gets a `///` doc comment").

🤖 Generated with [Claude Code](https://claude.com/claude-code)