### PR TITLE
Race-anchored session lifetime — ADR-0035 (#47 #51 #58)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,11 @@ trim_trailing_whitespace = false
 [*.{yml,yaml,json}]
 indent_size = 2
 
+# Frontend (React/TypeScript) is written 2-space; the global 4-space default
+# is for the Rust backend. Prettier honors .editorconfig, so this keeps
+# `prettier --check` in agreement with the established frontend house style.
+[*.{ts,tsx,js,jsx,mjs,cjs,css}]
+indent_size = 2
+
 [Makefile]
 indent_style = tab

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -263,15 +263,18 @@ impl MigrationTrait for Migration {
                     ruleset TEXT NOT NULL,
                     least_played_drink_category TEXT,
                     status TEXT NOT NULL,
-                    created_at datetime_text NOT NULL,
-                    last_activity_at datetime_text NOT NULL
+                    created_at datetime_text NOT NULL
                 )",
         )
         .await?;
 
+        // Supports the race-derived stale-session sweeper (ADR-0035):
+        // `close_stale_sessions` filters `status = 'active' AND created_at <
+        // cutoff`. The session has no maintained activity column anymore —
+        // liveness is derived from `session_races.created_at`.
         conn.execute_unprepared(
-            "CREATE INDEX idx_sessions_status_last_activity
-                 ON sessions(status, last_activity_at)",
+            "CREATE INDEX idx_sessions_status_created_at
+                 ON sessions(status, created_at)",
         )
         .await?;
 

--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -328,6 +328,19 @@ impl MigrationTrait for Migration {
         )
         .await?;
 
+        // Backs the race-derived liveness subqueries (ADR-0035): the
+        // `EXISTS` in `get_active_session_id` and the `NOT EXISTS` in
+        // `close_stale_sessions` both correlate on
+        // `session_id = ? AND created_at >= ?`. The `UNIQUE(session_id,
+        // race_number)` index above can seek `session_id` but leaves the
+        // `created_at` filter as a residual scan; this index covers both.
+        // Also backs the `list_active_sessions` JOIN on `session_id`.
+        conn.execute_unprepared(
+            "CREATE INDEX idx_session_races_session_created
+                 ON session_races(session_id, created_at)",
+        )
+        .await?;
+
         // ---- Session race participations ----
         //
         // One row per (race, user) for every user present at race-creation

--- a/backend/src/entities/sessions.rs
+++ b/backend/src/entities/sessions.rs
@@ -13,7 +13,6 @@ pub struct Model {
     pub least_played_drink_category: Option<DrinkCategory>,
     pub status: SessionStatus,
     pub created_at: DateTime,
-    pub last_activity_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/entities/sessions_behavior.rs
+++ b/backend/src/entities/sessions_behavior.rs
@@ -1,11 +1,8 @@
 //! `ActiveModelBehavior` for [`super::sessions`].
 //!
-//! Stamps `created_at` on insert. `last_activity_at` is *not* touched here —
-//! it's an application-managed activity timestamp, advanced explicitly by
-//! `services::helpers::touch_session` when something happens in the session
-//! (a join, a race transition, etc.). Treating it as a generic `updated_at`
-//! would advance it on every write, which would defeat the stale-session
-//! cleanup loop. See `docs/coding-standards/seaorm.md` § 1.
+//! Stamps `created_at` on insert. The session carries no maintained activity
+//! column — liveness is derived from `session_races.created_at` (ADR-0035),
+//! so there is nothing for `before_save` to advance on update.
 
 use async_trait::async_trait;
 use chrono::Utc;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -290,10 +290,11 @@ async fn main() -> anyhow::Result<()> {
             ServeDir::new(&static_dir).fallback(ServeFile::new(format!("{static_dir}/index.html"))),
         );
 
-    // Spawn background task to close stale sessions (no activity for 1 hour).
-    // Runs every 5 minutes. PR-F2 (#58) extracts the closure body into
-    // `services::sessions::session_cleanup_loop`; the `shutdown::supervised`
-    // wrapping stays, the body moves.
+    // Spawn background task to close stale sessions (race-derived liveness,
+    // ADR-0035). Runs every 15 minutes — relaxed from the legacy 5-minute
+    // cadence because every user-facing read path now derives liveness from
+    // race timestamps directly, so the sweep is purely DB hygiene and no
+    // read depends on it having run recently.
     //
     // Shutdown-safe (tokio.md § 13 final rule): `close_stale_sessions` runs
     // SELECT + two UPDATEs inside one transaction that only commits at the
@@ -303,7 +304,7 @@ async fn main() -> anyhow::Result<()> {
     tracker.spawn(shutdown::supervised("session cleanup task", {
         let cancel = cancel.clone();
         async move {
-            let mut tick = tokio::time::interval(Duration::from_secs(300));
+            let mut tick = tokio::time::interval(Duration::from_secs(900));
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 tokio::select! {

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -7,7 +7,6 @@ use chrono::Utc;
 use rand::seq::SliceRandom;
 use sea_orm::{
     ColumnTrait, Condition, ConnectionTrait, EntityTrait, PrimaryKeyTrait, QueryFilter, Set,
-    sea_query::Expr,
 };
 
 use crate::{
@@ -133,28 +132,6 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
 
     db_query(session_race_participations::Entity::insert_many(rows).exec(txn)).await?;
 
-    Ok(())
-}
-
-/// Bump the session's `last_activity_at` column to now. Single `UPDATE`,
-/// no prior read required.
-///
-/// # Errors
-///
-/// Returns `Internal` for unexpected DB failures.
-#[tracing::instrument(level = "debug", skip(db), fields(session_id = %session_id))]
-pub async fn touch_session<C: ConnectionTrait>(
-    db: &C,
-    session_id: &SessionId,
-) -> Result<(), Error> {
-    let now = Utc::now().naive_utc();
-    db_query(
-        sessions::Entity::update_many()
-            .col_expr(sessions::Column::LastActivityAt, Expr::value(now))
-            .filter(sessions::Column::Id.eq(session_id))
-            .exec(db),
-    )
-    .await?;
     Ok(())
 }
 
@@ -331,41 +308,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, Error::Forbidden { .. }));
-    }
-
-    // --- touch_session ---
-
-    #[tokio::test]
-    async fn touch_session_updates_last_activity_at() {
-        let db = setup_db().await;
-        let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
-
-        let before = sessions::Entity::find_by_id(session_id)
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap()
-            .last_activity_at;
-
-        // Sleep a millisecond so the new timestamp is strictly later. SQLite's
-        // DateTime has microsecond precision; 1ms of real wall-clock time is
-        // comfortably over the resolution boundary.
-        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
-
-        touch_session(&db, &session_id).await.unwrap();
-
-        let after = sessions::Entity::find_by_id(session_id)
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap()
-            .last_activity_at;
-
-        assert!(
-            after > before,
-            "expected last_activity_at to advance: before={before}, after={after}"
-        );
     }
 
     // --- require_exists ---

--- a/backend/src/services/runs/submission.rs
+++ b/backend/src/services/runs/submission.rs
@@ -248,9 +248,8 @@ async fn validate_run_request(
     Ok((session_race, times))
 }
 
-/// Insert the run row and bump the session's `last_activity_at`, atomically.
-/// Returns the new run's ID. Caller is expected to have already validated
-/// the request via `validate_run_request`.
+/// Insert the run row. Returns the new run's ID. Caller is expected to have
+/// already validated the request via `validate_run_request`.
 async fn insert_run(
     db: &DatabaseConnection,
     user_id: &UserId,
@@ -285,9 +284,6 @@ async fn insert_run(
         .insert(&txn),
     )
     .await?;
-
-    let session_id = SessionId::from_db(&session_race.session_id)?;
-    helpers::touch_session(&txn, &session_id).await?;
 
     db_txn(txn.commit()).await?;
 
@@ -344,8 +340,6 @@ pub async fn delete_run(
     let txn = db_txn(db.begin()).await?;
 
     db_query(run.delete(&txn)).await?;
-
-    helpers::touch_session(&txn, &session_id).await?;
 
     db_txn(txn.commit()).await?;
 

--- a/backend/src/services/session_context.rs
+++ b/backend/src/services/session_context.rs
@@ -1,8 +1,8 @@
 //! Loaded-and-validated session bundle.
 //!
 //! Aggregates the helpers from `services::helpers` so service functions that
-//! start by loading an active session, checking host/participant, and touching
-//! activity can read top-to-bottom without repeating the ceremony.
+//! start by loading an active session and checking host/participant can read
+//! top-to-bottom without repeating the ceremony.
 
 use sea_orm::ConnectionTrait;
 
@@ -86,32 +86,10 @@ impl SessionContext {
     ) -> Result<session_participants::Model, Error> {
         helpers::require_active_participant(db, &self.session_id, user_id).await
     }
-
-    /// Bump `last_activity_at` to now in both the DB and this struct.
-    /// Delegates the UPDATE to `helpers::touch_session`, then refreshes
-    /// the in-memory field so callers that read it post-touch see the
-    /// updated value.
-    ///
-    /// # Errors
-    ///
-    /// Propagates the errors of [`helpers::touch_session`] — currently only
-    /// `Internal` for unexpected DB failures.
-    #[tracing::instrument(
-        level = "debug",
-        skip(self, db),
-        fields(session_id = %self.session_id),
-    )]
-    pub async fn touch<C: ConnectionTrait>(&mut self, db: &C) -> Result<(), Error> {
-        helpers::touch_session(db, &self.session_id).await?;
-        self.session.last_activity_at = chrono::Utc::now().naive_utc();
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::EntityTrait;
-
     use super::*;
     use crate::{
         domain::enums::SessionStatus,
@@ -188,36 +166,5 @@ mod tests {
         let outsider = create_user(&db, "outsider").await;
         let err = ctx.require_participant(&db, &outsider).await.unwrap_err();
         assert!(matches!(err, Error::Forbidden { .. }));
-    }
-
-    #[tokio::test]
-    async fn touch_bumps_last_activity_at_in_db_and_struct() {
-        let db = setup_db().await;
-        let host = create_user(&db, "host").await;
-        let session_id = insert_session(&db, &host, SessionStatus::Active).await;
-        let mut ctx = SessionContext::load_active(&db, &session_id).await.unwrap();
-
-        let before = ctx.session.last_activity_at;
-        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
-        ctx.touch(&db).await.unwrap();
-
-        // In-memory field is updated.
-        assert!(
-            ctx.session.last_activity_at > before,
-            "struct field should advance: before={before}, after={}",
-            ctx.session.last_activity_at
-        );
-
-        // DB is also updated.
-        let db_value = sessions::Entity::find_by_id(session_id)
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap()
-            .last_activity_at;
-        assert!(
-            db_value > before,
-            "DB should advance: before={before}, after={db_value}"
-        );
     }
 }

--- a/backend/src/services/sessions.rs
+++ b/backend/src/services/sessions.rs
@@ -1,7 +1,7 @@
 //! Session services — split by concern.
 //!
 //! - [`types`]: shared DTOs and constants (`SessionRaceInfo`,
-//!   `RaceSubmission`, `REJOIN_GRACE_MINUTES`). Lives below the other
+//!   `RaceSubmission`, `RACE_WINDOW_HOURS`). Lives below the other
 //!   submodules so the dependency graph stays acyclic.
 //! - [`lifecycle`]: create, join, leave, host transfer, close-stale, listing.
 //! - [`detail`]: aggregated read for the polling endpoint

--- a/backend/src/services/sessions/detail.rs
+++ b/backend/src/services/sessions/detail.rs
@@ -115,8 +115,6 @@ pub struct SessionDetail {
     pub status: SessionStatus,
     /// Session-creation timestamp, UTC.
     pub created_at: DateTime<Utc>,
-    /// Most recent activity timestamp; used by stale-session cleanup.
-    pub last_activity_at: DateTime<Utc>,
     /// All participants who have ever joined this session, in join order.
     pub participants: Vec<ParticipantInfo>,
     /// 1-indexed race count: 1 means "no races completed; race 1 is up next".
@@ -126,9 +124,10 @@ pub struct SessionDetail {
     /// All races for this session, oldest first.
     pub races: Vec<RaceInfo>,
     /// Pending races for the requesting user, oldest first. Empty if the
-    /// user is not in this session, has no pending races, or is past the
-    /// 5-minute grace window after leaving. The API returns all matching
-    /// rows; the UI applies the "max 3 pending" cap.
+    /// user has no unresolved races, or all their pending races have expired
+    /// (each race is submittable for 1 hour from its creation — ADR-0035).
+    /// The API returns all matching rows; the UI applies the "max 3 pending"
+    /// cap.
     pub your_pending: Vec<SessionRaceInfo>,
 }
 
@@ -347,7 +346,6 @@ pub async fn get_session_detail(
         ruleset: session.ruleset,
         status: session.status,
         created_at: session.created_at.and_utc(),
-        last_activity_at: session.last_activity_at.and_utc(),
         participants,
         race_number,
         current_race,

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -119,9 +119,14 @@ pub async fn get_active_session_id(
 /// joining a new one. The stale session's `status` and any other participants'
 /// rows are left for the sweeper (eventual consistency — its remaining job).
 ///
-/// **Precondition:** the caller has already passed `check_not_in_any_session`,
-/// so any dangling row found here belongs to a session with no race-derived
-/// liveness left. Settling it is therefore always correct.
+/// **Why this is safe:** the caller has already passed
+/// `check_not_in_any_session`, so any dangling row found here belonged to a
+/// race-derived-stale session *as of that check*. The check runs before the
+/// transaction, so a concurrent `next_track` from another participant could
+/// in principle revive that session in the gap — but settling the row is
+/// still correct regardless: the user is explicitly starting or joining a
+/// new session, and the one-active-session invariant requires them to leave
+/// the old one either way.
 ///
 /// # Errors
 ///
@@ -554,7 +559,7 @@ struct StaleSessionRow {
 #[tracing::instrument(skip(db))]
 pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error> {
     let now = Utc::now().naive_utc();
-    let window_start = (Utc::now() - chrono::Duration::hours(RACE_WINDOW_HOURS)).naive_utc();
+    let window_start = now - chrono::Duration::hours(RACE_WINDOW_HOURS);
 
     let txn = db_txn(db.begin()).await?;
 
@@ -1137,6 +1142,17 @@ mod tests {
         create_session(&db, &user_id, "random")
             .await
             .expect("user in a stale session may create a fresh one");
+
+        // The dangling row in the stale session was settled — this pins
+        // `settle_dangling_participation`'s direct effect, not just the
+        // side effect that the new-session INSERT didn't collide.
+        assert!(
+            participant_row(&db, &stale_id, &user_id)
+                .await
+                .left_at
+                .is_some(),
+            "the dangling row in the stale session is settled"
+        );
     }
 
     #[tokio::test]
@@ -1157,5 +1173,13 @@ mod tests {
         join_session(&db, &fresh.id, &user_id)
             .await
             .expect("user in a stale session may join a fresh one");
+
+        assert!(
+            participant_row(&db, &stale_id, &user_id)
+                .await
+                .left_at
+                .is_some(),
+            "the dangling row in the stale session is settled"
+        );
     }
 }

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -4,17 +4,17 @@
 //! Detail aggregation lives in [`super::detail`]; race orchestration in
 //! [`super::races`].
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, Condition, ConnectionTrait,
-    DatabaseConnection, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, TransactionTrait, sea_query::Expr,
+    DatabaseConnection, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait, sea_query::Expr,
 };
 use uuid::Uuid;
 
 use super::{
     detail::{SessionDetail, get_session_detail},
-    types::REJOIN_GRACE_MINUTES,
+    types::RACE_WINDOW_HOURS,
 };
 use crate::{
     domain::{
@@ -33,43 +33,35 @@ struct ActiveParticipantRow {
     session_id: String,
 }
 
-/// Check that the user is not already active in any *active* session.
+/// Check that the user is not already active in any *live* session.
 /// Returns an error with the existing session ID if they are.
-/// JOINs sessions to ensure closed sessions don't block the user.
+///
+/// Delegates the liveness logic to [`get_active_session_id`] so both the
+/// "are you in a session" answers come from one query — see that function
+/// for the race-derived liveness predicate (ADR-0035).
 async fn check_not_in_any_session(
     db: &impl ConnectionTrait,
     user_id: &UserId,
 ) -> Result<(), Error> {
-    let existing = db_query(
-        ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
-            db.get_database_backend(),
-            r#"
-            SELECT sp.session_id
-            FROM session_participants sp
-            JOIN sessions s ON sp.session_id = s.id
-            WHERE sp.user_id = $1
-              AND sp.left_at IS NULL
-              AND s.status = 'active'
-            LIMIT 1
-            "#,
-            [user_id.into()],
-        ))
-        .one(db),
-    )
-    .await?;
-
-    if let Some(row) = existing {
-        return Err(Error::conflict(format!(
-            "Already in session {}",
-            row.session_id
-        )));
+    if let Some(session_id) = get_active_session_id(db, user_id).await? {
+        return Err(Error::conflict(format!("Already in session {session_id}")));
     }
-
     Ok(())
 }
 
 /// Returns the session ID the user is currently active in, or None.
-/// Only considers active sessions (not closed/stale ones).
+///
+/// "Currently active in" means: the user has a `session_participants` row
+/// with `left_at IS NULL`, the session's `status` is `'active'`, **and** the
+/// session is race-derived *live* — it has a `session_races` row created
+/// within the last [`RACE_WINDOW_HOURS`], or the session itself was created
+/// that recently (the bootstrap case: a brand-new session with no race
+/// chosen yet).
+///
+/// The liveness clause is what decouples user lockout from sweep timing
+/// (ADR-0035): a user whose abandoned session has gone stale is freed
+/// immediately by this read path, without waiting for `close_stale_sessions`
+/// to flip `status` to `'closed'`.
 ///
 /// # Errors
 ///
@@ -79,6 +71,8 @@ pub async fn get_active_session_id(
     db: &impl ConnectionTrait,
     user_id: &UserId,
 ) -> Result<Option<SessionId>, Error> {
+    let window_start = (Utc::now() - chrono::Duration::hours(RACE_WINDOW_HOURS)).naive_utc();
+
     let row = db_query(
         ActiveParticipantRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
             db.get_database_backend(),
@@ -89,15 +83,66 @@ pub async fn get_active_session_id(
         WHERE sp.user_id = $1
           AND sp.left_at IS NULL
           AND s.status = 'active'
+          AND (
+            s.created_at >= $2
+            OR EXISTS (
+              SELECT 1 FROM session_races sr
+              WHERE sr.session_id = s.id
+                AND sr.created_at >= $2
+            )
+          )
         LIMIT 1
         "#,
-            [user_id.into()],
+            [user_id.into(), window_start.into()],
         ))
         .one(db),
     )
     .await?;
 
     row.map(|r| SessionId::from_db(&r.session_id)).transpose()
+}
+
+/// Mark the user's dangling participant row (`left_at IS NULL`) as left, if
+/// one exists.
+///
+/// The partial unique index `idx_session_participants_one_active_session`
+/// permits a user at most one `left_at IS NULL` participant row across all
+/// sessions. A user abandoned in a session that has since gone race-derived
+/// *stale* (ADR-0035) still holds such a row — and the `INSERT` of a fresh
+/// participant row in `create_session` / `join_session` would collide with
+/// that index before the periodic sweeper gets around to settling it.
+///
+/// Calling this inside the create/join transaction settles that dangling row
+/// up front, so user lockout is genuinely decoupled from sweep timing — not
+/// merely decoupled at the application-level `check_not_in_any_session`.
+/// Semantically: a user implicitly leaves an abandoned session by starting or
+/// joining a new one. The stale session's `status` and any other participants'
+/// rows are left for the sweeper (eventual consistency — its remaining job).
+///
+/// **Precondition:** the caller has already passed `check_not_in_any_session`,
+/// so any dangling row found here belongs to a session with no race-derived
+/// liveness left. Settling it is therefore always correct.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
+async fn settle_dangling_participation(
+    txn: &impl ConnectionTrait,
+    user_id: &UserId,
+) -> Result<(), Error> {
+    let now = Utc::now().naive_utc();
+    db_query(
+        session_participants::Entity::update_many()
+            .col_expr(session_participants::Column::LeftAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::UserId.eq(user_id))
+                    .add(session_participants::Column::LeftAt.is_null()),
+            )
+            .exec(txn),
+    )
+    .await?;
+    Ok(())
 }
 
 /// Create a new session. The creator becomes both the host and the first
@@ -129,14 +174,18 @@ pub async fn create_session(
 
     check_not_in_any_session(db, user_id).await?;
 
-    // `last_activity_at` and `joined_at` are application-managed (not handled
-    // by `before_save` — see `entities/sessions_behavior.rs` for why), so
-    // capture `now` here and stamp them by hand. `sessions.created_at` is
-    // populated by `ActiveModelBehavior::before_save`.
+    // `joined_at` is application-managed (not handled by `before_save` — see
+    // `entities/sessions_behavior.rs` for why), so capture `now` here and
+    // stamp it by hand. `sessions.created_at` is populated by
+    // `ActiveModelBehavior::before_save`.
     let now = Utc::now().naive_utc();
     let session_id = SessionId::new_v4();
 
     let txn = db_txn(db.begin()).await?;
+
+    // Settle any dangling row from a now-stale session so the new
+    // participant INSERT doesn't collide with the one-active-session index.
+    settle_dangling_participation(&txn, user_id).await?;
 
     db_query(
         sessions::ActiveModel {
@@ -146,7 +195,6 @@ pub async fn create_session(
             least_played_drink_category: Set(None),
             status: Set(SessionStatus::Active),
             created_at: NotSet,
-            last_activity_at: Set(now),
         }
         .insert(&txn),
     )
@@ -182,8 +230,6 @@ pub struct SessionSummary {
     pub race_number: i64,
     /// Track-selection ruleset chosen at session creation.
     pub ruleset: SessionRuleset,
-    /// Most recent activity timestamp, used by the stale-session cleanup.
-    pub last_activity_at: DateTime<Utc>,
 }
 
 /// Row shape returned by the list-sessions JOIN query.
@@ -194,11 +240,19 @@ struct SessionSummaryRow {
     participant_count: i64,
     race_count: i64,
     ruleset: SessionRuleset,
-    last_activity_at: NaiveDateTime,
 }
 
-/// List active sessions sorted by `last_activity_at` DESC.
-/// Uses a single JOIN query instead of N+1 queries.
+/// List active sessions, most recently active first.
+///
+/// "Activity" is race-derived (ADR-0035): sessions sort by their newest
+/// `session_races.created_at`, falling back to `sessions.created_at` for a
+/// session that has no races yet. Uses a single JOIN query instead of N+1.
+///
+/// Note this filters only on `status = 'active'` and does not apply the
+/// race-derived liveness predicate — a session whose races have all expired
+/// but that the sweeper hasn't closed yet still appears here until the next
+/// sweep. That is acceptable for a listing surface; the frontend filters
+/// near-stale sessions out of the join UI (ADR-0035 § Negative consequences).
 ///
 /// # Errors
 ///
@@ -214,15 +268,14 @@ pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<Sessi
             u.username AS host_username,
             COUNT(DISTINCT CASE WHEN sp.left_at IS NULL THEN sp.id END) AS participant_count,
             COUNT(DISTINCT sr.id) AS race_count,
-            s.ruleset,
-            s.last_activity_at
+            s.ruleset
         FROM sessions s
         JOIN users u ON s.host_id = u.id
         LEFT JOIN session_participants sp ON sp.session_id = s.id
         LEFT JOIN session_races sr ON sr.session_id = s.id
         WHERE s.status = 'active'
         GROUP BY s.id
-        ORDER BY s.last_activity_at DESC
+        ORDER BY COALESCE(MAX(sr.created_at), s.created_at) DESC
         "#,
             [],
         ))
@@ -238,7 +291,6 @@ pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<Sessi
                 participant_count: r.participant_count,
                 race_number: r.race_count.max(1),
                 ruleset: r.ruleset,
-                last_activity_at: r.last_activity_at.and_utc(),
             })
         })
         .collect()
@@ -247,14 +299,12 @@ pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<Sessi
 /// Join (or rejoin) a session. **Single mutable row per (session, user)** —
 /// first join INSERTs, rejoin mutates the existing row.
 ///
-/// Rejoin behavior:
-/// - **Within grace** (`NOW() - left_at <= 5 min`): clear `left_at`, leave
-///   `joined_at` untouched. The user is treated as continuously present, so
-///   any pending races created before the leave remain accessible.
-/// - **Outside grace** (`NOW() - left_at > 5 min`): clear `left_at` AND reset
-///   `joined_at = NOW()`. Pre-gap pending records remain in the DB for
-///   history but are filtered out by the pending-races query
-///   (`session_races.created_at >= session_participants.joined_at`).
+/// Rejoin clears `left_at` unconditionally and never touches `joined_at`
+/// (ADR-0035). `joined_at` is therefore monotonic — set once on first join,
+/// it genuinely means "when this user first joined this session." Pending-race
+/// access no longer depends on it: a flaked-out user's pending races stay
+/// pending until each race expires on its own 1-hour clock, regardless of how
+/// long they were gone.
 ///
 /// # Errors
 ///
@@ -289,6 +339,11 @@ pub async fn join_session(
     let now = Utc::now().naive_utc();
     let txn = db_txn(db.begin()).await?;
 
+    // Settle any dangling row from a now-stale session so a fresh
+    // participant INSERT doesn't collide with the one-active-session index.
+    // A rejoin of *this* session is unaffected — its row has `left_at` set.
+    settle_dangling_participation(&txn, user_id).await?;
+
     match existing {
         None => {
             db_query(
@@ -304,7 +359,7 @@ pub async fn join_session(
             .await?;
         }
         Some(row) => {
-            let Some(left_at) = row.left_at else {
+            if row.left_at.is_none() {
                 // Defensive: should be unreachable in normal flow. `existing`
                 // is filtered to (session_id, user_id), so a row with
                 // `left_at IS NULL` here means the user is already active in
@@ -316,23 +371,14 @@ pub async fn join_session(
                 return Err(Error::conflict(
                     "Already an active participant in this session",
                 ));
-            };
-
-            let mut active: session_participants::ActiveModel = row.into();
-            active.left_at = Set(None);
-
-            let gap = now.signed_duration_since(left_at);
-            if gap > chrono::Duration::minutes(REJOIN_GRACE_MINUTES) {
-                // Outside grace — reset joined_at so pre-gap pending records
-                // are filtered out of the user's pending list.
-                active.joined_at = Set(now);
             }
 
+            // Rejoin: clear `left_at`, leave `joined_at` untouched (monotonic).
+            let mut active: session_participants::ActiveModel = row.into();
+            active.left_at = Set(None);
             db_query(active.update(&txn)).await?;
         }
     }
-
-    helpers::touch_session(&txn, session_id).await?;
 
     db_txn(txn.commit()).await?;
 
@@ -361,12 +407,10 @@ enum HostDisposition {
 /// counts active participants via `left_at IS NULL`, and relies on the
 /// leaver's row being excluded by the prior update.
 ///
-/// **Note on `joined_at` semantics:** `joined_at` is the start of the
-/// participant's *current* presence segment, which gets reset on a long-gap
-/// rejoin (see `join_session`). So "earliest-joined" effectively means
-/// "most-tenured in the current segment." That's the right host successor —
-/// someone who just rejoined after a long break shouldn't outrank a steadily
-/// present participant.
+/// **Note on `joined_at` semantics:** `joined_at` is monotonic (ADR-0035) —
+/// set once on first join and never reset, even across a leave/rejoin. So
+/// "earliest-joined" genuinely means "first to ever join this session,"
+/// which is a stable, well-defined host successor.
 async fn transfer_host_or_close(
     txn: &impl ConnectionTrait,
     session_id: &SessionId,
@@ -449,32 +493,53 @@ pub async fn leave_session(
     // `sessions.host_id` as 500 rather than a silent false-negative compare.
     let host_id = UserId::from_db(&session.host_id)?;
     let is_host_leaving = host_id == *user_id;
-    let mut active_session: sessions::ActiveModel = session.into();
     let disposition = transfer_host_or_close(&txn, session_id, user_id, is_host_leaving).await?;
 
+    // Only write the session row when the disposition actually changes a
+    // column. The session carries no activity timestamp to bump anymore
+    // (ADR-0035), so the `NoChange` case has nothing to UPDATE.
     match disposition {
         HostDisposition::TransferredTo(new_host_id) => {
+            let mut active_session: sessions::ActiveModel = session.into();
             active_session.host_id = Set((&new_host_id).into());
+            db_query(active_session.update(&txn)).await?;
         }
         HostDisposition::SessionClosed => {
+            let mut active_session: sessions::ActiveModel = session.into();
             active_session.status = Set(SessionStatus::Closed);
+            db_query(active_session.update(&txn)).await?;
         }
         HostDisposition::NoChange => {}
     }
-
-    active_session.last_activity_at = Set(now);
-    db_query(active_session.update(&txn)).await?;
 
     db_txn(txn.commit()).await?;
 
     Ok(())
 }
 
-/// Close sessions that have had no activity for over an hour.
+/// Row shape for the stale-session SELECT.
+#[derive(Debug, FromQueryResult)]
+struct StaleSessionRow {
+    id: String,
+}
+
+/// Close sessions whose race window has fully elapsed (ADR-0035).
 ///
-/// Also marks all remaining active participants as left, preventing
-/// users from being soft-locked out of creating/joining new sessions.
-/// Returns the number of sessions closed.
+/// A session is *stale* when it is `status = 'active'`, was created more than
+/// [`RACE_WINDOW_HOURS`] ago, **and** has no `session_races` row created
+/// within that same window. The `created_at` clause handles the bootstrap
+/// case: a brand-new session with no race chosen yet keeps its first hour
+/// from its own creation timestamp before it can go stale.
+///
+/// This is purely DB hygiene. Clean exits already close their session inline
+/// via `leave_session`; every user-facing read path derives liveness from
+/// race timestamps directly (see [`get_active_session_id`] and
+/// `get_pending_races`), so no read depends on this sweep having run recently.
+/// The sweep only keeps `sessions.status` eventually consistent with that
+/// derived truth.
+///
+/// Also marks all remaining active participants of the closed sessions as
+/// left. Returns the number of sessions closed.
 ///
 /// The cleanup runs as two set-based `UPDATE`s in one transaction
 /// (`seaorm.md` § 1) — one to flip the matching session rows to
@@ -488,30 +553,38 @@ pub async fn leave_session(
 /// UPDATE statements that drive the cleanup.
 #[tracing::instrument(skip(db))]
 pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error> {
-    let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).naive_utc();
     let now = Utc::now().naive_utc();
+    let window_start = (Utc::now() - chrono::Duration::hours(RACE_WINDOW_HOURS)).naive_utc();
 
     let txn = db_txn(db.begin()).await?;
 
-    // Capture the stale ids once. We can't derive them from the sessions
-    // `update_many`'s result (it returns a count, not a row set), and using
-    // a subquery in the participants filter pulls the same SELECT into the
-    // engine implicitly. The explicit form keeps the filter expressions
-    // readable and short-circuits cleanly when the cleanup has nothing to
-    // do (the common case).
+    // Capture the stale ids once. The `NOT EXISTS` subquery against
+    // `session_races` is awkward in the builder API, so this read is
+    // hand-rolled SQL (`seaorm.md` § 1 — raw SQL for clumsy multi-table
+    // shapes). Both `UPDATE`s below scope to the captured set, and the
+    // empty-set case short-circuits cleanly (the common case).
     let stale_ids: Vec<String> = db_query(
-        sessions::Entity::find()
-            .select_only()
-            .column(sessions::Column::Id)
-            .filter(
-                Condition::all()
-                    .add(sessions::Column::Status.eq(SessionStatus::Active))
-                    .add(sessions::Column::LastActivityAt.lt(one_hour_ago)),
-            )
-            .into_tuple()
-            .all(&txn),
+        StaleSessionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            txn.get_database_backend(),
+            r#"
+            SELECT s.id
+            FROM sessions s
+            WHERE s.status = 'active'
+              AND s.created_at < $1
+              AND NOT EXISTS (
+                  SELECT 1 FROM session_races sr
+                  WHERE sr.session_id = s.id
+                    AND sr.created_at >= $1
+              )
+            "#,
+            [window_start.into()],
+        ))
+        .all(&txn),
     )
-    .await?;
+    .await?
+    .into_iter()
+    .map(|r| r.id)
+    .collect();
 
     if stale_ids.is_empty() {
         db_txn(txn.commit()).await?;
@@ -549,11 +622,9 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        services::sessions::get_pending_races,
-        test_helpers::{
-            backdate_participant, create_user, insert_participant, insert_session, setup_db,
-        },
+    use crate::test_helpers::{
+        backdate_session, create_user, insert_participant, insert_session, insert_session_race,
+        setup_db,
     };
 
     // ── transfer_host_or_close ───────────────────────────────────────
@@ -851,190 +922,240 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    // ── close_stale_sessions (race-derived sweeper, ADR-0035) ────────────
+
+    /// Fetch a participant row by (session, user).
+    async fn participant_row(
+        db: &DatabaseConnection,
+        session_id: &SessionId,
+        user_id: &UserId,
+    ) -> session_participants::Model {
+        session_participants::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_participants::Column::SessionId.eq(session_id))
+                    .add(session_participants::Column::UserId.eq(user_id)),
+            )
+            .one(db)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    /// Fetch a session's current status.
+    async fn session_status(db: &DatabaseConnection, session_id: &SessionId) -> SessionStatus {
+        sessions::Entity::find_by_id(session_id)
+            .one(db)
+            .await
+            .unwrap()
+            .unwrap()
+            .status
+    }
+
     #[tokio::test]
     async fn test_stale_cleanup_marks_participants_as_left() {
         let db = setup_db().await;
         let host_id = create_user(&db, "host").await;
         let user_id = create_user(&db, "user").await;
 
-        let session = create_session(&db, &host_id, "random").await.unwrap();
-        join_session(&db, &session.id, &user_id).await.unwrap();
+        // A session created over an hour ago with no races is stale.
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        insert_participant(&db, &session_id, &user_id, None).await;
+        backdate_session(
+            &db,
+            &session_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
 
-        // Backdate last_activity_at past the stale threshold
-        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
-        let s = sessions::Entity::find_by_id(session.id)
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap();
-        let mut active: sessions::ActiveModel = s.into();
-        active.last_activity_at = Set(two_hours_ago);
-        active.update(&db).await.unwrap();
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 1, "the stale session is closed");
 
-        close_stale_sessions(&db).await.unwrap();
-
-        // Both users must be able to create a new session after their old one times out
-        assert!(
-            create_session(&db, &host_id, "random").await.is_ok(),
-            "host should be freed from stale session"
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Closed
         );
         assert!(
-            create_session(&db, &user_id, "random").await.is_ok(),
-            "user should be freed from stale session"
+            participant_row(&db, &session_id, &host_id)
+                .await
+                .left_at
+                .is_some(),
+            "host participant marked as left"
+        );
+        assert!(
+            participant_row(&db, &session_id, &user_id)
+                .await
+                .left_at
+                .is_some(),
+            "user participant marked as left"
         );
     }
 
-    // ── Rejoin grace (verifies join_session's grace-window logic by
-    //    inspecting downstream pending state) ───────────────────────────
+    #[tokio::test]
+    async fn test_close_stale_keeps_recent_bootstrap_session() {
+        // A brand-new session with no races yet is alive for its first hour
+        // from its own creation timestamp.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "fresh session is not stale");
+        assert_eq!(
+            session_status(&db, &session.id).await,
+            SessionStatus::Active
+        );
+    }
 
     #[tokio::test]
-    async fn test_rejoin_within_grace_preserves_pending() {
+    async fn test_close_stale_closes_old_bootstrap_session() {
+        // A session created over an hour ago that never picked a track is
+        // stale — the bootstrap window has elapsed.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(
+            &db,
+            &session_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 1);
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Closed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_stale_keeps_session_with_recent_race() {
+        // Even though the session was created over an hour ago, a race
+        // created within the window keeps it alive.
         let db = setup_db().await;
         crate::test_helpers::seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(
+            &db,
+            &session_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+        // A race created just now — well inside the window.
+        insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "a recent race keeps the session alive");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_stale_closes_session_with_all_races_expired() {
+        // The session has a race, but it was created over an hour ago — the
+        // race has expired and nothing keeps the session alive.
+        let db = setup_db().await;
+        crate::test_helpers::seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(
+            &db,
+            &session_id,
+            (Utc::now() - chrono::Duration::hours(3)).naive_utc(),
+        )
+        .await;
+        insert_session_race(
+            &db,
+            &session_id,
+            1,
+            1,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 1, "all races expired → session closed");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Closed
+        );
+    }
+
+    // ── Monotonic joined_at + lockout decoupling (ADR-0035) ──────────────
+
+    #[tokio::test]
+    async fn test_rejoin_does_not_advance_joined_at() {
+        // `joined_at` is monotonic — leave/rejoin clears `left_at` but never
+        // touches `joined_at`, regardless of how long the user was gone.
+        let db = setup_db().await;
         let host_id = create_user(&db, "host").await;
         let user_b = create_user(&db, "b").await;
         let session = create_session(&db, &host_id, "random").await.unwrap();
         join_session(&db, &session.id, &user_b).await.unwrap();
-        crate::services::sessions::next_track(&db, &session.id, &host_id)
-            .await
-            .unwrap();
 
-        // Capture B's joined_at, then leave + backdate left_at to 3 min ago.
-        let original_joined = session_participants::Entity::find()
-            .filter(
-                Condition::all()
-                    .add(session_participants::Column::SessionId.eq(session.id))
-                    .add(session_participants::Column::UserId.eq(user_b)),
-            )
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap()
-            .joined_at;
+        let original_joined = participant_row(&db, &session.id, &user_b).await.joined_at;
+
         leave_session(&db, &session.id, &user_b).await.unwrap();
-        let three_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(3);
-        backdate_participant(&db, &session.id, &user_b, None, Some(three_min_ago)).await;
-
         join_session(&db, &session.id, &user_b).await.unwrap();
 
-        let row = session_participants::Entity::find()
-            .filter(
-                Condition::all()
-                    .add(session_participants::Column::SessionId.eq(session.id))
-                    .add(session_participants::Column::UserId.eq(user_b)),
-            )
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap();
+        let row = participant_row(&db, &session.id, &user_b).await;
         assert!(row.left_at.is_none(), "left_at cleared on rejoin");
         assert_eq!(
             row.joined_at, original_joined,
-            "within-grace rejoin must NOT advance joined_at"
-        );
-
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert_eq!(
-            pending.len(),
-            1,
-            "pre-leave pending preserved on within-grace rejoin"
+            "rejoin must never advance joined_at"
         );
     }
 
     #[tokio::test]
-    async fn test_rejoin_after_grace_resets_joined_at_and_forfeits_pending() {
-        use crate::entities::session_race_participations;
-
+    async fn test_user_in_stale_session_can_create_fresh_session() {
+        // The user still has an active participant row in a session that has
+        // gone stale (created over an hour ago, no races) but that the
+        // sweeper has not yet flipped to `closed`. Lockout must not depend on
+        // sweep timing — the user can immediately create a new session.
         let db = setup_db().await;
-        crate::test_helpers::seed_tracks_for_test(&db).await;
-        let host_id = create_user(&db, "host").await;
-        let user_b = create_user(&db, "b").await;
-        let session = create_session(&db, &host_id, "random").await.unwrap();
-        join_session(&db, &session.id, &user_b).await.unwrap();
-        crate::services::sessions::next_track(&db, &session.id, &host_id)
+        let user_id = create_user(&db, "user").await;
+        let stale_id = insert_session(&db, &user_id, SessionStatus::Active).await;
+        insert_participant(&db, &stale_id, &user_id, None).await;
+        backdate_session(
+            &db,
+            &stale_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+
+        // Sanity: the stale session is still `active` in the DB.
+        assert_eq!(session_status(&db, &stale_id).await, SessionStatus::Active);
+
+        create_session(&db, &user_id, "random")
             .await
-            .unwrap();
-
-        let original_joined = session_participants::Entity::find()
-            .filter(
-                Condition::all()
-                    .add(session_participants::Column::SessionId.eq(session.id))
-                    .add(session_participants::Column::UserId.eq(user_b)),
-            )
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap()
-            .joined_at;
-
-        leave_session(&db, &session.id, &user_b).await.unwrap();
-        // Backdate left_at to 20 min ago — well past the 5-minute window.
-        let twenty_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(20);
-        backdate_participant(&db, &session.id, &user_b, None, Some(twenty_min_ago)).await;
-
-        join_session(&db, &session.id, &user_b).await.unwrap();
-
-        let row = session_participants::Entity::find()
-            .filter(
-                Condition::all()
-                    .add(session_participants::Column::SessionId.eq(session.id))
-                    .add(session_participants::Column::UserId.eq(user_b)),
-            )
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(row.left_at.is_none(), "left_at cleared on rejoin");
-        assert!(
-            row.joined_at > original_joined,
-            "outside-grace rejoin must advance joined_at: was {}, now {}",
-            original_joined,
-            row.joined_at,
-        );
-
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert!(
-            pending.is_empty(),
-            "pre-gap pending is forfeited (filtered by created_at >= joined_at)"
-        );
-
-        // The participation row itself stays for history.
-        let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(user_b))
-            .count(&db)
-            .await
-            .unwrap();
-        assert_eq!(count, 1, "forfeited participation row remains in DB");
+            .expect("user in a stale session may create a fresh one");
     }
 
     #[tokio::test]
-    async fn test_multiple_short_flaps_within_grace_preserve_pending() {
+    async fn test_user_in_stale_session_can_join_fresh_session() {
         let db = setup_db().await;
-        crate::test_helpers::seed_tracks_for_test(&db).await;
-        let host_id = create_user(&db, "host").await;
-        let user_b = create_user(&db, "b").await;
-        let session = create_session(&db, &host_id, "random").await.unwrap();
-        join_session(&db, &session.id, &user_b).await.unwrap();
-        crate::services::sessions::next_track(&db, &session.id, &host_id)
+        let user_id = create_user(&db, "user").await;
+        let other_host = create_user(&db, "other").await;
+        let stale_id = insert_session(&db, &user_id, SessionStatus::Active).await;
+        insert_participant(&db, &stale_id, &user_id, None).await;
+        backdate_session(
+            &db,
+            &stale_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+
+        let fresh = create_session(&db, &other_host, "random").await.unwrap();
+        join_session(&db, &fresh.id, &user_id)
             .await
-            .unwrap();
-
-        // Flap 1: leave, backdate left_at to 2 min ago, rejoin.
-        leave_session(&db, &session.id, &user_b).await.unwrap();
-        let two_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(2);
-        backdate_participant(&db, &session.id, &user_b, None, Some(two_min_ago)).await;
-        join_session(&db, &session.id, &user_b).await.unwrap();
-
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert_eq!(pending.len(), 1, "after first short flap, pending intact");
-
-        // Flap 2: leave again, backdate left_at to 1 min ago, rejoin.
-        leave_session(&db, &session.id, &user_b).await.unwrap();
-        let one_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(1);
-        backdate_participant(&db, &session.id, &user_b, None, Some(one_min_ago)).await;
-        join_session(&db, &session.id, &user_b).await.unwrap();
-
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert_eq!(pending.len(), 1, "multiple short flaps preserve pending");
+            .expect("user in a stale session may join a fresh one");
     }
 }

--- a/backend/src/services/sessions/races.rs
+++ b/backend/src/services/sessions/races.rs
@@ -15,7 +15,7 @@ use sea_orm::{
     QueryOrder, Set, TransactionTrait,
 };
 
-use super::types::{REJOIN_GRACE_MINUTES, SessionRaceInfo};
+use super::types::{RACE_WINDOW_HOURS, SessionRaceInfo};
 use crate::{
     domain::{ImagePath, SessionId, SessionRaceId, UserId},
     entities::{cups, runs, session_race_participations, session_races},
@@ -39,28 +39,28 @@ struct PendingRaceRow {
 /// Return the requesting user's pending races within a session, oldest first.
 ///
 /// A race is **pending** for user `U` iff all of the following hold (per
-/// docs/design.md "Pending Race Tracking"):
+/// docs/data-model.md "Pending Race Tracking", ADR-0035):
 ///
 /// 1. A `session_race_participations` row exists for `(SR.id, U.id)` —
 ///    proves `U` was present when `SR` was created.
 /// 2. `skipped_at IS NULL` on that row — `U` hasn't explicitly forfeited.
 /// 3. No `runs` row exists for `(SR.id, U.id)` — `U` hasn't submitted.
-/// 4. `U` is currently within grace — `session_participants.left_at IS NULL`
-///    OR `NOW() - left_at <= REJOIN_GRACE_MINUTES`.
-/// 5. `SR.created_at >= session_participants.joined_at` — excludes pre-gap
-///    pending after a long-gap rejoin reset `joined_at`.
-/// 6. `sessions.status = 'active'` — closed sessions accept no further
+/// 4. `SR.created_at >= NOW() - RACE_WINDOW_HOURS` — the race is still inside
+///    its 1-hour submission window. Expired races drop out for everyone.
+/// 5. `sessions.status = 'active'` — closed sessions accept no further
 ///    submissions, so any "pending" entries on them are phantom (the user
-///    has no API path to resolve them). Required in addition to the grace
-///    clause: a session can close while users are still inside their
-///    5-minute grace window (e.g. via `close_stale_sessions`, or as part of
-///    the host-leaves-last cascade).
+///    has no API path to resolve them).
 ///
-/// Returns empty if the user is not a participant, all races are submitted/
-/// skipped, the session is closed, or the user is past the grace window.
+/// Note this no longer consults `session_participants` at all: a user's
+/// `left_at` is irrelevant to pending access (ADR-0035). A flaked-out user
+/// keeps their pending races until each race expires on its own clock; they
+/// rejoin to act on them. The race window is the single timeout.
 ///
-/// **Lazy check note:** The grace-period predicate is computed at query time
-/// from `NOW()` and stored timestamps. No background task touches
+/// Returns empty if the user is not a participant, all races are submitted /
+/// skipped / expired, or the session is closed.
+///
+/// **Lazy check note:** The expiry predicate is computed at query time from
+/// `NOW()` and stored timestamps. No background task touches
 /// `session_race_participations` rows — they remain in the DB for history
 /// regardless of accessibility.
 ///
@@ -81,8 +81,7 @@ pub async fn get_pending_races(
     session_id: &SessionId,
     user_id: &UserId,
 ) -> Result<Vec<SessionRaceInfo>, Error> {
-    let now = Utc::now().naive_utc();
-    let grace_cutoff = now - chrono::Duration::minutes(REJOIN_GRACE_MINUTES);
+    let window_start = (Utc::now() - chrono::Duration::hours(RACE_WINDOW_HOURS)).naive_utc();
 
     let rows = db_query(
         PendingRaceRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
@@ -96,21 +95,18 @@ pub async fn get_pending_races(
         JOIN sessions s ON s.id = sr.session_id
         JOIN tracks t ON sr.track_id = t.id
         JOIN cups c ON t.cup_id = c.id
-        JOIN session_participants sp
-          ON sp.session_id = sr.session_id AND sp.user_id = srp.user_id
         WHERE sr.session_id = $1
           AND srp.user_id = $2
           AND s.status = 'active'
           AND srp.skipped_at IS NULL
-          AND sr.created_at >= sp.joined_at
-          AND (sp.left_at IS NULL OR sp.left_at >= $3)
+          AND sr.created_at >= $3
           AND NOT EXISTS (
               SELECT 1 FROM runs r
               WHERE r.session_race_id = sr.id AND r.user_id = srp.user_id
           )
         ORDER BY sr.race_number ASC
         "#,
-            [session_id.into(), user_id.into(), grace_cutoff.into()],
+            [session_id.into(), user_id.into(), window_start.into()],
         ))
         .all(db),
     )
@@ -159,9 +155,9 @@ pub async fn get_pending_races(
 ///   directions; see also the matching skip-then-submit guard in
 ///   `services::runs::create_run`).
 /// - `Forbidden` if the user is not currently an active participant of the
-///   session. A user who left (even within their grace window) must rejoin
-///   before they can act on pending races; otherwise the symmetry with
-///   `create_run` breaks (which also requires an active participant).
+///   session. A user who left must rejoin before they can act on pending
+///   races; otherwise the symmetry with `create_run` breaks (which also
+///   requires an active participant).
 ///
 /// # Errors
 ///
@@ -189,9 +185,9 @@ pub async fn skip_pending_race(
             other => other,
         })?;
     // Symmetry with `create_run`: the user must currently be in the session
-    // to act on pending races. Within-grace users (`left_at IS NOT NULL`)
-    // still see their pending races via `get_pending_races` clause 4, but
-    // they need to rejoin before they can submit or skip.
+    // to act on pending races. A user who left still sees their pending
+    // races (until each race expires), but must rejoin before they can
+    // submit or skip.
     helpers::require_active_participant(db, session_id, user_id).await?;
 
     // Verify the race belongs to this session. Looking up by ID first and
@@ -245,8 +241,6 @@ pub async fn skip_pending_race(
     let mut active: session_race_participations::ActiveModel = participation.into();
     active.skipped_at = Set(Some(now));
     db_query(active.update(&txn)).await?;
-
-    helpers::touch_session(&txn, session_id).await?;
 
     db_txn(txn.commit()).await?;
 
@@ -311,7 +305,6 @@ pub async fn next_track(
     .await?;
 
     helpers::insert_race_participations(&txn, session_id, &race_id).await?;
-    helpers::touch_session(&txn, session_id).await?;
 
     db_txn(txn.commit()).await?;
 
@@ -426,7 +419,6 @@ pub async fn skip_turn(
     .await?;
 
     helpers::insert_race_participations(&txn, session_id, &race_id).await?;
-    helpers::touch_session(&txn, session_id).await?;
 
     db_txn(txn.commit()).await?;
 
@@ -459,11 +451,10 @@ mod tests {
     use super::*;
     use crate::{
         domain::enums::SessionStatus,
-        entities::sessions,
-        services::sessions::{close_stale_sessions, create_session, join_session, leave_session},
+        services::sessions::{create_session, join_session, leave_session},
         test_helpers::{
-            backdate_participant, create_user, insert_participant, insert_race_participation,
-            insert_session, insert_session_race, seed_tracks_for_test, setup_db,
+            create_user, insert_participant, insert_race_participation, insert_session,
+            insert_session_race, seed_tracks_for_test, setup_db,
         },
     };
 
@@ -918,7 +909,7 @@ mod tests {
         assert_eq!(pending.len(), 5, "API returns all; UI applies the cap");
     }
 
-    // ── Grace period (PR 3D-1) ──────────────────────────────────────────
+    // ── Per-race expiry + session-status filter (ADR-0035) ───────────────
 
     #[tokio::test]
     async fn test_pending_accessible_when_currently_in_session() {
@@ -929,88 +920,101 @@ mod tests {
         next_track(&db, &session.id, &host_id).await.unwrap();
 
         let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
-        assert_eq!(pending.len(), 1, "left_at IS NULL → pending accessible");
+        assert_eq!(pending.len(), 1, "fresh race → pending accessible");
     }
 
     #[tokio::test]
-    async fn test_pending_accessible_when_within_grace() {
-        // Two participants so the session stays active after user_b leaves
-        // (host transfer keeps it open). This isolates the grace check from
-        // the session-status filter — we want to assert grace alone keeps
-        // pending accessible.
+    async fn test_pending_includes_race_within_window() {
+        // A race created well inside the 1-hour window is still pending.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
-        let user_b = create_user(&db, "b").await;
-        let session = create_session(&db, &host_id, "random").await.unwrap();
-        join_session(&db, &session.id, &user_b).await.unwrap();
-        next_track(&db, &session.id, &host_id).await.unwrap();
-        leave_session(&db, &session.id, &user_b).await.unwrap();
-
-        // Backdate user_b's left_at to 3 minutes ago — well inside the
-        // 5-minute window. Session is still active (host remained).
-        let three_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(3);
-        backdate_participant(&db, &session.id, &user_b, None, Some(three_min_ago)).await;
-
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert_eq!(
-            pending.len(),
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        let race_id = insert_session_race(
+            &db,
+            &session_id,
             1,
-            "within grace + active session → pending accessible"
-        );
+            1,
+            (Utc::now() - chrono::Duration::minutes(30)).naive_utc(),
+        )
+        .await;
+        insert_race_participation(&db, &race_id, &host_id, None).await;
+
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert_eq!(pending.len(), 1, "race within the window stays pending");
     }
 
     #[tokio::test]
-    async fn test_pending_inaccessible_when_grace_expired() {
-        // Two participants so the session stays active — this isolates the
-        // grace check from the status filter, proving exclusion is from
-        // grace expiration alone.
+    async fn test_pending_excludes_expired_race() {
+        // A race created over an hour ago has expired — it drops out of the
+        // pending list even though the participation row is unresolved.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
-        let user_b = create_user(&db, "b").await;
-        let session = create_session(&db, &host_id, "random").await.unwrap();
-        join_session(&db, &session.id, &user_b).await.unwrap();
-        next_track(&db, &session.id, &host_id).await.unwrap();
-        leave_session(&db, &session.id, &user_b).await.unwrap();
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        let race_id = insert_session_race(
+            &db,
+            &session_id,
+            1,
+            1,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+        insert_race_participation(&db, &race_id, &host_id, None).await;
 
-        // Backdate user_b's left_at to 6 minutes ago — past the 5-minute window.
-        let six_min_ago = Utc::now().naive_utc() - chrono::Duration::minutes(6);
-        backdate_participant(&db, &session.id, &user_b, None, Some(six_min_ago)).await;
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "expired race drops from pending");
 
-        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
-        assert!(pending.is_empty(), "grace expired → no accessible pending");
-
-        // The row still exists in the DB (lazy check, no cleanup).
+        // The participation row itself stays for history (lazy check).
         let count = session_race_participations::Entity::find()
-            .filter(session_race_participations::Column::UserId.eq(user_b))
+            .filter(session_race_participations::Column::UserId.eq(host_id))
             .count(&db)
             .await
             .unwrap();
         assert_eq!(count, 1, "participation row remains for history");
     }
 
+    #[tokio::test]
+    async fn test_pending_unaffected_by_user_left_at() {
+        // A user who has left the session still sees their pending races
+        // (until each race expires) — `left_at` no longer gates pending
+        // access at all (ADR-0035). Two participants so the session stays
+        // active after user_b leaves.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user_b = create_user(&db, "b").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user_b).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        leave_session(&db, &session.id, &user_b).await.unwrap();
+
+        let pending = get_pending_races(&db, &session.id, &user_b).await.unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "a left user still sees their unexpired pending race"
+        );
+    }
+
     /// Documents intent: no background timer or sweeper task touches
     /// `session_race_participations`. Pending accessibility is a pure read-time
-    /// derivation from `(session_race_participations, session_participants,
-    /// runs)` — see `get_pending_races`. Forfeited rows remain in the DB
-    /// indefinitely as historical state. If a future PR adds a sweeper, this
-    /// assertion (and the design rationale in docs/design.md "Pending Race
-    /// Tracking") needs to be revisited.
+    /// derivation from `(session_race_participations, session_races, runs)`
+    /// plus the per-race expiry clock — see `get_pending_races`. Resolved /
+    /// expired rows remain in the DB indefinitely as historical state.
     #[tokio::test]
     async fn test_lazy_check_assertion() {
         // No-op test by design — this comment IS the assertion.
     }
 
     #[tokio::test]
-    async fn test_pending_excludes_closed_session_even_within_grace() {
-        // Regression: `close_stale_sessions` (and the host-leaves-last
-        // cascade in leave_session) sets `left_at = NOW()` for still-active
-        // participants and flips `status` to closed in the same transaction.
-        // Within the next 5 minutes, those users are inside the grace window
-        // — but the session can no longer accept submissions or skips, so
-        // the pending entries are phantom. `get_pending_races` must filter
-        // them out via `sessions.status = 'active'`.
+    async fn test_pending_excludes_closed_session() {
+        // A closed session can no longer accept submissions or skips, so any
+        // "pending" entries on it are phantom. `get_pending_races` must
+        // filter them out via `sessions.status = 'active'`.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
@@ -1021,27 +1025,11 @@ mod tests {
         let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
         assert_eq!(pending.len(), 1);
 
-        // Backdate last_activity_at past the stale threshold so
-        // close_stale_sessions catches it; this mirrors the production path
-        // (sets left_at = NOW() and status = 'closed' atomically).
-        let two_hours_ago = Utc::now().naive_utc() - chrono::Duration::hours(2);
-        let s = sessions::Entity::find_by_id(session.id)
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap();
-        let mut active: sessions::ActiveModel = s.into();
-        active.last_activity_at = Set(two_hours_ago);
-        active.update(&db).await.unwrap();
-        close_stale_sessions(&db).await.unwrap();
+        // The solo host leaving closes the session inline.
+        leave_session(&db, &session.id, &host_id).await.unwrap();
 
-        // Host's left_at is now ~now (well within the 5-min grace), but the
-        // session is closed — pending must be empty.
         let pending = get_pending_races(&db, &session.id, &host_id).await.unwrap();
-        assert!(
-            pending.is_empty(),
-            "closed session must not return pending even within grace window"
-        );
+        assert!(pending.is_empty(), "closed session must not return pending");
 
         // The participation row itself stays in the DB for history.
         let count = session_race_participations::Entity::find()

--- a/backend/src/services/sessions/types.rs
+++ b/backend/src/services/sessions/types.rs
@@ -4,13 +4,27 @@
 //! consumed by [`super::detail`] aggregation (or vice versa). Living at a
 //! layer below both submodules breaks what would otherwise be a
 //! `detail` ↔ `races` cycle on [`SessionRaceInfo`] / [`get_pending_races`],
-//! and a `races` → `lifecycle` cycle on [`REJOIN_GRACE_MINUTES`].
+//! and a `races` ↔ `lifecycle` cycle on [`RACE_WINDOW_HOURS`].
 //!
 //! [`get_pending_races`]: super::races::get_pending_races
 
 use chrono::{DateTime, Utc};
 
 use crate::domain::{ImagePath, SessionRaceId, UserId, Username};
+
+/// The single timeout that anchors session lifetime (ADR-0035).
+///
+/// A `session_races` row is submittable for this many hours from its
+/// `created_at`; after that the race is expired and drops out of every
+/// pending list. The same window doubles as the session bootstrap grace:
+/// a brand-new session with no race chosen yet is considered alive for
+/// this long from its own `created_at`.
+///
+/// Consumed by [`super::lifecycle`] (the stale-session sweeper and the two
+/// "are you in a session" liveness predicates) and [`super::races`]
+/// (`get_pending_races`). Defined here so neither submodule depends on the
+/// other for it.
+pub const RACE_WINDOW_HOURS: i64 = 1;
 
 /// Submission info for a single participant in a race.
 #[derive(serde::Serialize, Clone)]
@@ -45,16 +59,3 @@ pub struct SessionRaceInfo {
     /// Per-participant submissions; empty until runs come in.
     pub submissions: Vec<RaceSubmission>,
 }
-
-/// Grace window for "rejoin without losing pre-leave pending races."
-///
-/// Within this window of `left_at`, rejoining preserves `joined_at` (and
-/// therefore preserves access to pre-leave pending races, per the §3 grace
-/// semantics). After this window, `joined_at` is reset to `NOW()`, forfeiting
-/// any pre-gap pending records.
-///
-/// Defined here (not in [`super::lifecycle`], where it semantically
-/// originates) because both [`super::lifecycle::join_session`] and the
-/// pending-races query in [`super::races`] consume it; living at the shared
-/// layer keeps the submodule dependency graph acyclic.
-pub const REJOIN_GRACE_MINUTES: i64 = 5;

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -129,12 +129,32 @@ pub async fn insert_session(
         least_played_drink_category: Set(None),
         status: Set(status),
         created_at: NotSet,
-        last_activity_at: Set(Utc::now().naive_utc()),
     }
     .insert(db)
     .await
     .expect("insert session");
     id
+}
+
+/// Backdate a session's `created_at`. Tests use this to simulate a session
+/// that was created N hours ago without sleeping — e.g. to drive the
+/// race-derived stale-session sweeper or the liveness predicates.
+pub async fn backdate_session(
+    db: &DatabaseConnection,
+    session_id: &SessionId,
+    created_at: chrono::NaiveDateTime,
+) {
+    use sea_orm::EntityTrait;
+
+    let row = sessions::Entity::find_by_id(session_id)
+        .one(db)
+        .await
+        .expect("query session")
+        .expect("session exists");
+
+    let mut active: sessions::ActiveModel = row.into();
+    active.created_at = Set(created_at);
+    active.update(db).await.expect("backdate session");
 }
 
 /// Insert a participant into a session. Pass `None` for `left_at` to create
@@ -169,17 +189,24 @@ pub async fn insert_session_race(
     created_at: chrono::NaiveDateTime,
 ) -> SessionRaceId {
     let id = SessionRaceId::new_v4();
-    session_races::ActiveModel {
+    let model = session_races::ActiveModel {
         id: Set((&id).into()),
         session_id: Set(session_id.into()),
         race_number: Set(race_number),
         track_id: Set(track_id),
         chosen_by: Set(None),
-        created_at: Set(created_at),
+        created_at: NotSet,
     }
     .insert(db)
     .await
     .expect("insert session race");
+    // `session_races::before_save` stamps `created_at = now` on every insert,
+    // overriding any value passed to the `ActiveModel`. Apply the requested
+    // timestamp with a follow-up update so tests can build races at an
+    // arbitrary age (e.g. to drive per-race expiry or the stale sweeper).
+    let mut active: session_races::ActiveModel = model.into();
+    active.created_at = Set(created_at);
+    active.update(db).await.expect("backdate session race");
     id
 }
 

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -276,7 +276,7 @@ async fn test_full_session_lifecycle() {
 }
 
 #[tokio::test]
-async fn test_list_sessions_returns_only_active_sorted_by_last_activity() {
+async fn test_list_sessions_returns_only_active() {
     let (server, _db) = setup_test_app().await;
     let (token, _) = register_and_get_token(&server, "host").await;
 
@@ -484,7 +484,8 @@ async fn test_stale_session_cleanup() {
     let session: Value = res.json();
     let session_id = session["id"].as_str().unwrap().to_string();
 
-    // Manually set last_activity_at to 2 hours ago
+    // Backdate created_at to 2 hours ago — a session with no races that was
+    // created over an hour ago is stale (ADR-0035 race-derived sweeper).
     let two_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).naive_utc();
     let session_model = sessions::Entity::find_by_id(&session_id)
         .one(&db)
@@ -492,7 +493,7 @@ async fn test_stale_session_cleanup() {
         .unwrap()
         .unwrap();
     let mut active: sessions::ActiveModel = session_model.into();
-    active.last_activity_at = Set(two_hours_ago);
+    active.created_at = Set(two_hours_ago);
     active.update(&db).await.unwrap();
 
     // Run cleanup

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -68,7 +68,6 @@ export interface SessionSummary {
   participant_count: number
   race_number: number
   ruleset: string
-  last_activity_at: string
 }
 
 export interface ParticipantInfo {
@@ -156,7 +155,6 @@ export interface SessionDetail {
   ruleset: string
   status: string
   created_at: string
-  last_activity_at: string
   participants: ParticipantInfo[]
   race_number: number
   current_race: SessionRaceInfo | null


### PR DESCRIPTION
Closes #47 #51 #58

Implements [ADR-0035](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/decisions/0035-race-anchored-session-lifetime.md): replaces the two parallel timeout concepts — the 1-hour idle-session timeout (anchored on `sessions.last_activity_at`) and the 5-minute rejoin grace — with a single **race-anchored** timeout. Each `session_races` row is submittable for 1 hour from its `created_at`; a session is "live" while it has a race in that window, or was itself created within the last hour (the bootstrap case).

Single combined PR because the three issues are co-dependent — the schema drop, the service rewrites, and the test changes can't compile or pass in isolation.

## What changed

**#47 — lifecycle**
- Dropped the `last_activity_at` column and its index from the consolidated migration and `entities/sessions.rs`; added `idx_sessions_status_created_at` to back the new sweeper predicate.
- `join_session`: dropped the rejoin gap-comparison. `joined_at` is now monotonic — set once on first join, never reset. Host succession (ADR-0014) is cleaner under this.
- `check_not_in_any_session` / `get_active_session_id`: gained the race-derived liveness clause, so "are you in a session" no longer waits on the sweeper. The two queries are now consolidated (`check_` delegates to `get_active_session_id`) — no risk of the predicates drifting apart.

**#51 — per-race expiry**
- `get_pending_races`: dropped the grace clause, the `joined_at` clause, and the `session_participants` join; added `sr.created_at >= NOW() - 1h`. A user's `left_at` no longer affects pending access at all.
- Deleted `REJOIN_GRACE_MINUTES`; added `RACE_WINDOW_HOURS` (the single 1-hour constant, shared via `sessions/types.rs`).

**#58 — race-derived sweeper**
- `close_stale_sessions`: predicate rewritten to "session created over an hour ago AND no race created within the last hour" (the `NOT EXISTS` subquery is hand-rolled SQL per seaorm.md § 1).
- Deleted `helpers::touch_session` and all call sites (`create_session`, `join_session`, `leave_session`, `next_track`, `skip_turn`, `create_run`, `delete_run`, `skip_pending_race`) plus `SessionContext::touch`.
- Sweep cadence relaxed 5 min → 15 min.

## Beyond the literal ADR — flagged for review

- **`settle_dangling_participation`.** ADR-0035 says the liveness clause "decouples user lockout from sweep timing." It does — at the application level. But the schema has a partial unique index `idx_session_participants_one_active_session` (`UNIQUE(user_id) WHERE left_at IS NULL`) the ADR doesn't mention: the `INSERT` of a fresh participant row in `create_session`/`join_session` would still collide with a user's dangling row from a now-stale session. So this PR adds `settle_dangling_participation`, called inside the create/join transaction — it marks the user's dangling row as left so the decoupling is real (semantically: you implicitly leave an abandoned session by starting a new one). Without it, lockout would stay sweep-bound, and at 15-min cadence that's *worse* than the old 5-min behavior. See `.agents/handoffs/cowork.md` for the suggestion to record this in the ADR.
- **Wire format.** `SessionDetail` and `SessionSummary` API responses lose their `last_activity_at` field; `frontend/src/api/types.ts` is updated to match. `api-contract.md` § 4's ETag spec still references `session.last_activity_at` and needs a design revision (it was the only ETag input that captured participant joins/leaves) — flagged for Cowork, not touched here.
- **`.editorconfig`.** Added a 2-space override for frontend source extensions. The global `indent_size = 4` is correct for Rust but Prettier (which honors `.editorconfig`) was therefore demanding 4-space for the 2-space frontend codebase. This is a pre-existing latent bug surfaced by touching `types.ts`; fix confirmed with Brendan.

## Out of scope (Cowork's lane)

`docs/data-model.md`, `docs/user-workflows.md` § 1.5, and `docs/api-contract.md` § 4 — see `.agents/handoffs/cowork.md`.

## Testing

`cargo test` — 279 unit + 27/21/8/… integration tests pass; `cargo clippy --tests` clean; `bun run typecheck` clean.

Test changes: dropped the five grace tests (`pending_*_grace_*`, `rejoin_*_grace*`, `multiple_short_flaps_within_grace_*`), the `touch_session` / `SessionContext::touch` tests, and the `last_activity_at`-movement assertions. Added per-race-expiry tests (`get_pending_races` excludes expired races, includes races in-window, is unaffected by `left_at`), sweeper tests (`close_stale_sessions` for the all-races-expired / recent-race / fresh-bootstrap / old-bootstrap cases), a monotonic-`joined_at` rejoin test, and the lockout-decoupling tests (a user in a stale session can create/join a fresh one).

### Manual test steps

The 1-hour expiry and 15-min sweep are timer-driven and covered by unit tests (which backdate timestamps); the steps below cover what's observable live.

1. **Setup:** `cd backend && cargo run` (in another terminal `cd frontend && bun run dev`). The dev SQLite DB is recreated from the migration on boot — if you have an old DB file, delete it first (the schema changed).
2. **Create + join:** Register two users in two browsers. User A creates a session; user B joins it. Both should see two participants.
3. **Leave + rejoin keeps you in:** User B leaves, then rejoins the same session. B should rejoin cleanly with no "already in a session" error, and the participant list should still show both.
4. **One active session at a time:** While B is in A's session, B tries to create a new session → expect a 409 "Already in session …".
5. **Leave frees you:** B leaves A's session, then creates their own → should succeed.
6. **Pending races survive a leave:** A picks a track (`next_track`). B leaves the session *without* submitting. B rejoins → B's pending race for that track should still be listed (no 5-minute grace cutoff anymore).
7. **Host succession unchanged:** In a 3-person session, the host leaves → host role transfers to the earliest-joined remaining participant; session stays active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)