### PR TITLE
164: drop pending races on session close + notifications MVP

### DIFF
--- a/backend/migration/src/m20260101_000001_initial_schema.rs
+++ b/backend/migration/src/m20260101_000001_initial_schema.rs
@@ -358,6 +358,12 @@ impl MigrationTrait for Migration {
         // when"). If a user-deletion path is ever added, it must explicitly
         // decide what to do with these rows rather than letting them silently
         // vanish.
+        //
+        // `skipped_at` flips when the user explicitly forfeits the race;
+        // `dropped_at` (ADR-0037) flips when the session closes around an
+        // unresolved pending row. The two are mutually exclusive in practice
+        // and together with a `runs` row form the four-state per-(race, user)
+        // status enum (`unraced` / `raced` / `skipped` / `dropped`).
 
         conn.execute_unprepared(
             "CREATE TABLE IF NOT EXISTS session_race_participations (
@@ -365,6 +371,7 @@ impl MigrationTrait for Migration {
                     user_id TEXT NOT NULL REFERENCES users(id),
                     created_at datetime_text NOT NULL,
                     skipped_at datetime_text,
+                    dropped_at datetime_text,
                     PRIMARY KEY (session_race_id, user_id)
                 )",
         )
@@ -430,6 +437,44 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
+        // ---- Notifications (ADR-0038) ----
+        //
+        // Per-user inbox of asynchronous events. `kind` is the discriminator
+        // (snake_case, indexed); `payload` is the kind-specific structured
+        // body, stored as JSON TEXT (the serde-tagged `NotificationPayload`
+        // enum on the Rust side). `read_at` is NULL until the user dismisses.
+        //
+        // ON DELETE CASCADE on user_id: when a user is gone their inbox
+        // should be too — unlike `session_race_participations`, notifications
+        // carry no cross-user audit value.
+        conn.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS notifications (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    kind TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at datetime_text NOT NULL,
+                    read_at datetime_text
+                )",
+        )
+        .await?;
+
+        // Partial index for the "list my unread, newest first" hot path
+        // (the home-screen badge poll). Raw SQL because SeaORM's builder
+        // doesn't support partial-index WHERE clauses.
+        conn.execute_unprepared(
+            "CREATE INDEX idx_notifications_user_unread
+                 ON notifications(user_id, created_at DESC) WHERE read_at IS NULL",
+        )
+        .await?;
+
+        // Full index for paginated "show me everything, including read".
+        conn.execute_unprepared(
+            "CREATE INDEX idx_notifications_user_created
+                 ON notifications(user_id, created_at DESC)",
+        )
+        .await?;
+
         Ok(())
     }
 
@@ -437,6 +482,8 @@ impl MigrationTrait for Migration {
         // Drop in reverse FK dependency order so FKs don't block drops.
         let conn = manager.get_connection();
 
+        conn.execute_unprepared("DROP TABLE IF EXISTS notifications")
+            .await?;
         conn.execute_unprepared("DROP TABLE IF EXISTS run_flags")
             .await?;
         conn.execute_unprepared("DROP TABLE IF EXISTS runs").await?;

--- a/backend/src/domain/ids.rs
+++ b/backend/src/domain/ids.rs
@@ -142,6 +142,7 @@ uuid_id_newtype!(SessionRaceId, "session_races.id");
 uuid_id_newtype!(SessionParticipantId, "session_participants.id");
 uuid_id_newtype!(RunFlagId, "run_flags.id");
 uuid_id_newtype!(DrinkTypeId, "drink_types.id");
+uuid_id_newtype!(NotificationId, "notifications.id");
 
 // ── Integer-backed ID newtypes ──────────────────────────────────────────
 //

--- a/backend/src/domain/mod.rs
+++ b/backend/src/domain/mod.rs
@@ -10,7 +10,7 @@ pub mod race_setup;
 pub mod strings;
 
 pub use ids::{
-    BodyId, CharacterId, CupId, DrinkTypeId, GliderId, RunFlagId, RunId, SessionId,
+    BodyId, CharacterId, CupId, DrinkTypeId, GliderId, NotificationId, RunFlagId, RunId, SessionId,
     SessionParticipantId, SessionRaceId, TrackId, UserId, WheelId,
 };
 pub(crate) use numeric::assert_lap_sum;

--- a/backend/src/entities/mod.rs
+++ b/backend/src/entities/mod.rs
@@ -11,6 +11,7 @@ pub mod characters;
 pub mod cups;
 pub mod drink_types;
 pub mod gliders;
+pub mod notifications;
 pub mod run_flags;
 pub mod runs;
 pub mod session_participants;
@@ -26,6 +27,7 @@ pub mod wheels;
 // service code never sets these by hand. See `docs/coding-standards/seaorm.md`
 // § 1 (and PR-E1 / Issue #137 for the migration that introduced this split).
 mod drink_types_behavior;
+mod notifications_behavior;
 mod run_flags_behavior;
 mod runs_behavior;
 mod session_race_participations_behavior;

--- a/backend/src/entities/notifications.rs
+++ b/backend/src/entities/notifications.rs
@@ -1,0 +1,47 @@
+//! Hand-written entity for `notifications` (ADR-0038).
+//!
+//! Per-user inbox of asynchronous events. `kind` is the discriminator
+//! (`snake_case`, lifted out of the JSON for indexing); `payload` is the
+//! kind-specific structured body, stored as JSON TEXT — the serde-tagged
+//! [`NotificationPayload`] enum on the Rust side. `read_at` is NULL until
+//! the user dismisses the notification.
+//!
+//! [`NotificationPayload`]: crate::services::notifications::NotificationPayload
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "notifications")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
+    pub id: String,
+    #[sea_orm(column_type = "Text")]
+    pub user_id: String,
+    #[sea_orm(column_type = "Text")]
+    pub kind: String,
+    #[sea_orm(column_type = "Text")]
+    pub payload: String,
+    pub created_at: DateTime,
+    pub read_at: Option<DateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::UserId",
+        to = "super::users::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Users,
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Users.def()
+    }
+}
+
+// `ActiveModelBehavior` for this entity lives in the sibling
+// `notifications_behavior.rs` (it stamps `created_at`).

--- a/backend/src/entities/notifications_behavior.rs
+++ b/backend/src/entities/notifications_behavior.rs
@@ -1,0 +1,22 @@
+//! `ActiveModelBehavior` for [`super::notifications`]. Stamps `created_at` on
+//! insert. `read_at` is set explicitly by the mark-as-read path, not here.
+//! See `docs/coding-standards/seaorm.md` § 1.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{ActiveModelBehavior, ConnectionTrait, DbErr, Set};
+
+use super::notifications::ActiveModel;
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(Utc::now().naive_utc());
+        }
+        Ok(self)
+    }
+}

--- a/backend/src/entities/prelude.rs
+++ b/backend/src/entities/prelude.rs
@@ -1,7 +1,8 @@
 pub use super::{
     bodies::Entity as Bodies, characters::Entity as Characters, cups::Entity as Cups,
-    drink_types::Entity as DrinkTypes, gliders::Entity as Gliders, run_flags::Entity as RunFlags,
-    runs::Entity as Runs, session_participants::Entity as SessionParticipants,
+    drink_types::Entity as DrinkTypes, gliders::Entity as Gliders,
+    notifications::Entity as Notifications, run_flags::Entity as RunFlags, runs::Entity as Runs,
+    session_participants::Entity as SessionParticipants,
     session_race_participations::Entity as SessionRaceParticipations,
     session_races::Entity as SessionRaces, sessions::Entity as Sessions, tracks::Entity as Tracks,
     users::Entity as Users, wheels::Entity as Wheels,

--- a/backend/src/entities/session_race_participations.rs
+++ b/backend/src/entities/session_race_participations.rs
@@ -2,7 +2,8 @@
 //!
 //! Composite primary key `(session_race_id, user_id)` — one row per (race, user)
 //! captured at race-creation time. Existence proves presence; `skipped_at`
-//! flips when the user explicitly forfeits the race.
+//! flips when the user explicitly forfeits the race; `dropped_at` (ADR-0037)
+//! flips when the session closes around an unresolved pending row.
 
 use sea_orm::entity::prelude::*;
 
@@ -15,6 +16,7 @@ pub struct Model {
     pub user_id: String,
     pub created_at: DateTime,
     pub skipped_at: Option<DateTime>,
+    pub dropped_at: Option<DateTime>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -195,6 +195,19 @@ async fn main() -> anyhow::Result<()> {
             "/api/v1/users/{id}",
             get(routes::users::get_user).put(routes::users::update_user),
         )
+        // Notifications (per-user inbox, ADR-0038)
+        .route(
+            "/api/v1/me/notifications",
+            get(routes::notifications::list_notifications),
+        )
+        .route(
+            "/api/v1/me/notifications/unread-count",
+            get(routes::notifications::unread_count),
+        )
+        .route(
+            "/api/v1/me/notifications/read-all",
+            post(routes::notifications::mark_all_read),
+        )
         // Drink types
         .route(
             "/api/v1/drink-types",

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -4,6 +4,8 @@ pub mod auth;
 pub mod drink_types;
 /// Read-only seeded game data: characters, bodies, wheels, gliders, cups, tracks.
 pub mod game_data;
+/// Per-user notifications inbox — list, unread-count, mark-all-read.
+pub mod notifications;
 /// Run recording — create / list / get / delete individual race runs.
 pub mod runs;
 /// Session lifecycle — create, join, leave, list, get, race orchestration.

--- a/backend/src/routes/notifications.rs
+++ b/backend/src/routes/notifications.rs
@@ -1,0 +1,76 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AppState, error::Error, extract::Json, middleware::auth::User, services::notifications,
+};
+
+/// Query string for `GET /me/notifications`.
+#[derive(Deserialize)]
+pub struct ListNotificationsQuery {
+    /// When `true`, include already-read notifications. Defaults to `false`
+    /// (unread only) — the home-screen dropdown's day-one shape.
+    #[serde(default)]
+    pub include_read: bool,
+}
+
+/// `GET /me/notifications` — list the authenticated user's notifications,
+/// newest first. Unread-only unless `?include_read=true`.
+///
+/// # Errors
+///
+/// Propagates the errors of [`notifications::list_notifications`] — `Internal`
+/// for unexpected DB failures or a corrupt stored payload.
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id, include_read = query.include_read))]
+pub async fn list_notifications(
+    user: User,
+    State(state): State<AppState>,
+    Query(query): Query<ListNotificationsQuery>,
+) -> Result<Json<Vec<notifications::NotificationView>>, Error> {
+    let list =
+        notifications::list_notifications(&state.db, &user.user_id, query.include_read).await?;
+    Ok(Json(list))
+}
+
+/// Response body for `GET /me/notifications/unread-count`.
+#[derive(Serialize)]
+pub struct UnreadCountResponse {
+    /// Number of unread notifications for the authenticated user.
+    pub count: u64,
+}
+
+/// `GET /me/notifications/unread-count` — cheap unread tally for the
+/// home-screen badge poll.
+///
+/// # Errors
+///
+/// Propagates the errors of [`notifications::unread_count`] — `Internal` for
+/// unexpected DB failures.
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id))]
+pub async fn unread_count(
+    user: User,
+    State(state): State<AppState>,
+) -> Result<Json<UnreadCountResponse>, Error> {
+    let count = notifications::unread_count(&state.db, &user.user_id).await?;
+    Ok(Json(UnreadCountResponse { count }))
+}
+
+/// `POST /me/notifications/read-all` — mark all of the authenticated user's
+/// unread notifications as read. Returns `204 No Content`.
+///
+/// # Errors
+///
+/// Propagates the errors of [`notifications::mark_all_read`] — `Internal` for
+/// unexpected DB failures.
+#[tracing::instrument(skip_all, fields(user_id = %user.user_id))]
+pub async fn mark_all_read(
+    user: User,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, Error> {
+    notifications::mark_all_read(&state.db, &user.user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/services/helpers.rs
+++ b/backend/src/services/helpers.rs
@@ -128,6 +128,7 @@ pub async fn insert_race_participations<C: ConnectionTrait>(
             user_id: Set(p.user_id),
             created_at: Set(now),
             skipped_at: Set(None),
+            dropped_at: Set(None),
         });
 
     db_query(session_race_participations::Entity::insert_many(rows).exec(txn)).await?;

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -2,6 +2,8 @@
 pub mod auth;
 /// Cross-service helpers (lookup-or-404, etc.) that don't fit one resource.
 pub mod helpers;
+/// Per-user notifications inbox: record, list, unread-count, mark-all-read.
+pub mod notifications;
 /// Run-recording service: submission + read-side queries.
 pub mod runs;
 /// Shared session-context type passed through nested service calls.

--- a/backend/src/services/notifications.rs
+++ b/backend/src/services/notifications.rs
@@ -151,10 +151,10 @@ pub async fn record(
 /// # Errors
 ///
 /// Propagates the errors of [`record`].
-#[tracing::instrument(
-    skip(txn),
-    fields(user_id = %user_id, session_id = %session_id, dropped_count),
-)]
+// `dropped_count` is intentionally not named in `fields(...)` — a bare name
+// there declares an empty span field that nothing records. As an unskipped
+// `Copy` argument it is auto-captured into the span by `#[instrument]`.
+#[tracing::instrument(skip(txn), fields(user_id = %user_id, session_id = %session_id))]
 pub async fn record_pending_drops(
     txn: &impl ConnectionTrait,
     user_id: &UserId,

--- a/backend/src/services/notifications.rs
+++ b/backend/src/services/notifications.rs
@@ -1,0 +1,442 @@
+//! Notifications service (ADR-0038).
+//!
+//! A per-user inbox of asynchronous events. Each event materializes one
+//! `notifications` row inside the same transaction as the triggering write —
+//! no worker, no queue, no async dispatch (ADR-0038 § Generation pattern).
+//!
+//! The module exposes:
+//! - [`NotificationPayload`] — the closed, serde-tagged enum of event kinds.
+//! - [`record`] — the generic typed constructor every event site calls.
+//! - [`record_pending_drops`] — the ADR-0037 consumer (pending races dropped
+//!   on session close).
+//! - [`list_notifications`] / [`unread_count`] / [`mark_all_read`] — the read
+//!   and dismiss surface backing the three `/me/notifications` endpoints.
+//!
+//! For MVP the enum carries a single variant (`PendingRacesDropped`); the
+//! other kinds named in ADR-0038 (`H2hLeadChanged`, `TrackRecordLost`,
+//! `LeaderboardRankChanged`) are deliberately deferred to future cups.
+
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, ConnectionTrait, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, sea_query::Expr,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    domain::{NotificationId, SessionId, UserId},
+    entities::notifications,
+    error::Error,
+    timeout::db_query,
+};
+
+/// Hard cap on rows returned by [`list_notifications`].
+///
+/// ADR-0038 § API surface specifies cursor pagination per ADR-0032 for
+/// `GET /me/notifications`. No cursor-pagination infrastructure exists in the
+/// codebase yet — `GET /runs` (the ADR-0032 exemplar) also still uses a flat
+/// `LIMIT 100` cap. This endpoint follows that precedent rather than building
+/// keyset pagination for one endpoint in isolation; revisiting it project-wide
+/// is tracked as a follow-up. At friend-group scale (ADR-0038 estimates
+/// ~18k notification rows/year across ~10 users) a 100-row cap comfortably
+/// covers the unread inbox and a deep history scroll.
+const NOTIFICATIONS_PAGE_LIMIT: u64 = 100;
+
+/// Closed set of notification event kinds, with serde-tagged serialization.
+///
+/// `kind` is the serde tag — lifted into the `notifications.kind` column for
+/// indexing — and the rest of each variant body is the JSON payload stored in
+/// `notifications.payload`. Adding a kind is adding a variant: the compiler
+/// then surfaces every site that pattern-matches.
+///
+/// MVP carries only [`Self::PendingRacesDropped`]. The future variants from
+/// ADR-0038 § Rust modeling land with their respective cups.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NotificationPayload {
+    /// The user's session closed while they still had unresolved pending
+    /// races; those races were dropped (ADR-0037).
+    PendingRacesDropped {
+        /// The session that closed.
+        session_id: SessionId,
+        /// How many of the user's pending races were dropped.
+        dropped_count: u32,
+    },
+}
+
+impl NotificationPayload {
+    /// The `snake_case` discriminator stored in the `kind` column.
+    ///
+    /// Mirrors the serde tag — keep the two in lockstep when adding variants.
+    const fn kind_str(&self) -> &'static str {
+        match self {
+            Self::PendingRacesDropped { .. } => "pending_races_dropped",
+        }
+    }
+}
+
+/// Wire view of a single notification — the JSON shape returned by
+/// `GET /me/notifications`.
+///
+/// The stored `kind` column is intentionally not surfaced separately: it is
+/// already present as the serde tag inside `payload`.
+#[derive(Debug, Serialize)]
+pub struct NotificationView {
+    /// Stable UUID of the notification row.
+    pub id: NotificationId,
+    /// When the event was recorded, UTC.
+    pub created_at: DateTime<Utc>,
+    /// When the user dismissed it, or `None` while unread.
+    pub read_at: Option<DateTime<Utc>>,
+    /// Kind-tagged structured payload.
+    pub payload: NotificationPayload,
+}
+
+/// Parse a stored notification row into its wire view.
+///
+/// A `payload` column that doesn't deserialize as a [`NotificationPayload`]
+/// is data corruption (hand-edited row, or a write from a future schema) and
+/// surfaces as `Internal`.
+fn row_into_view(row: &notifications::Model) -> Result<NotificationView, Error> {
+    let payload: NotificationPayload = serde_json::from_str(&row.payload).map_err(|e| {
+        Error::Internal(anyhow::Error::new(e).context("Deserializing notification payload"))
+    })?;
+    Ok(NotificationView {
+        id: NotificationId::from_db(&row.id)?,
+        created_at: row.created_at.and_utc(),
+        read_at: row.read_at.map(|t| t.and_utc()),
+        payload,
+    })
+}
+
+/// Record a notification for `user_id`.
+///
+/// The INSERT runs on whatever connection / transaction handle is passed: an
+/// event site that already holds a transaction passes it so the notification
+/// is atomic with the triggering write (ADR-0038 § Atomicity).
+///
+/// # Errors
+///
+/// Returns `Internal` if the payload fails to serialize (should not happen
+/// for the closed enum) or for unexpected DB failures on the INSERT.
+#[tracing::instrument(skip(txn, payload), fields(user_id = %user_id, kind = payload.kind_str()))]
+pub async fn record(
+    txn: &impl ConnectionTrait,
+    user_id: &UserId,
+    payload: &NotificationPayload,
+) -> Result<(), Error> {
+    let payload_json = serde_json::to_string(payload).map_err(|e| {
+        Error::Internal(anyhow::Error::new(e).context("Serializing notification payload"))
+    })?;
+
+    db_query(
+        notifications::ActiveModel {
+            id: Set(NotificationId::new_v4().into()),
+            user_id: Set(user_id.into()),
+            kind: Set(payload.kind_str().to_string()),
+            payload: Set(payload_json),
+            created_at: NotSet,
+            read_at: Set(None),
+        }
+        .insert(txn),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Record a [`NotificationPayload::PendingRacesDropped`] for one affected
+/// user. Called once per user inside the session-close transaction (ADR-0037).
+///
+/// # Errors
+///
+/// Propagates the errors of [`record`].
+#[tracing::instrument(
+    skip(txn),
+    fields(user_id = %user_id, session_id = %session_id, dropped_count),
+)]
+pub async fn record_pending_drops(
+    txn: &impl ConnectionTrait,
+    user_id: &UserId,
+    session_id: &SessionId,
+    dropped_count: u32,
+) -> Result<(), Error> {
+    record(
+        txn,
+        user_id,
+        &NotificationPayload::PendingRacesDropped {
+            session_id: *session_id,
+            dropped_count,
+        },
+    )
+    .await
+}
+
+/// List a user's notifications, newest first.
+///
+/// Unread-only by default; `include_read = true` returns the full history.
+/// Capped at [`NOTIFICATIONS_PAGE_LIMIT`] rows.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures or a corrupt stored payload.
+#[tracing::instrument(skip(db), fields(user_id = %user_id, include_read))]
+pub async fn list_notifications(
+    db: &impl ConnectionTrait,
+    user_id: &UserId,
+    include_read: bool,
+) -> Result<Vec<NotificationView>, Error> {
+    let mut query = notifications::Entity::find().filter(notifications::Column::UserId.eq(user_id));
+    if !include_read {
+        query = query.filter(notifications::Column::ReadAt.is_null());
+    }
+
+    let rows = db_query(
+        query
+            // Compound ordering keeps a stable sequence when two rows share a
+            // `created_at` (sub-millisecond inserts) — `id` is the tie-break.
+            .order_by_desc(notifications::Column::CreatedAt)
+            .order_by_desc(notifications::Column::Id)
+            .limit(NOTIFICATIONS_PAGE_LIMIT)
+            .all(db),
+    )
+    .await?;
+
+    rows.iter().map(row_into_view).collect()
+}
+
+/// Count a user's unread notifications. Backs the home-screen badge poll.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
+#[tracing::instrument(skip(db), fields(user_id = %user_id))]
+pub async fn unread_count(db: &impl ConnectionTrait, user_id: &UserId) -> Result<u64, Error> {
+    let count = db_query(
+        notifications::Entity::find()
+            .filter(notifications::Column::UserId.eq(user_id))
+            .filter(notifications::Column::ReadAt.is_null())
+            .count(db),
+    )
+    .await?;
+    Ok(count)
+}
+
+/// Mark every unread notification for `user_id` as read.
+///
+/// One set-based UPDATE (`seaorm.md` § 1) scoped to the requesting user, so
+/// it never touches another user's inbox. Returns the number of rows flipped.
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures.
+#[tracing::instrument(skip(db), fields(user_id = %user_id))]
+pub async fn mark_all_read(db: &impl ConnectionTrait, user_id: &UserId) -> Result<u64, Error> {
+    let now = Utc::now().naive_utc();
+    let result = db_query(
+        notifications::Entity::update_many()
+            .col_expr(notifications::Column::ReadAt, Expr::value(now))
+            .filter(notifications::Column::UserId.eq(user_id))
+            .filter(notifications::Column::ReadAt.is_null())
+            .exec(db),
+    )
+    .await?;
+    Ok(result.rows_affected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{create_user, setup_db};
+
+    #[test]
+    fn test_pending_races_dropped_round_trips_through_json() {
+        let session_id = SessionId::new_v4();
+        let payload = NotificationPayload::PendingRacesDropped {
+            session_id,
+            dropped_count: 3,
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        let back: NotificationPayload = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(payload, back);
+    }
+
+    #[test]
+    fn test_pending_races_dropped_json_carries_kind_tag() {
+        let payload = NotificationPayload::PendingRacesDropped {
+            session_id: SessionId::new_v4(),
+            dropped_count: 2,
+        };
+        let value: serde_json::Value = serde_json::to_value(&payload).expect("serialize to value");
+        assert_eq!(value["kind"], "pending_races_dropped");
+        assert_eq!(value["dropped_count"], 2);
+        assert_eq!(payload.kind_str(), "pending_races_dropped");
+    }
+
+    #[tokio::test]
+    async fn test_record_inserts_a_row_with_kind_and_payload() {
+        let db = setup_db().await;
+        let user = create_user(&db, "user").await;
+        let session_id = SessionId::new_v4();
+
+        record(
+            &db,
+            &user,
+            &NotificationPayload::PendingRacesDropped {
+                session_id,
+                dropped_count: 4,
+            },
+        )
+        .await
+        .expect("record succeeds");
+
+        let rows = notifications::Entity::find()
+            .filter(notifications::Column::UserId.eq(user))
+            .all(&db)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind, "pending_races_dropped");
+        assert!(rows[0].read_at.is_none(), "fresh notification is unread");
+
+        let stored: NotificationPayload = serde_json::from_str(&rows[0].payload).unwrap();
+        assert_eq!(
+            stored,
+            NotificationPayload::PendingRacesDropped {
+                session_id,
+                dropped_count: 4,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_returns_unread_newest_first() {
+        let db = setup_db().await;
+        let user = create_user(&db, "user").await;
+
+        // Three notifications; insert order is the chronological order.
+        for n in 1..=3u32 {
+            record(
+                &db,
+                &user,
+                &NotificationPayload::PendingRacesDropped {
+                    session_id: SessionId::new_v4(),
+                    dropped_count: n,
+                },
+            )
+            .await
+            .unwrap();
+            // `created_at` is millisecond-resolution; nudge so ordering is
+            // unambiguous rather than relying on the `id` tie-break.
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+
+        let list = list_notifications(&db, &user, false).await.unwrap();
+        assert_eq!(list.len(), 3);
+        let counts: Vec<u32> = list
+            .iter()
+            .map(|n| match n.payload {
+                NotificationPayload::PendingRacesDropped { dropped_count, .. } => dropped_count,
+            })
+            .collect();
+        assert_eq!(counts, vec![3, 2, 1], "newest first");
+    }
+
+    #[tokio::test]
+    async fn test_list_excludes_read_unless_include_read() {
+        let db = setup_db().await;
+        let user = create_user(&db, "user").await;
+        record(
+            &db,
+            &user,
+            &NotificationPayload::PendingRacesDropped {
+                session_id: SessionId::new_v4(),
+                dropped_count: 1,
+            },
+        )
+        .await
+        .unwrap();
+
+        mark_all_read(&db, &user).await.unwrap();
+
+        let unread_only = list_notifications(&db, &user, false).await.unwrap();
+        assert!(unread_only.is_empty(), "read rows excluded by default");
+
+        let all = list_notifications(&db, &user, true).await.unwrap();
+        assert_eq!(all.len(), 1, "include_read returns read rows");
+        assert!(all[0].read_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_unread_count_tracks_unread_rows() {
+        let db = setup_db().await;
+        let user = create_user(&db, "user").await;
+        assert_eq!(unread_count(&db, &user).await.unwrap(), 0);
+
+        for _ in 0..2 {
+            record(
+                &db,
+                &user,
+                &NotificationPayload::PendingRacesDropped {
+                    session_id: SessionId::new_v4(),
+                    dropped_count: 1,
+                },
+            )
+            .await
+            .unwrap();
+        }
+        assert_eq!(unread_count(&db, &user).await.unwrap(), 2);
+
+        mark_all_read(&db, &user).await.unwrap();
+        assert_eq!(unread_count(&db, &user).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mark_all_read_does_not_bleed_across_users() {
+        let db = setup_db().await;
+        let alice = create_user(&db, "alice").await;
+        let bob = create_user(&db, "bob").await;
+        for user in [&alice, &bob] {
+            record(
+                &db,
+                user,
+                &NotificationPayload::PendingRacesDropped {
+                    session_id: SessionId::new_v4(),
+                    dropped_count: 1,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let flipped = mark_all_read(&db, &alice).await.unwrap();
+        assert_eq!(flipped, 1, "only alice's row flips");
+        assert_eq!(unread_count(&db, &alice).await.unwrap(), 0);
+        assert_eq!(
+            unread_count(&db, &bob).await.unwrap(),
+            1,
+            "bob's inbox is untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_pending_drops_writes_expected_payload() {
+        let db = setup_db().await;
+        let user = create_user(&db, "user").await;
+        let session_id = SessionId::new_v4();
+
+        record_pending_drops(&db, &user, &session_id, 5)
+            .await
+            .expect("record_pending_drops succeeds");
+
+        let list = list_notifications(&db, &user, false).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(
+            list[0].payload,
+            NotificationPayload::PendingRacesDropped {
+                session_id,
+                dropped_count: 5,
+            }
+        );
+    }
+}

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -469,88 +469,104 @@ struct PendingDropRow {
     dropped_count: i64,
 }
 
-/// Drop every unresolved pending race in a closing session and notify the
-/// affected users (ADR-0037).
+/// The "unresolved pending race" predicate, shared verbatim by the count
+/// query and the drop `UPDATE` inside [`close_session`].
 ///
-/// A pending race is *unresolved* for `(race, user)` when a
-/// `session_race_participations` row exists with `skipped_at IS NULL`,
-/// `dropped_at IS NULL`, and no `runs` row for that pair. Each such row gets
-/// `dropped_at` stamped; each affected user gets one `PendingRacesDropped`
-/// notification (ADR-0038) carrying their drop count.
+/// A `(race, user)` participation row is *unresolved pending* when it has no
+/// `skipped_at`, no `dropped_at`, and no `runs` row. The count query (which
+/// sizes each notification's `dropped_count`) and the UPDATE (which actually
+/// stamps `dropped_at`) must agree on this *exactly* — if they drift, a
+/// notification's count silently mismatches the rows stamped. Lifting it to a
+/// single `const` makes drift impossible. Written with the
+/// `session_race_participations` table named in full (no alias) so it is
+/// valid both inside the aliased SELECT and inside the UPDATE, whose target
+/// table cannot be aliased.
+const UNRESOLVED_PENDING_PREDICATE: &str = "
+        session_race_participations.skipped_at IS NULL
+    AND session_race_participations.dropped_at IS NULL
+    AND NOT EXISTS (
+        SELECT 1 FROM runs r
+        WHERE r.session_race_id = session_race_participations.session_race_id
+          AND r.user_id = session_race_participations.user_id
+    )";
+
+/// Close a session: drop its unresolved pending races, notify the affected
+/// users, then flip `status` to `Closed` — in that order, on `txn`.
 ///
-/// `skipped` and `raced` rows are deliberately untouched — skip and submit
-/// both beat drop, so the four-state status enum stays mutually exclusive.
+/// **This is the single choke-point for closing a session.** Every path that
+/// closes a session — `leave_session`'s last-leave branch and
+/// `close_stale_sessions` — goes through here, so the ADR-0037 invariant —
+/// *every unresolved pending row is stamped `dropped_at` before the session's
+/// status flips* — is structural, not convention. `get_pending_races` depends
+/// on it: it carries no `sessions.status` filter, so a session flipped to
+/// `closed` without its pending rows dropped would resurface phantom pending
+/// races. Any future close path must call this rather than flipping `status`
+/// itself.
 ///
-/// **Caller contract:** must run inside the session-close transaction, before
-/// `sessions.status` is flipped. If the drop UPDATE or any notification INSERT
-/// fails, the whole close rolls back — drops are atomic with the close
-/// (ADR-0037 / ADR-0038 § Atomicity).
+/// An *unresolved pending* `(race, user)` row (see
+/// [`UNRESOLVED_PENDING_PREDICATE`]) gets `dropped_at` stamped; each affected
+/// user gets one `PendingRacesDropped` notification (ADR-0038) carrying their
+/// drop count. `skipped` and `raced` rows are deliberately untouched — skip
+/// and submit both beat drop, so the four-state status enum stays mutually
+/// exclusive.
+///
+/// **Caller contract:** must run inside a transaction. The drop UPDATE, the
+/// notification INSERTs, and the status flip are atomic with each other and
+/// with the caller's other writes — if any step fails, the whole close rolls
+/// back (ADR-0037 / ADR-0038 § Atomicity).
 ///
 /// # Errors
 ///
 /// Returns `Internal` for unexpected DB failures on the count query, the drop
-/// UPDATE, or any notification INSERT.
+/// UPDATE, any notification INSERT, or the status UPDATE.
 #[tracing::instrument(skip(txn), fields(session_id = %session_id))]
-async fn close_session_and_drop_pending(
-    txn: &impl ConnectionTrait,
-    session_id: &SessionId,
-) -> Result<(), Error> {
+async fn close_session(txn: &impl ConnectionTrait, session_id: &SessionId) -> Result<(), Error> {
     let now = Utc::now().naive_utc();
 
     // Per-user count of rows about to be dropped — captured before the UPDATE
     // so each notification payload carries an accurate `dropped_count`. The
     // `NOT EXISTS` correlation is clumsy in the builder API, so this is
     // hand-rolled SQL (`seaorm.md` § 1).
+    let count_sql = format!(
+        "SELECT session_race_participations.user_id AS user_id,
+                COUNT(*) AS dropped_count
+         FROM session_race_participations
+         JOIN session_races sr
+           ON session_race_participations.session_race_id = sr.id
+         WHERE sr.session_id = $1
+           AND {UNRESOLVED_PENDING_PREDICATE}
+         GROUP BY session_race_participations.user_id"
+    );
     let drops: Vec<PendingDropRow> = db_query(
         PendingDropRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
             txn.get_database_backend(),
-            r#"
-            SELECT srp.user_id AS user_id, COUNT(*) AS dropped_count
-            FROM session_race_participations srp
-            JOIN session_races sr ON srp.session_race_id = sr.id
-            WHERE sr.session_id = $1
-              AND srp.skipped_at IS NULL
-              AND srp.dropped_at IS NULL
-              AND NOT EXISTS (
-                  SELECT 1 FROM runs r
-                  WHERE r.session_race_id = srp.session_race_id
-                    AND r.user_id = srp.user_id
-              )
-            GROUP BY srp.user_id
-            "#,
+            &count_sql,
             [session_id.into()],
         ))
         .all(txn),
     )
     .await?;
 
-    if drops.is_empty() {
-        // Nothing unresolved — a session can close with every race already
-        // raced or skipped. No drops, no notifications.
-        return Ok(());
-    }
-
     // Stamp `dropped_at` on every unresolved pending row in this session, in
-    // one set-based UPDATE. The predicate matches the count query above.
-    db_query(txn.execute(sea_orm::Statement::from_sql_and_values(
-        txn.get_database_backend(),
-        r#"
-        UPDATE session_race_participations
-        SET dropped_at = $2
-        WHERE session_race_id IN (
-                  SELECT id FROM session_races WHERE session_id = $1
-              )
-          AND skipped_at IS NULL
-          AND dropped_at IS NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM runs r
-              WHERE r.session_race_id = session_race_participations.session_race_id
-                AND r.user_id = session_race_participations.user_id
-          )
-        "#,
-        [session_id.into(), now.into()],
-    )))
-    .await?;
+    // one set-based UPDATE. The predicate is the same `const` the count query
+    // used, so the two cannot drift. Skipped when there's nothing to drop —
+    // a session can close with every race already raced or skipped.
+    if !drops.is_empty() {
+        let drop_sql = format!(
+            "UPDATE session_race_participations
+             SET dropped_at = $2
+             WHERE session_race_id IN (
+                       SELECT id FROM session_races WHERE session_id = $1
+                   )
+               AND {UNRESOLVED_PENDING_PREDICATE}"
+        );
+        db_query(txn.execute(sea_orm::Statement::from_sql_and_values(
+            txn.get_database_backend(),
+            &drop_sql,
+            [session_id.into(), now.into()],
+        )))
+        .await?;
+    }
 
     // One notification per affected user (ADR-0038 consumer trigger).
     for drop in drops {
@@ -563,6 +579,15 @@ async fn close_session_and_drop_pending(
         })?;
         notifications::record_pending_drops(txn, &user_id, session_id, dropped_count).await?;
     }
+
+    // Flip status last — the drops above are guaranteed to have landed.
+    db_query(
+        sessions::Entity::update_many()
+            .col_expr(sessions::Column::Status, Expr::value(SessionStatus::Closed))
+            .filter(sessions::Column::Id.eq(session_id))
+            .exec(txn),
+    )
+    .await?;
 
     Ok(())
 }
@@ -615,12 +640,9 @@ pub async fn leave_session(
             db_query(active_session.update(&txn)).await?;
         }
         HostDisposition::SessionClosed => {
-            // Drop unresolved pending races + notify affected users before
-            // flipping status — same transaction (ADR-0037).
-            close_session_and_drop_pending(&txn, session_id).await?;
-            let mut active_session: sessions::ActiveModel = session.into();
-            active_session.status = Set(SessionStatus::Closed);
-            db_query(active_session.update(&txn)).await?;
+            // Single choke-point: drop unresolved pending races, notify the
+            // affected users, then flip status — all on this transaction.
+            close_session(&txn, session_id).await?;
         }
         HostDisposition::NoChange => {}
     }
@@ -653,17 +675,16 @@ struct StaleSessionRow {
 /// session inline via `leave_session`; this handles the abandoned case
 /// (phones died, tabs closed without a Leave tap).
 ///
-/// For each closing session it drops every unresolved pending race
-/// (`dropped_at` stamped) and records a `PendingRacesDropped` notification per
-/// affected user — see [`close_session_and_drop_pending`]. It also marks all
-/// remaining active participants as left. Returns the number of sessions
-/// closed.
+/// It marks all remaining active participants as left, then closes each stale
+/// session through the [`close_session`] choke-point — dropping its unresolved
+/// pending races and recording a `PendingRacesDropped` notification per
+/// affected user. Returns the number of sessions closed.
 ///
-/// The cleanup runs in one transaction (`seaorm.md` § 1): a per-session drop
-/// step (see [`close_session_and_drop_pending`]), then two set-based `UPDATE`s
-/// — one to settle still-active participants, one to flip the session rows to
-/// `Closed`. The list of stale ids is fetched once up front so every step
-/// scopes to the same set without re-querying.
+/// The cleanup runs in one transaction (`seaorm.md` § 1): one set-based
+/// `UPDATE` to settle still-active participants, then a per-session
+/// [`close_session`] call (drop → notify → status flip) for each stale id.
+/// The list of stale ids is fetched once up front so every step scopes to the
+/// same set without re-querying.
 ///
 /// # Errors
 ///
@@ -678,9 +699,9 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
 
     // Capture the stale ids once. The `NOT EXISTS` subqueries are awkward in
     // the builder API, so this read is hand-rolled SQL (`seaorm.md` § 1 — raw
-    // SQL for clumsy multi-table shapes). Both `UPDATE`s below scope to the
-    // captured set, and the empty-set case short-circuits cleanly (the common
-    // case).
+    // SQL for clumsy multi-table shapes). The participant `UPDATE` and the
+    // per-session `close_session` calls below all scope to the captured set,
+    // and the empty-set case short-circuits cleanly (the common case).
     //
     // The predicate enumerates every meaningful activity signal a session can
     // produce (ADR-0037): a new race, a submitted run, a join or leave, or a
@@ -734,14 +755,8 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
         return Ok(0);
     }
 
-    // Drop each closing session's unresolved pending races and notify the
-    // affected users, before the batch status flip (ADR-0037 / ADR-0038).
-    for id in &stale_ids {
-        let session_id = SessionId::from_db(id)?;
-        close_session_and_drop_pending(&txn, &session_id).await?;
-    }
-
-    // Mark all still-active participants of the stale sessions as left.
+    // Mark all still-active participants of the stale sessions as left, in
+    // one set-based UPDATE (seaorm.md § 1).
     db_query(
         session_participants::Entity::update_many()
             .col_expr(session_participants::Column::LeftAt, Expr::value(now))
@@ -754,19 +769,16 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
     )
     .await?;
 
-    // Close the stale sessions in one statement (seaorm.md § 1 — the
-    // exemplar for the set-based-update rule names this exact cleanup).
-    let result = db_query(
-        sessions::Entity::update_many()
-            .col_expr(sessions::Column::Status, Expr::value(SessionStatus::Closed))
-            .filter(sessions::Column::Id.is_in(stale_ids))
-            .exec(&txn),
-    )
-    .await?;
+    // Close each stale session through the single choke-point — drop pending
+    // races, notify the affected users, flip status. Per-session (not a batch
+    // status UPDATE) so the drop-before-flip invariant holds for every one.
+    for id in &stale_ids {
+        close_session(&txn, &SessionId::from_db(id)?).await?;
+    }
 
     db_txn(txn.commit()).await?;
 
-    Ok(result.rows_affected)
+    Ok(stale_ids.len() as u64)
 }
 
 #[cfg(test)]

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     entities::{session_participants, sessions},
     error::Error,
-    services::helpers,
+    services::{helpers, notifications},
     timeout::{db_query, db_txn},
 };
 
@@ -308,8 +308,8 @@ pub async fn list_active_sessions(db: &impl ConnectionTrait) -> Result<Vec<Sessi
 /// (ADR-0035). `joined_at` is therefore monotonic — set once on first join,
 /// it genuinely means "when this user first joined this session." Pending-race
 /// access no longer depends on it: a flaked-out user's pending races stay
-/// pending until each race expires on its own 1-hour clock, regardless of how
-/// long they were gone.
+/// pending for as long as the session is alive (ADR-0037), regardless of how
+/// long they were gone — they rejoin to act on them.
 ///
 /// # Errors
 ///
@@ -462,6 +462,111 @@ async fn transfer_host_or_close(
     }
 }
 
+/// Row shape for the per-user pending-drop count query.
+#[derive(Debug, FromQueryResult)]
+struct PendingDropRow {
+    user_id: String,
+    dropped_count: i64,
+}
+
+/// Drop every unresolved pending race in a closing session and notify the
+/// affected users (ADR-0037).
+///
+/// A pending race is *unresolved* for `(race, user)` when a
+/// `session_race_participations` row exists with `skipped_at IS NULL`,
+/// `dropped_at IS NULL`, and no `runs` row for that pair. Each such row gets
+/// `dropped_at` stamped; each affected user gets one `PendingRacesDropped`
+/// notification (ADR-0038) carrying their drop count.
+///
+/// `skipped` and `raced` rows are deliberately untouched — skip and submit
+/// both beat drop, so the four-state status enum stays mutually exclusive.
+///
+/// **Caller contract:** must run inside the session-close transaction, before
+/// `sessions.status` is flipped. If the drop UPDATE or any notification INSERT
+/// fails, the whole close rolls back — drops are atomic with the close
+/// (ADR-0037 / ADR-0038 § Atomicity).
+///
+/// # Errors
+///
+/// Returns `Internal` for unexpected DB failures on the count query, the drop
+/// UPDATE, or any notification INSERT.
+#[tracing::instrument(skip(txn), fields(session_id = %session_id))]
+async fn close_session_and_drop_pending(
+    txn: &impl ConnectionTrait,
+    session_id: &SessionId,
+) -> Result<(), Error> {
+    let now = Utc::now().naive_utc();
+
+    // Per-user count of rows about to be dropped — captured before the UPDATE
+    // so each notification payload carries an accurate `dropped_count`. The
+    // `NOT EXISTS` correlation is clumsy in the builder API, so this is
+    // hand-rolled SQL (`seaorm.md` § 1).
+    let drops: Vec<PendingDropRow> = db_query(
+        PendingDropRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
+            txn.get_database_backend(),
+            r#"
+            SELECT srp.user_id AS user_id, COUNT(*) AS dropped_count
+            FROM session_race_participations srp
+            JOIN session_races sr ON srp.session_race_id = sr.id
+            WHERE sr.session_id = $1
+              AND srp.skipped_at IS NULL
+              AND srp.dropped_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM runs r
+                  WHERE r.session_race_id = srp.session_race_id
+                    AND r.user_id = srp.user_id
+              )
+            GROUP BY srp.user_id
+            "#,
+            [session_id.into()],
+        ))
+        .all(txn),
+    )
+    .await?;
+
+    if drops.is_empty() {
+        // Nothing unresolved — a session can close with every race already
+        // raced or skipped. No drops, no notifications.
+        return Ok(());
+    }
+
+    // Stamp `dropped_at` on every unresolved pending row in this session, in
+    // one set-based UPDATE. The predicate matches the count query above.
+    db_query(txn.execute(sea_orm::Statement::from_sql_and_values(
+        txn.get_database_backend(),
+        r#"
+        UPDATE session_race_participations
+        SET dropped_at = $2
+        WHERE session_race_id IN (
+                  SELECT id FROM session_races WHERE session_id = $1
+              )
+          AND skipped_at IS NULL
+          AND dropped_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM runs r
+              WHERE r.session_race_id = session_race_participations.session_race_id
+                AND r.user_id = session_race_participations.user_id
+          )
+        "#,
+        [session_id.into(), now.into()],
+    )))
+    .await?;
+
+    // One notification per affected user (ADR-0038 consumer trigger).
+    for drop in drops {
+        let user_id = UserId::from_db(&drop.user_id)?;
+        let dropped_count = u32::try_from(drop.dropped_count).map_err(|_| {
+            Error::Internal(anyhow::anyhow!(
+                "dropped_count {} does not fit in u32",
+                drop.dropped_count
+            ))
+        })?;
+        notifications::record_pending_drops(txn, &user_id, session_id, dropped_count).await?;
+    }
+
+    Ok(())
+}
+
 /// Leave a session. Sets `left_at` and handles host transfer.
 ///
 /// # Errors
@@ -510,6 +615,9 @@ pub async fn leave_session(
             db_query(active_session.update(&txn)).await?;
         }
         HostDisposition::SessionClosed => {
+            // Drop unresolved pending races + notify affected users before
+            // flipping status — same transaction (ADR-0037).
+            close_session_and_drop_pending(&txn, session_id).await?;
             let mut active_session: sessions::ActiveModel = session.into();
             active_session.status = Set(SessionStatus::Closed);
             db_query(active_session.update(&txn)).await?;
@@ -528,29 +636,34 @@ struct StaleSessionRow {
     id: String,
 }
 
-/// Close sessions whose race window has fully elapsed (ADR-0035).
+/// Close sessions whose activity window has fully elapsed (ADR-0035, ADR-0037).
 ///
 /// A session is *stale* when it is `status = 'active'`, was created more than
-/// [`RACE_WINDOW_HOURS`] ago, **and** has no `session_races` row created
-/// within that same window. The `created_at` clause handles the bootstrap
-/// case: a brand-new session with no race chosen yet keeps its first hour
-/// from its own creation timestamp before it can go stale.
+/// [`RACE_WINDOW_HOURS`] ago, **and** has had no meaningful activity within
+/// that same window — no new race, no submitted run, no join or leave, no
+/// skipped pending race (the five-signal predicate from ADR-0037). The
+/// `created_at` clause handles the bootstrap case: a brand-new session with
+/// no race chosen yet keeps its first hour from its own creation timestamp
+/// before it can go stale.
 ///
-/// This is purely DB hygiene. Clean exits already close their session inline
-/// via `leave_session`; every user-facing read path derives liveness from
-/// race timestamps directly (see [`get_active_session_id`] and
-/// `get_pending_races`), so no read depends on this sweep having run recently.
-/// The sweep only keeps `sessions.status` eventually consistent with that
-/// derived truth.
+/// Since ADR-0037 removed the per-race timer from `get_pending_races`, this
+/// sweep is the sole gatekeeper for closing dormant sessions — a pending race
+/// stays submittable for as long as the session is alive, and the session is
+/// alive until this predicate says otherwise. Clean exits still close their
+/// session inline via `leave_session`; this handles the abandoned case
+/// (phones died, tabs closed without a Leave tap).
 ///
-/// Also marks all remaining active participants of the closed sessions as
-/// left. Returns the number of sessions closed.
+/// For each closing session it drops every unresolved pending race
+/// (`dropped_at` stamped) and records a `PendingRacesDropped` notification per
+/// affected user — see [`close_session_and_drop_pending`]. It also marks all
+/// remaining active participants as left. Returns the number of sessions
+/// closed.
 ///
-/// The cleanup runs as two set-based `UPDATE`s in one transaction
-/// (`seaorm.md` § 1) — one to flip the matching session rows to
-/// `Closed`, one to settle their still-active participants. The list
-/// of stale ids is fetched once up front so both `UPDATE`s can scope
-/// to the same set without re-querying.
+/// The cleanup runs in one transaction (`seaorm.md` § 1): a per-session drop
+/// step (see [`close_session_and_drop_pending`]), then two set-based `UPDATE`s
+/// — one to settle still-active participants, one to flip the session rows to
+/// `Closed`. The list of stale ids is fetched once up front so every step
+/// scopes to the same set without re-querying.
 ///
 /// # Errors
 ///
@@ -563,11 +676,19 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
 
     let txn = db_txn(db.begin()).await?;
 
-    // Capture the stale ids once. The `NOT EXISTS` subquery against
-    // `session_races` is awkward in the builder API, so this read is
-    // hand-rolled SQL (`seaorm.md` § 1 — raw SQL for clumsy multi-table
-    // shapes). Both `UPDATE`s below scope to the captured set, and the
-    // empty-set case short-circuits cleanly (the common case).
+    // Capture the stale ids once. The `NOT EXISTS` subqueries are awkward in
+    // the builder API, so this read is hand-rolled SQL (`seaorm.md` § 1 — raw
+    // SQL for clumsy multi-table shapes). Both `UPDATE`s below scope to the
+    // captured set, and the empty-set case short-circuits cleanly (the common
+    // case).
+    //
+    // The predicate enumerates every meaningful activity signal a session can
+    // produce (ADR-0037): a new race, a submitted run, a join or leave, or a
+    // skipped pending race within the window all keep the session alive. With
+    // the per-race timer gone from `get_pending_races`, the sweeper is the
+    // sole gatekeeper for closing dormant sessions, so it honors all of them.
+    // Kept in lockstep with the ETag formula in `api-contract.md` § 4 — the
+    // two share a maintenance contract.
     let stale_ids: Vec<String> = db_query(
         StaleSessionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
             txn.get_database_backend(),
@@ -580,6 +701,23 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
                   SELECT 1 FROM session_races sr
                   WHERE sr.session_id = s.id
                     AND sr.created_at >= $1
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM runs r
+                  JOIN session_races sr ON r.session_race_id = sr.id
+                  WHERE sr.session_id = s.id
+                    AND r.created_at >= $1
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM session_participants sp
+                  WHERE sp.session_id = s.id
+                    AND (sp.joined_at >= $1 OR sp.left_at >= $1)
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM session_race_participations srp
+                  JOIN session_races sr ON srp.session_race_id = sr.id
+                  WHERE sr.session_id = s.id
+                    AND srp.skipped_at >= $1
               )
             "#,
             [window_start.into()],
@@ -594,6 +732,13 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
     if stale_ids.is_empty() {
         db_txn(txn.commit()).await?;
         return Ok(0);
+    }
+
+    // Drop each closing session's unresolved pending races and notify the
+    // affected users, before the batch status flip (ADR-0037 / ADR-0038).
+    for id in &stale_ids {
+        let session_id = SessionId::from_db(id)?;
+        close_session_and_drop_pending(&txn, &session_id).await?;
     }
 
     // Mark all still-active participants of the stale sessions as left.
@@ -627,9 +772,15 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{
-        backdate_session, create_user, insert_participant, insert_session, insert_session_race,
-        setup_db,
+    use crate::{
+        domain::SessionRaceId,
+        entities::{notifications as notifications_entity, session_race_participations},
+        services::sessions::{next_track, skip_pending_race},
+        test_helpers::{
+            backdate_participant, backdate_session, create_user, insert_participant,
+            insert_race_participation, insert_run, insert_session, insert_session_race,
+            seed_game_data, seed_tracks_for_test, setup_db,
+        },
     };
 
     // ── transfer_host_or_close ───────────────────────────────────────
@@ -963,16 +1114,17 @@ mod tests {
         let host_id = create_user(&db, "host").await;
         let user_id = create_user(&db, "user").await;
 
-        // A session created over an hour ago with no races is stale.
+        // A session created over an hour ago with no races and no recent
+        // join/leave/run/skip is stale.
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
         let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
         insert_participant(&db, &session_id, &user_id, None).await;
-        backdate_session(
-            &db,
-            &session_id,
-            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
-        )
-        .await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        // Backdate the joins too — a join within the window would itself keep
+        // the session alive under the ADR-0037 activity predicate.
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
+        backdate_participant(&db, &session_id, &user_id, Some(two_hours_ago), None).await;
 
         let closed = close_stale_sessions(&db).await.unwrap();
         assert_eq!(closed, 1, "the stale session is closed");
@@ -1019,14 +1171,11 @@ mod tests {
         // stale — the bootstrap window has elapsed.
         let db = setup_db().await;
         let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
         let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
-        backdate_session(
-            &db,
-            &session_id,
-            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
-        )
-        .await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
 
         let closed = close_stale_sessions(&db).await.unwrap();
         assert_eq!(closed, 1);
@@ -1043,14 +1192,13 @@ mod tests {
         let db = setup_db().await;
         crate::test_helpers::seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
         let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
-        backdate_session(
-            &db,
-            &session_id,
-            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
-        )
-        .await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        // Backdate the join so the recent race is the *only* live signal —
+        // isolates the race clause of the activity predicate.
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
         // A race created just now — well inside the window.
         insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
 
@@ -1069,14 +1217,11 @@ mod tests {
         let db = setup_db().await;
         crate::test_helpers::seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
+        let three_hours_ago = (Utc::now() - chrono::Duration::hours(3)).naive_utc();
         let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
-        backdate_session(
-            &db,
-            &session_id,
-            (Utc::now() - chrono::Duration::hours(3)).naive_utc(),
-        )
-        .await;
+        backdate_session(&db, &session_id, three_hours_ago).await;
+        backdate_participant(&db, &session_id, &host_id, Some(three_hours_ago), None).await;
         insert_session_race(
             &db,
             &session_id,
@@ -1181,5 +1326,292 @@ mod tests {
                 .is_some(),
             "the dangling row in the stale session is settled"
         );
+    }
+
+    // ── Extended sweeper predicate: per-signal liveness (ADR-0037) ───────
+    //
+    // Each test backdates the session past the window and isolates one
+    // activity signal within the window, asserting the session stays alive.
+    // The all-signals-stale case is `test_stale_cleanup_marks_participants_as_left`.
+
+    #[tokio::test]
+    async fn test_close_stale_keeps_session_with_recent_run() {
+        // A run submitted within the window keeps the session alive even
+        // though the session and its race are both older than the window.
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, two_hours_ago).await;
+        // Run created just now — well inside the window.
+        insert_run(&db, &race_id, &host_id, 1).await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "a recent run keeps the session alive");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_stale_keeps_session_with_recent_join() {
+        // A participant who joined within the window keeps the session alive.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        backdate_session(
+            &db,
+            &session_id,
+            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
+        )
+        .await;
+        // `insert_participant` stamps `joined_at = now` — a recent join.
+        insert_participant(&db, &session_id, &host_id, None).await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "a recent join keeps the session alive");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_stale_keeps_session_with_recent_leave() {
+        // A participant who left within the window keeps the session alive —
+        // a recent leave is still recent activity.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        // Joined long ago, left just now.
+        backdate_participant(
+            &db,
+            &session_id,
+            &host_id,
+            Some(two_hours_ago),
+            Some(Utc::now().naive_utc()),
+        )
+        .await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "a recent leave keeps the session alive");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_stale_keeps_session_with_recent_skip() {
+        // A pending race skipped within the window keeps the session alive.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, two_hours_ago).await;
+        // Participation skipped just now — the skip is the only live signal.
+        insert_race_participation(&db, &race_id, &host_id, Some(Utc::now().naive_utc())).await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 0, "a recent skip keeps the session alive");
+        assert_eq!(
+            session_status(&db, &session_id).await,
+            SessionStatus::Active
+        );
+    }
+
+    // ── Drop-on-close + notification trigger (ADR-0037 / ADR-0038) ───────
+
+    /// Fetch a (race, user) participation row.
+    async fn participation_row(
+        db: &DatabaseConnection,
+        session_race_id: &SessionRaceId,
+        user_id: &UserId,
+    ) -> session_race_participations::Model {
+        session_race_participations::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(session_race_participations::Column::SessionRaceId.eq(session_race_id))
+                    .add(session_race_participations::Column::UserId.eq(user_id)),
+            )
+            .one(db)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    /// Fetch all of a user's notification rows.
+    async fn notification_rows(
+        db: &DatabaseConnection,
+        user_id: &UserId,
+    ) -> Vec<notifications_entity::Model> {
+        notifications_entity::Entity::find()
+            .filter(notifications_entity::Column::UserId.eq(user_id))
+            .all(db)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_leave_close_drops_unresolved_pending() {
+        // The solo host leaves with an unresolved pending race — the inline
+        // close stamps `dropped_at` on the participation row.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let row = participation_row(&db, &race.id, &host_id).await;
+        assert!(
+            row.dropped_at.is_some(),
+            "unresolved pending row is dropped"
+        );
+        assert!(row.skipped_at.is_none(), "drop does not touch skipped_at");
+    }
+
+    #[tokio::test]
+    async fn test_close_does_not_drop_skipped_rows() {
+        // A row already resolved by an explicit skip is not re-stamped as
+        // dropped — skip beats drop, the states stay mutually exclusive.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+        skip_pending_race(&db, &session.id, &race.id, &host_id)
+            .await
+            .unwrap();
+
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let row = participation_row(&db, &race.id, &host_id).await;
+        assert!(row.skipped_at.is_some(), "skipped_at preserved");
+        assert!(
+            row.dropped_at.is_none(),
+            "an already-skipped row is not dropped"
+        );
+        assert!(
+            notification_rows(&db, &host_id).await.is_empty(),
+            "a skipped-only close drops nothing, so notifies nobody"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_does_not_drop_submitted_rows() {
+        // A row resolved by a submitted run is not dropped.
+        let db = setup_db().await;
+        seed_game_data(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        let race = next_track(&db, &session.id, &host_id).await.unwrap();
+        insert_run(&db, &race.id, &host_id, race.track_id).await;
+
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        let row = participation_row(&db, &race.id, &host_id).await;
+        assert!(
+            row.dropped_at.is_none(),
+            "a submitted (raced) row is not dropped"
+        );
+        assert!(
+            notification_rows(&db, &host_id).await.is_empty(),
+            "nothing unresolved, so no drop notification"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_records_one_notification_per_affected_user() {
+        // A two-user session with two unresolved races for each user. When
+        // the last participant leaves, each user gets exactly one
+        // notification carrying their own drop count.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let user2_id = create_user(&db, "user2").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+        join_session(&db, &session.id, &user2_id).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+        next_track(&db, &session.id, &host_id).await.unwrap();
+
+        // user2 leaves first (session stays open), then host leaves (closes).
+        leave_session(&db, &session.id, &user2_id).await.unwrap();
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        for user in [&host_id, &user2_id] {
+            let rows = notification_rows(&db, user).await;
+            assert_eq!(rows.len(), 1, "exactly one notification per affected user");
+            assert_eq!(rows[0].kind, "pending_races_dropped");
+            let payload: crate::services::notifications::NotificationPayload =
+                serde_json::from_str(&rows[0].payload).unwrap();
+            assert_eq!(
+                payload,
+                crate::services::notifications::NotificationPayload::PendingRacesDropped {
+                    session_id: session.id,
+                    dropped_count: 2,
+                },
+                "payload carries the session and the per-user drop count"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_close_empty_session_records_no_notifications() {
+        // A session with no unresolved pending races (here: no races at all)
+        // closes without recording any notification.
+        let db = setup_db().await;
+        let host_id = create_user(&db, "host").await;
+        let session = create_session(&db, &host_id, "random").await.unwrap();
+
+        leave_session(&db, &session.id, &host_id).await.unwrap();
+
+        assert_eq!(
+            session_status(&db, &session.id).await,
+            SessionStatus::Closed
+        );
+        assert!(
+            notification_rows(&db, &host_id).await.is_empty(),
+            "closing an empty session notifies nobody"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sweeper_drops_pending_and_notifies() {
+        // The abandoned-session path: the stale-session sweeper closes the
+        // session, drops the unresolved pending row, and notifies the user.
+        let db = setup_db().await;
+        seed_tracks_for_test(&db).await;
+        let host_id = create_user(&db, "host").await;
+        let two_hours_ago = (Utc::now() - chrono::Duration::hours(2)).naive_utc();
+        let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
+        insert_participant(&db, &session_id, &host_id, None).await;
+        backdate_session(&db, &session_id, two_hours_ago).await;
+        backdate_participant(&db, &session_id, &host_id, Some(two_hours_ago), None).await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, two_hours_ago).await;
+        insert_race_participation(&db, &race_id, &host_id, None).await;
+
+        let closed = close_stale_sessions(&db).await.unwrap();
+        assert_eq!(closed, 1, "the abandoned session is swept closed");
+
+        let row = participation_row(&db, &race_id, &host_id).await;
+        assert!(row.dropped_at.is_some(), "sweeper drops the pending row");
+
+        let rows = notification_rows(&db, &host_id).await;
+        assert_eq!(rows.len(), 1, "sweeper records the drop notification");
+        assert_eq!(rows[0].kind, "pending_races_dropped");
     }
 }

--- a/backend/src/services/sessions/races.rs
+++ b/backend/src/services/sessions/races.rs
@@ -15,7 +15,7 @@ use sea_orm::{
     QueryOrder, Set, TransactionTrait,
 };
 
-use super::types::{RACE_WINDOW_HOURS, SessionRaceInfo};
+use super::types::SessionRaceInfo;
 use crate::{
     domain::{ImagePath, SessionId, SessionRaceId, UserId},
     entities::{cups, runs, session_race_participations, session_races},
@@ -39,30 +39,33 @@ struct PendingRaceRow {
 /// Return the requesting user's pending races within a session, oldest first.
 ///
 /// A race is **pending** for user `U` iff all of the following hold (per
-/// docs/data-model.md "Pending Race Tracking", ADR-0035):
+/// docs/data-model.md "Pending Race Tracking", ADR-0037):
 ///
 /// 1. A `session_race_participations` row exists for `(SR.id, U.id)` —
 ///    proves `U` was present when `SR` was created.
 /// 2. `skipped_at IS NULL` on that row — `U` hasn't explicitly forfeited.
 /// 3. No `runs` row exists for `(SR.id, U.id)` — `U` hasn't submitted.
-/// 4. `SR.created_at >= NOW() - RACE_WINDOW_HOURS` — the race is still inside
-///    its 1-hour submission window. Expired races drop out for everyone.
-/// 5. `sessions.status = 'active'` — closed sessions accept no further
-///    submissions, so any "pending" entries on them are phantom (the user
-///    has no API path to resolve them).
+/// 4. `dropped_at IS NULL` on that row — the session hasn't closed around it.
 ///
-/// Note this no longer consults `session_participants` at all: a user's
-/// `left_at` is irrelevant to pending access (ADR-0035). A flaked-out user
-/// keeps their pending races until each race expires on its own clock; they
-/// rejoin to act on them. The race window is the single timeout.
+/// **The session is the deadline (ADR-0037).** A pending race stays
+/// submittable for as long as the session is alive. There is no per-race
+/// timer and no `sessions.status` filter: when a session closes — via clean
+/// last-leave or via the sweeper — the close transaction stamps `dropped_at`
+/// on every unresolved row, so clause 4 alone captures "the session is over."
+/// A race created four hours ago in a still-active session is still pending.
 ///
-/// Returns empty if the user is not a participant, all races are submitted /
-/// skipped / expired, or the session is closed.
+/// This no longer consults `session_participants`: a user's `left_at` is
+/// irrelevant to pending access (ADR-0035). A flaked-out user keeps their
+/// pending races until the session closes; they rejoin to act on them.
 ///
-/// **Lazy check note:** The expiry predicate is computed at query time from
-/// `NOW()` and stored timestamps. No background task touches
-/// `session_race_participations` rows — they remain in the DB for history
-/// regardless of accessibility.
+/// Returns empty if the user is not a participant, or all races are
+/// submitted / skipped / dropped.
+///
+/// **Lazy check note:** pending accessibility is a read-time derivation from
+/// `(session_race_participations, session_races, runs)`. The only writer of
+/// `dropped_at` is the session-close transaction (ADR-0037); no periodic
+/// task ages a row out on its own clock. Resolved rows (`skipped`, `raced`,
+/// `dropped`) remain in the DB indefinitely as historical state.
 ///
 /// **`submissions` is intentionally empty.** Pending races report only the
 /// race shell here; per-race submissions belong to the current/history views,
@@ -81,8 +84,6 @@ pub async fn get_pending_races(
     session_id: &SessionId,
     user_id: &UserId,
 ) -> Result<Vec<SessionRaceInfo>, Error> {
-    let window_start = (Utc::now() - chrono::Duration::hours(RACE_WINDOW_HOURS)).naive_utc();
-
     let rows = db_query(
         PendingRaceRow::find_by_statement(sea_orm::Statement::from_sql_and_values(
             db.get_database_backend(),
@@ -92,21 +93,19 @@ pub async fn get_pending_races(
                t.image_path, sr.created_at
         FROM session_race_participations srp
         JOIN session_races sr ON srp.session_race_id = sr.id
-        JOIN sessions s ON s.id = sr.session_id
         JOIN tracks t ON sr.track_id = t.id
         JOIN cups c ON t.cup_id = c.id
         WHERE sr.session_id = $1
           AND srp.user_id = $2
-          AND s.status = 'active'
           AND srp.skipped_at IS NULL
-          AND sr.created_at >= $3
+          AND srp.dropped_at IS NULL
           AND NOT EXISTS (
               SELECT 1 FROM runs r
               WHERE r.session_race_id = sr.id AND r.user_id = srp.user_id
           )
         ORDER BY sr.race_number ASC
         "#,
-            [session_id.into(), user_id.into(), window_start.into()],
+            [session_id.into(), user_id.into()],
         ))
         .all(db),
     )
@@ -739,6 +738,7 @@ mod tests {
             user_id: Set("ghost".to_string()),
             created_at: NotSet,
             skipped_at: Set(None),
+            dropped_at: Set(None),
         }
         .insert(&txn)
         .await;
@@ -909,7 +909,7 @@ mod tests {
         assert_eq!(pending.len(), 5, "API returns all; UI applies the cap");
     }
 
-    // ── Per-race expiry + session-status filter (ADR-0035) ───────────────
+    // ── Session-is-the-deadline pending derivation (ADR-0037) ────────────
 
     #[tokio::test]
     async fn test_pending_accessible_when_currently_in_session() {
@@ -924,8 +924,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pending_includes_race_within_window() {
-        // A race created well inside the 1-hour window is still pending.
+    async fn test_pending_includes_old_race_in_active_session() {
+        // The session is the deadline (ADR-0037): a race created four hours
+        // ago is still pending as long as the session is active and the
+        // participation row has not been dropped. There is no per-race timer.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
@@ -936,38 +938,47 @@ mod tests {
             &session_id,
             1,
             1,
-            (Utc::now() - chrono::Duration::minutes(30)).naive_utc(),
+            (Utc::now() - chrono::Duration::hours(4)).naive_utc(),
         )
         .await;
         insert_race_participation(&db, &race_id, &host_id, None).await;
 
         let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
-        assert_eq!(pending.len(), 1, "race within the window stays pending");
+        assert_eq!(
+            pending.len(),
+            1,
+            "a 4-hour-old race in an active session is still pending"
+        );
     }
 
     #[tokio::test]
-    async fn test_pending_excludes_expired_race() {
-        // A race created over an hour ago has expired — it drops out of the
-        // pending list even though the participation row is unresolved.
+    async fn test_pending_excludes_dropped_race() {
+        // A race whose participation row has `dropped_at` set (the session
+        // closed around it, ADR-0037) drops out of the pending list even
+        // though it was never skipped or submitted.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;
         let session_id = insert_session(&db, &host_id, SessionStatus::Active).await;
         insert_participant(&db, &session_id, &host_id, None).await;
-        let race_id = insert_session_race(
-            &db,
-            &session_id,
-            1,
-            1,
-            (Utc::now() - chrono::Duration::hours(2)).naive_utc(),
-        )
-        .await;
+        let race_id = insert_session_race(&db, &session_id, 1, 1, Utc::now().naive_utc()).await;
         insert_race_participation(&db, &race_id, &host_id, None).await;
 
-        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
-        assert!(pending.is_empty(), "expired race drops from pending");
+        // Stamp `dropped_at` directly to isolate the query's clause 4.
+        let row = session_race_participations::Entity::find()
+            .filter(session_race_participations::Column::SessionRaceId.eq(race_id))
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut active: session_race_participations::ActiveModel = row.into();
+        active.dropped_at = Set(Some(Utc::now().naive_utc()));
+        active.update(&db).await.unwrap();
 
-        // The participation row itself stays for history (lazy check).
+        let pending = get_pending_races(&db, &session_id, &host_id).await.unwrap();
+        assert!(pending.is_empty(), "dropped race drops from pending");
+
+        // The participation row itself stays for history.
         let count = session_race_participations::Entity::find()
             .filter(session_race_participations::Column::UserId.eq(host_id))
             .count(&db)
@@ -1000,11 +1011,13 @@ mod tests {
         );
     }
 
-    /// Documents intent: no background timer or sweeper task touches
-    /// `session_race_participations`. Pending accessibility is a pure read-time
-    /// derivation from `(session_race_participations, session_races, runs)`
-    /// plus the per-race expiry clock — see `get_pending_races`. Resolved /
-    /// expired rows remain in the DB indefinitely as historical state.
+    /// Documents intent: pending accessibility is a read-time derivation from
+    /// `(session_race_participations, session_races, runs)` — see
+    /// `get_pending_races`. No periodic timer ages a row out on its own
+    /// clock. The one writer of `dropped_at` is the session-close transaction
+    /// (`close_session_and_drop_pending`, ADR-0037), which runs inline on the
+    /// last leave or via the stale-session sweeper. Resolved rows (`skipped`,
+    /// `raced`, `dropped`) remain in the DB indefinitely as historical state.
     #[tokio::test]
     async fn test_lazy_check_assertion() {
         // No-op test by design — this comment IS the assertion.
@@ -1012,9 +1025,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_pending_excludes_closed_session() {
-        // A closed session can no longer accept submissions or skips, so any
-        // "pending" entries on it are phantom. `get_pending_races` must
-        // filter them out via `sessions.status = 'active'`.
+        // When a session closes, the close transaction stamps `dropped_at` on
+        // every unresolved pending row (ADR-0037). `get_pending_races` filters
+        // those out via its `dropped_at IS NULL` clause — no `sessions.status`
+        // check is needed, the drop already happened.
         let db = setup_db().await;
         seed_tracks_for_test(&db).await;
         let host_id = create_user(&db, "host").await;

--- a/backend/src/services/sessions/races.rs
+++ b/backend/src/services/sessions/races.rs
@@ -1015,9 +1015,9 @@ mod tests {
     /// `(session_race_participations, session_races, runs)` — see
     /// `get_pending_races`. No periodic timer ages a row out on its own
     /// clock. The one writer of `dropped_at` is the session-close transaction
-    /// (`close_session_and_drop_pending`, ADR-0037), which runs inline on the
-    /// last leave or via the stale-session sweeper. Resolved rows (`skipped`,
-    /// `raced`, `dropped`) remain in the DB indefinitely as historical state.
+    /// (`close_session`, ADR-0037), which runs inline on the last leave or via
+    /// the stale-session sweeper. Resolved rows (`skipped`, `raced`,
+    /// `dropped`) remain in the DB indefinitely as historical state.
     #[tokio::test]
     async fn test_lazy_check_assertion() {
         // No-op test by design — this comment IS the assertion.

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -21,12 +21,12 @@ use uuid::Uuid;
 use crate::{
     db,
     domain::{
-        SessionId, SessionRaceId, UserId,
+        RunId, SessionId, SessionRaceId, UserId,
         enums::{SessionRuleset, SessionStatus},
     },
     drink_type_id::drink_type_uuid,
     entities::{
-        bodies, characters, cups, drink_types, gliders, session_participants,
+        bodies, characters, cups, drink_types, gliders, runs, session_participants,
         session_race_participations, session_races, sessions, tracks, users, wheels,
     },
 };
@@ -223,10 +223,50 @@ pub async fn insert_race_participation(
         user_id: Set(user_id.into()),
         created_at: NotSet,
         skipped_at: Set(skipped_at),
+        dropped_at: Set(None),
     }
     .insert(db)
     .await
     .expect("insert race participation");
+}
+
+/// Insert a `runs` row directly with placeholder vehicle/time fields.
+///
+/// For tests that need a submitted run without going through `create_run`'s
+/// full validation surface. Requires [`seed_game_data`] (character/body/
+/// wheel/glider id 1, the `Test Beer` drink type). `created_at` is stamped
+/// `now` by `before_save`. Returns the new run ID.
+pub async fn insert_run(
+    db: &DatabaseConnection,
+    session_race_id: &SessionRaceId,
+    user_id: &UserId,
+    track_id: i32,
+) -> RunId {
+    let id = RunId::new_v4();
+    let drink_id = drink_type_uuid("Test Beer");
+    runs::ActiveModel {
+        id: Set((&id).into()),
+        user_id: Set(user_id.into()),
+        session_race_id: Set(session_race_id.into()),
+        track_id: Set(track_id),
+        character_id: Set(1),
+        body_id: Set(1),
+        wheel_id: Set(1),
+        glider_id: Set(1),
+        track_time: Set(120_000),
+        lap1_time: Set(40_000),
+        lap2_time: Set(40_000),
+        lap3_time: Set(40_000),
+        drink_type_id: Set((&drink_id).into()),
+        disqualified: Set(false),
+        photo_path: Set(None),
+        created_at: NotSet,
+        notes: Set(None),
+    }
+    .insert(db)
+    .await
+    .expect("insert run");
+    id
 }
 
 /// Backdate a participant's `left_at` and optionally `joined_at`. Tests use

--- a/backend/tests/schema_drift.rs
+++ b/backend/tests/schema_drift.rs
@@ -62,8 +62,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use beerio_kart::entities::{
-    bodies, characters, cups, drink_types, gliders, run_flags, runs, session_participants,
-    session_race_participations, session_races, sessions, tracks, users, wheels,
+    bodies, characters, cups, drink_types, gliders, notifications, run_flags, runs,
+    session_participants, session_race_participations, session_races, sessions, tracks, users,
+    wheels,
 };
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{Database, EntityTrait, QuerySelect};
@@ -90,6 +91,11 @@ async fn each_entity_can_load_from_a_fresh_migrated_db() {
     cups::Entity::find().limit(0).all(&db).await.unwrap();
     drink_types::Entity::find().limit(0).all(&db).await.unwrap();
     gliders::Entity::find().limit(0).all(&db).await.unwrap();
+    notifications::Entity::find()
+        .limit(0)
+        .all(&db)
+        .await
+        .unwrap();
     run_flags::Entity::find().limit(0).all(&db).await.unwrap();
     runs::Entity::find().limit(0).all(&db).await.unwrap();
     session_participants::Entity::find()

--- a/backend/tests/session_integration.rs
+++ b/backend/tests/session_integration.rs
@@ -16,7 +16,10 @@ use beerio_kart::{
     config::Config,
     db,
     drink_type_id::drink_type_uuid,
-    entities::{bodies, characters, cups, drink_types, gliders, sessions, tracks, wheels},
+    entities::{
+        bodies, characters, cups, drink_types, gliders, session_participants, sessions, tracks,
+        wheels,
+    },
     routes,
 };
 use chrono::Utc;
@@ -85,6 +88,19 @@ async fn setup_test_app() -> (TestServer, sea_orm::DatabaseConnection) {
         .route(
             "/api/v1/sessions/{id}/races/{race_id}/skip",
             post(routes::sessions::skip_pending_race),
+        )
+        // Notifications (ADR-0038)
+        .route(
+            "/api/v1/me/notifications",
+            get(routes::notifications::list_notifications),
+        )
+        .route(
+            "/api/v1/me/notifications/unread-count",
+            get(routes::notifications::unread_count),
+        )
+        .route(
+            "/api/v1/me/notifications/read-all",
+            post(routes::notifications::mark_all_read),
         )
         // Runs
         .route("/api/v1/runs", post(routes::runs::create_run))
@@ -484,8 +500,9 @@ async fn test_stale_session_cleanup() {
     let session: Value = res.json();
     let session_id = session["id"].as_str().unwrap().to_string();
 
-    // Backdate created_at to 2 hours ago — a session with no races that was
-    // created over an hour ago is stale (ADR-0035 race-derived sweeper).
+    // Backdate created_at to 2 hours ago — a session with no races, no runs,
+    // and no recent join/leave/skip that was created over an hour ago is
+    // stale (ADR-0035 / ADR-0037 activity-derived sweeper).
     let two_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).naive_utc();
     let session_model = sessions::Entity::find_by_id(&session_id)
         .one(&db)
@@ -495,6 +512,17 @@ async fn test_stale_session_cleanup() {
     let mut active: sessions::ActiveModel = session_model.into();
     active.created_at = Set(two_hours_ago);
     active.update(&db).await.unwrap();
+
+    // Backdate the host's join too — a join within the window is itself an
+    // activity signal that keeps the session alive (ADR-0037 sweeper).
+    let participant = session_participants::Entity::find()
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut active_participant: session_participants::ActiveModel = participant.into();
+    active_participant.joined_at = Set(two_hours_ago);
+    active_participant.update(&db).await.unwrap();
 
     // Run cleanup
     let closed = beerio_kart::services::sessions::close_stale_sessions(&db)
@@ -832,4 +860,127 @@ async fn test_skip_after_leaving_returns_403() {
         .add_header(AUTH_HEADER, auth_value(&token_user2))
         .await;
     res.assert_status(axum::http::StatusCode::FORBIDDEN);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Notifications: pending-drop inbox (ADR-0037 + ADR-0038)
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_pending_drop_notification_full_flow() {
+    let (server, db) = setup_test_app().await;
+    seed_minimal_game_data(&db).await;
+    let (token, _host_id) = register_and_get_token(&server, "host").await;
+
+    // Create a session and pick a track — the host now has one pending race.
+    let res = server
+        .post("/api/v1/sessions")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .json(&json!({ "ruleset": "random" }))
+        .await;
+    res.assert_status(axum::http::StatusCode::CREATED);
+    let session: Value = res.json();
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/next-track"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::CREATED);
+
+    // Nothing has closed yet — the inbox is empty.
+    let res = server
+        .get("/api/v1/me/notifications")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let list: Value = res.json();
+    assert_eq!(list.as_array().unwrap().len(), 0, "inbox starts empty");
+
+    // The solo host leaves — the session closes and the pending race drops.
+    let res = server
+        .post(&format!("/api/v1/sessions/{session_id}/leave"))
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // The badge poll sees one unread notification.
+    let res = server
+        .get("/api/v1/me/notifications/unread-count")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let count: Value = res.json();
+    assert_eq!(count["count"], 1);
+
+    // The list endpoint surfaces the drop, kind-tagged with its payload.
+    let res = server
+        .get("/api/v1/me/notifications")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::OK);
+    let list: Value = res.json();
+    let items = list.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    let payload = &items[0]["payload"];
+    assert_eq!(payload["kind"], "pending_races_dropped");
+    assert_eq!(payload["session_id"], session_id);
+    assert_eq!(payload["dropped_count"], 1);
+    assert!(
+        items[0]["read_at"].is_null(),
+        "fresh notification is unread"
+    );
+
+    // Mark everything read.
+    let res = server
+        .post("/api/v1/me/notifications/read-all")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    res.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // Unread count drops to zero; the default list is now empty.
+    let res = server
+        .get("/api/v1/me/notifications/unread-count")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let count: Value = res.json();
+    assert_eq!(count["count"], 0);
+
+    let res = server
+        .get("/api/v1/me/notifications")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let list: Value = res.json();
+    assert_eq!(
+        list.as_array().unwrap().len(),
+        0,
+        "read notifications are excluded by default"
+    );
+
+    // include_read=true still returns it, now with read_at set.
+    let res = server
+        .get("/api/v1/me/notifications?include_read=true")
+        .add_header(AUTH_HEADER, auth_value(&token))
+        .await;
+    let list: Value = res.json();
+    let items = list.as_array().unwrap();
+    assert_eq!(items.len(), 1, "include_read returns the read notification");
+    assert!(
+        !items[0]["read_at"].is_null(),
+        "read notification carries a read_at timestamp"
+    );
+}
+
+#[tokio::test]
+async fn test_notification_endpoints_require_auth() {
+    let (server, _db) = setup_test_app().await;
+
+    let res = server.get("/api/v1/me/notifications").await;
+    res.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+
+    let res = server.get("/api/v1/me/notifications/unread-count").await;
+    res.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+
+    let res = server.post("/api/v1/me/notifications/read-all").await;
+    res.assert_status(axum::http::StatusCode::UNAUTHORIZED);
 }

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -67,7 +67,7 @@ POST   /sessions                   Create a new session (choose ruleset)
 GET    /sessions                   List active sessions (sorted by most recent activity)
 GET    /sessions/:id               Get session details (participants, current race, state)
 POST   /sessions/:id/join          Join a session (dedicated endpoint — designed for future password support)
-POST   /sessions/:id/leave         Leave a session (triggers grace period for pending races)
+POST   /sessions/:id/leave         Leave a session (if you were the last to leave, the session closes and unresolved pending races are dropped)
 POST   /sessions/:id/next-track    Trigger next track selection (host or chooser, depending on ruleset)
 POST   /sessions/:id/choose-track  Choose a specific track (for rulesets where a player picks)
 POST   /sessions/:id/skip-turn     Pass the chooser's turn to the next person (any participant can trigger)
@@ -107,7 +107,17 @@ GET    /stats/head-to-head/:user_id_1/:user_id_2   H2H record between two player
 
 All leaderboard endpoints accept `?alcoholic=true|false|all` to filter by drink category. Default matches the requesting user's preferred drink category. DQ'd runs are excluded from leaderboard calculations.
 
-### 1.8 Admin
+### 1.8 Notifications
+
+```
+GET    /me/notifications               List the caller's notifications, newest first (unread only; ?include_read=true for all)
+GET    /me/notifications/unread-count  Cheap unread tally for the home-screen badge — returns { "count": N }
+POST   /me/notifications/read-all      Mark all of the caller's unread notifications as read (204 No Content)
+```
+
+Per-user inbox of asynchronous events ([ADR-0038](./decisions/0038-notifications-system.md)). All three endpoints scope to the authenticated user. The first (MVP) event kind is `pending_races_dropped` — emitted when a session closes around unresolved pending races ([ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md)). `GET /me/notifications` is capped at 100 rows; cursor pagination per [ADR-0032](./decisions/0032-cursor-based-pagination.md) is a project-wide follow-up (no list endpoint uses keyset pagination yet — `GET /runs` shares the flat cap).
+
+### 1.9 Admin
 
 ```
 GET    /admin/flags                List unresolved flags (admin only)
@@ -155,17 +165,16 @@ PUT    /admin/flags/:id            Resolve a flag (admin only)
 - **Decision:** `GET /sessions/:id` (the polling endpoint, called every 2–3s per § 1.5) supports `ETag` / `If-None-Match`. The backend computes a strong ETag from session state; clients sending `If-None-Match: <etag>` get `304 Not Modified` with an empty body when nothing's changed.
 - **Why:** Without conditional GETs, every poll transfers the full session state — participants, races, submission status, pending lists. With ~10 active users polling a multi-participant session every 2s, that's a lot of redundant JSON. A 304 response is dozens of bytes. On mobile, the bandwidth and battery savings are real; on the server, the CPU savings are smaller but real.
 - **Implementation:**
-  - Compute the ETag as a hash of seven values:
+  - Compute the ETag as a hash of six values:
     1. `session.status`
     2. `COALESCE(MAX(session_races.created_at), '1970-01-01T00:00:00Z')` for this session
     3. `COALESCE(MAX(runs.created_at), '1970-01-01T00:00:00Z')` where the run's `session_race.session_id = :id`
     4. `COALESCE(MAX(session_participants.joined_at), '1970-01-01T00:00:00Z')` for this session
     5. `COALESCE(MAX(session_participants.left_at), '1970-01-01T00:00:00Z')` for this session
     6. `COALESCE(MAX(session_race_participations.skipped_at), '1970-01-01T00:00:00Z')` for races in this session
-    7. `FLOOR(NOW().unix_timestamp / 60)` — a one-minute time bucket
-  - **Why these seven.** The first six are the derived-data signals for every state mutation: status change, new race, new run, join, leave/rejoin (rejoin clears the leaver's `left_at` to NULL, which changes the MAX-of-remaining), and skip-pending-race. The seventh bucket exists because ADR-0035 introduced a time-based invalidation that no stored data captures: at minute 60 after a race's creation, that race silently drops out of the per-user pending list (per the `sr.created_at >= NOW() - 1 hour` clause in `get_pending_races`). Without the bucket, a conditional poll mid-expiry returns 304 against a now-stale cached pending list. The 60-second bucket bounds the staleness window to ≤ 60s past expiry; clients re-polling every 2.5s will see the change on the first poll after the bucket rolls.
-  - Use `BLAKE3` (or `xxhash`) of the seven values concatenated with a separator; format as `W/"<hex>"` (weak ETag, since two semantically-equivalent responses might serialize differently). `COALESCE` keeps NULL inputs from causing spurious churn.
-  - In the handler: compute the seven inputs *before* loading the full state (one query for the four `MAX(...)` aggregates, one for the session row). If `If-None-Match` matches, return 304 immediately. Otherwise load and return 200 with the new ETag in the response header.
+  - **Why these six.** They are the derived-data signals for every state mutation: status change, new race, new run, join, leave/rejoin (rejoin clears the leaver's `left_at` to NULL, which changes the MAX-of-remaining), and skip-pending-race. ADR-0035 had also added a seventh input — a `FLOOR(NOW() / 60)` one-minute time bucket — because the per-race 1-hour expiry was a time-based invalidation no stored data captured. [ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md) removed that per-race timer: a pending race now drops out only when `dropped_at` is stamped at session close, which already moves either `session.status` (clean last-leave) or `session_participants.left_at` (the leave that triggered the close) — both already inputs. No time-based predicate silently ages a row out anymore, so the bucket no longer earns its keep and is dropped. The six inputs here are the same activity signals the stale-session sweeper's predicate enumerates (see `close_stale_sessions`); the two formulas share a maintenance contract — a new activity-producing endpoint means adding inputs to both.
+  - Use `BLAKE3` (or `xxhash`) of the six values concatenated with a separator; format as `W/"<hex>"` (weak ETag, since two semantically-equivalent responses might serialize differently). `COALESCE` keeps NULL inputs from causing spurious churn.
+  - In the handler: compute the six inputs *before* loading the full state (one query for the `MAX(...)` aggregates, one for the session row). If `If-None-Match` matches, return 304 immediately. Otherwise load and return 200 with the new ETag in the response header.
   - Apply the same pattern only to `GET /sessions/:id` for now — it's the only high-frequency endpoint. Other GETs don't need it.
 - **Trade-offs considered:**
   - **WebSockets / SSE:** § 1.5 already decided polling. ETags make polling cheap enough that we don't need to revisit.
@@ -281,3 +290,4 @@ The list of stable `code` values returned in error responses. Add to this list w
 - 2026-05-10 — Renamed `AppError` → `error::Error` in the § 3 (error response contract) prose and example. Companion to the module-name-repetition cleanup in PR-H1+ (d). PR #103 sequence.
 - 2026-05-15 — § 8 error code registry: added `504 | gateway_timeout` for the per-call DB timeout path introduced in PR-F4. The `code` field is deferred per § 3, so this isn't a wire-contract change today — the registry already documents codes ahead of implementation (e.g., `lap_times_mismatch`), and adding this row avoids drift when the `code` field eventually lands. PR [#155](https://github.com/brendanbyrne/beerio-kart/pull/155).
 - 2026-05-15 — `code` field rollout (#157). § 3 rewritten: dropped the speculative `Implementation:` block (the codebase shape is now real); references to "deferred" replaced with the actually-emitted shape; pointer to ADR 0036 added for the design rationale. § 8 grew two rows for the path/json extractor failures (`invalid_path_param`, `invalid_request_body`) added by the custom extractors that closed #146 as part of #157. The `code` field is now emitted on every error response.
+- 2026-05-16 — ADR-0037 + ADR-0038. New § 1.8 Notifications endpoint group (`GET /me/notifications`, `GET /me/notifications/unread-count`, `POST /me/notifications/read-all`); Admin renumbered 1.8 → 1.9. § 4 ETag formula dropped from seven inputs to six — the `FLOOR(NOW() / 60)` time bucket is removed now that ADR-0037 deleted the per-race expiry timer (no time-based predicate silently ages a pending row out anymore). § 1.5 `POST /sessions/:id/leave` description updated: leaving as the last participant closes the session and drops unresolved pending races. Issues [#58](https://github.com/brendanbyrne/beerio-kart/issues/58), [#164](https://github.com/brendanbyrne/beerio-kart/issues/164).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -152,8 +152,10 @@ Notes:
 - `host_id` is set to the creating user when the session is created. If the host leaves, host role transfers to the earliest-joined remaining participant.
 - `least_played_drink_category` stores values as `"alcoholic"` or `"non_alcoholic"` (snake_case, per database convention). The frontend maps these to display text with hyphens ("non-alcoholic").
 - Ruleset-specific config uses explicit nullable columns rather than a JSON blob. With four well-defined rulesets, explicit columns are safer (database can enforce CHECK constraints) and queryable. New config options require a migration, but that's the right tradeoff for known rulesets.
-- Session liveness is **race-derived** per [ADR-0035](./decisions/0035-race-anchored-session-lifetime.md). A session is alive iff `status = 'active'` AND (a race exists within the last hour OR `created_at` is within the last hour). The same predicate is applied at every user-facing read path (`get_pending_races`, `check_not_in_any_session`, `get_active_session_id`) and by the stale-session sweeper. There is no maintained `last_activity_at` column — each meaningful user action lands its own row (`session_races`, `runs`, `session_participants`) and liveness reads from those.
-- A periodic Tokio task (`close_stale_sessions`, every 15 minutes) flips `status` to `'closed'` for sessions failing the liveness predicate. Pure DB hygiene — no user-facing read depends on the sweeper having run recently. Clean exits (last participant leaves) close the session inline via `leave_session`'s `transfer_host_or_close` path; the sweeper handles only the abandoned case (tab closed, phone died).
+- Session liveness is **activity-derived** per [ADR-0035](./decisions/0035-race-anchored-session-lifetime.md) and [ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md). There is no maintained `last_activity_at` column — each meaningful user action lands its own row (`session_races`, `runs`, `session_participants`, `session_race_participations`) and liveness reads from those. Two related predicates:
+  - **Read-path lockout** (`check_not_in_any_session`, `get_active_session_id`): a user is held in a session iff `status = 'active'` AND (a race exists within the last hour OR `created_at` is within the last hour). This decouples user lockout from sweep timing.
+  - **Stale-session sweeper** (`close_stale_sessions`, ADR-0037): a session is *stale* iff `status = 'active'`, `created_at` is over an hour old, AND no activity of any kind happened within the last hour — no new race, no submitted run, no join or leave, no skipped pending race (five signals). With the per-race timer gone from pending derivation (see Pending Race Tracking), the sweeper is the sole gatekeeper for closing dormant sessions.
+- A periodic Tokio task (`close_stale_sessions`, every 15 minutes) flips `status` to `'closed'` for stale sessions. Clean exits (last participant leaves) close the session inline via `leave_session`'s `transfer_host_or_close` path; the sweeper handles only the abandoned case (tab closed, phone died). **Closing a session — by either path — drops every unresolved pending race in it** (`dropped_at` stamped on the `session_race_participations` row) and records a `notifications` row per affected user (ADR-0037 / ADR-0038). The drop and the notifications are atomic with the close.
 - Future consideration: `password_hash` column for session passwords. Deferred — the `POST /sessions/:id/join` endpoint is designed as a dedicated action so password checking can be added later without restructuring the join flow.
 - A user can only be active in one session at a time (enforced by a partial unique index on `session_participants(user_id) WHERE left_at IS NULL`).
 - **Session UI icons:** The host is indicated by a 🏠 (house) icon, not a crown. The 👑 (crown) is reserved for the player with the most fastest track times in the session — an earned distinction, not a role.
@@ -177,7 +179,7 @@ Constraints:
 Notes:
 - "Currently in session" = `left_at` is null.
 - `joined_at` is **monotonic** — set when the row is first inserted, never reset on rejoin. Genuinely means "when did this user first join this session."
-- On rejoin (any duration): clear `left_at` (set to NULL). `joined_at` is untouched. Pending races remain accessible iff their own per-race 1-hour window hasn't expired (per ADR-0035). No 5-minute grace concept — race-anchored expiry replaces it.
+- On rejoin (any duration): clear `left_at` (set to NULL). `joined_at` is untouched. Pending races remain accessible for as long as the session is alive (per [ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md)) — a user who leaves with pending races can rejoin and act on them as long as someone else kept the session alive. If everyone leaves, the session closes and the pending races are dropped. No 5-minute grace concept, and no per-race timer — the session is the deadline.
 - **Settle-on-new-join.** The schema's partial unique index `UNIQUE(user_id) WHERE left_at IS NULL` allows at most one active participation per user. When a user starts or joins a *new* session (`create_session` / `join_session`), the same transaction also sets `left_at = NOW()` on any pre-existing `left_at IS NULL` row for that user in a *different* session. Semantically: starting or joining a new session is an implicit leave of any abandoned one. Without this, the application-level race-derived liveness predicate would let the check pass while the INSERT collided with the partial unique index — so lockout would still be sweep-bound. The stale session's `status` and other participants' rows are left to the sweeper (eventual consistency).
 - Per-race presence (which races the user was actually present for at creation time) is NOT derived from this table — see `session_race_participations`.
 
@@ -212,7 +214,8 @@ session_race_participations
 ├── session_race_id: UUID (foreign key -> session_races, not null)
 ├── user_id: UUID (foreign key -> users, not null)
 ├── created_at: TIMESTAMP (not null)
-└── skipped_at: TIMESTAMP (nullable — set when the user explicitly skips this race)
+├── skipped_at: TIMESTAMP (nullable — set when the user explicitly skips this race)
+└── dropped_at: TIMESTAMP (nullable — set when the session closes around an unresolved pending row)
 ```
 
 Constraints:
@@ -222,10 +225,19 @@ Constraints:
 Notes:
 - Inserted at race-creation time, in the same transaction as the `session_races` INSERT, for every user with `session_participants.left_at IS NULL` in this session.
 - Existence of a row = "this user was present when this race was created" (the primary fact this table proves).
-- `skipped_at IS NULL` AND no corresponding `runs` row = pending state.
-- `skipped_at IS NOT NULL` = user explicitly forfeited this race.
 - A `runs` row for `(session_race_id, user_id)` = user submitted; pending state cleared by row presence in `runs`.
-- Rows are never deleted. After a race ages out of its 1-hour window or after a session closes, rows remain in the DB for history; they just become inaccessible via normal API paths. Both filters are required — the per-race expiry check **and** the `session.status = 'active'` check — because a session can close (via `close_stale_sessions` or the host-leaves-last cascade) while individual races within it are still inside their 1-hour window. See the Pending Race Tracking derivation below.
+- `skipped_at IS NOT NULL` = user explicitly forfeited this race.
+- `dropped_at IS NOT NULL` = the session closed (clean last-leave or sweeper) while this row was still an unresolved pending race ([ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md)). Distinct from `skipped` — `skipped` is "the user chose to forfeit," `dropped` is "the session ended around them." `skipped` and `raced` both beat `dropped`: a row that already has `skipped_at` set, or a `runs` row, is never stamped `dropped_at`.
+- Rows are never deleted. After a session closes, rows remain in the DB for history; they just become inaccessible via normal API paths (the close stamps `dropped_at`, which the Pending Race Tracking derivation below filters on).
+
+**Per-(race, user) status enum** (derived, not stored as such). These four mutually-exclusive states apply only to `(race, user)` pairs where a `session_race_participations` row exists — i.e. where the user was present at race creation. A user who joined the session *after* a race was created has no row for it and none of the states apply.
+
+| Status | Derivation |
+|---|---|
+| `unraced` | row exists, no `runs` row, `skipped_at IS NULL`, `dropped_at IS NULL` (this is "pending") |
+| `raced` | a `runs` row exists for `(race, user)` |
+| `skipped` | `skipped_at IS NOT NULL` |
+| `dropped` | `dropped_at IS NOT NULL` |
 
 ### Runs
 
@@ -312,6 +324,31 @@ Notes:
 - The `flagged_for_review` column on the `runs` table is removed — flag status is determined by the presence of an unresolved `run_flags` row.
 - `run_id` is NOT unique — a run can have multiple flags, both resolved and unresolved. Different issues (e.g., wrong time and wrong race setup) are tracked as separate flags and resolved independently. Resolved flags are kept as audit history. Application code prevents duplicate flags (same run + same reason while unresolved).
 
+### Notifications
+
+A per-user inbox of asynchronous events, per [ADR-0038](./decisions/0038-notifications-system.md). Each event materializes one row; dismissal flips `read_at`. The first (MVP) consumer is the pending-races-dropped event from ADR-0037.
+
+```
+notifications
+├── id: UUID (primary key)
+├── user_id: UUID (foreign key -> users, not null — recipient)
+├── kind: TEXT (not null — discriminator, snake_case)
+├── payload: TEXT (not null — kind-specific structured data, JSON)
+├── created_at: TIMESTAMP (not null)
+└── read_at: TIMESTAMP (nullable — set when the user dismisses)
+```
+
+Constraints:
+- Foreign key on `user_id` with **ON DELETE CASCADE** — when a user is deleted their inbox goes with them (notifications carry no cross-user audit value, unlike `session_race_participations`).
+- Index `idx_notifications_user_unread` on `(user_id, created_at DESC) WHERE read_at IS NULL` — the "list my unread, newest first" hot path.
+- Index `idx_notifications_user_created` on `(user_id, created_at DESC)` — paginated "show me everything, including read."
+
+Notes:
+- **Append-only.** Each event is its own row; there is no supersession. "Three drops" yields three rows.
+- **Keep forever.** No retention task for MVP — bounded well below "concern" at friend-group scale. A future Issue adds retention if it ever matters.
+- `kind` is a snake_case discriminator (`pending_races_dropped`, …) lifted out of the JSON `payload` for indexing. `payload` stores the kind-specific structured body — the serde-tagged `NotificationPayload` enum on the Rust side. JSON-as-TEXT follows [ADR-0028](./decisions/0028-timestamp-storage-as-iso8601-text.md)'s same-shape rule; the DB never queries inside it.
+- Every notification INSERT runs in the same transaction as the triggering write (ADR-0038 § Atomicity) — no worker, no queue. The pending-drops consumer writes one row per affected user inside the session-close transaction.
+
 ### Head-to-Head Derivation
 
 Head-to-head records are derived from session data, not stored separately. A "win" is when two players both submitted non-DQ'd runs for the same `session_race_id` and one had a faster `track_time`. Ties (identical times) count as 0-0 — neither a win nor a loss.
@@ -324,15 +361,16 @@ This approach supports an unbounded number of rivals — no tracking table neede
 
 ### Pending Race Tracking
 
-Within a session, a participant may have "pending" races — session races they were present for but haven't yet submitted a time. The UI caps pending races at 3 (oldest expire first), but the schema places no limit, allowing this cap to be adjusted later.
+Within a session, a participant may have "pending" races — session races they were present for but haven't yet submitted a time. The UI caps pending races at 3, but the schema places no limit, allowing this cap to be adjusted later.
 
-**Derivation** (per [ADR-0035](./decisions/0035-race-anchored-session-lifetime.md)). A `session_race_participations` row represents pending state for user `U` and race `SR` iff **all** of the following hold:
+**Derivation** (per [ADR-0037](./decisions/0037-pending-races-dropped-on-session-close.md)). A `session_race_participations` row represents pending state for user `U` and race `SR` iff **all** of the following hold:
 
 1. The row exists (i.e. `U` was present when `SR` was created).
 2. `skipped_at IS NULL` on the row.
 3. No `runs` row exists for `(SR.id, U.id)`.
-4. `SR.created_at >= NOW() - INTERVAL 1 HOUR` — the per-race submission window.
-5. `sessions.status = 'active'` for `SR.session_id`. Closed sessions accept no further submissions or skips, so any pending entries on them would be phantom (no API path to resolve them).
+4. `dropped_at IS NULL` on the row.
+
+Four clauses, no per-race timer and no `sessions.status` filter. **The session is the deadline** (ADR-0037): a pending race stays submittable for as long as the session is alive. When a session closes — clean last-leave or sweeper — the close transaction stamps `dropped_at` on every unresolved row, so clause 4 alone captures "the session is over." A race created four hours ago in a still-active session is still pending. This is the narrowing of [ADR-0035](./decisions/0035-race-anchored-session-lifetime.md)'s per-race 1-hour window, which is gone.
 
 Pending races are returned ordered by `session_races.race_number ASC`. The API returns all; the UI applies the 3-cap.
 
@@ -340,7 +378,7 @@ Pending races are returned ordered by `session_races.race_number ASC`. The API r
 
 **Session advancement.** If the session advances while a participant hasn't submitted, they see their pending list (oldest first) when they go to submit, and must resolve them in order before submitting for the current race. This ensures no one person holds up the group, consistent with "never feel rushed."
 
-**Forfeiture vs. deletion.** Forfeited pending records (those filtered out by race expiry or session close) are **not deleted** from `session_race_participations`. They remain as historical state and become inaccessible via the derivation above. This preserves the audit trail of "what was pending at any moment" for debugging and future analytics.
+**Forfeiture vs. deletion.** Resolved pending records — `skipped`, `raced`, or `dropped` — are **not deleted** from `session_race_participations`. They remain as historical state and become inaccessible via the derivation above. This preserves the audit trail of "what was pending at any moment" for debugging and future analytics.
 
 ### Session Rulesets
 
@@ -365,3 +403,4 @@ Each session uses one ruleset that determines how tracks are selected. The rules
 - 2026-05-05 — Extracted from `docs/design.md` as part of PR 1 (docs restructure foundation). See `docs/designs/archive/2026-05-04-design-doc-restructure.md` §5.1.
 - 2026-05-13 — § `run_flags` now enumerates the canonical snake_case storage values for `reason` alongside the display text, mirroring the storage-vs-display split already documented for `sessions.{ruleset,status,least_played_drink_category}`. The values are load-bearing as of PR-D3 ([#120](https://github.com/brendanbyrne/beerio-kart/issues/120) / PR [#148](https://github.com/brendanbyrne/beerio-kart/pull/148)), which committed them via `RunFlagReason::string_value` annotations on the `DeriveActiveEnum` backing the column. Review feedback from PR #148.
 - 2026-05-15 — Updated the 2026-05-05 history entry's path reference for the design-doc-restructure record (now archived under `designs/archive/`). Companion to PR [#160](https://github.com/brendanbyrne/beerio-kart/pull/160) / Issue [#159](https://github.com/brendanbyrne/beerio-kart/issues/159).
+- 2026-05-16 — ADR-0037 + ADR-0038. `session_race_participations` gains a nullable `dropped_at` column and the four-state per-(race, user) status enum (`unraced` / `raced` / `skipped` / `dropped`). Pending Race Tracking derivation simplified to four clauses — the per-race 1-hour timer and the `sessions.status` filter are gone; the session is the deadline. Session liveness note rewritten: the stale-session sweeper now uses a five-signal activity predicate, and closing a session drops its unresolved pending races + records notifications. Session Participants rejoin rule updated to "rejoin while the session is alive." New `notifications` table section added (ADR-0038 inbox). Issues [#51](https://github.com/brendanbyrne/beerio-kart/issues/51), [#58](https://github.com/brendanbyrne/beerio-kart/issues/58), [#164](https://github.com/brendanbyrne/beerio-kart/issues/164).

--- a/docs/decisions/0032-cursor-based-pagination.md
+++ b/docs/decisions/0032-cursor-based-pagination.md
@@ -36,6 +36,12 @@ Chosen: **Option B** — Cursor-based pagination using `created_at` + `id` (comp
 
 - Slightly more complex to implement and explain. Acceptable: if the implementation burden is real, offset-based can be substituted later with a note about the tradeoff.
 
+## Implementation status
+
+Not yet implemented in any list endpoint as of 2026-05-17. Both `GET /runs` ([`services/runs/read.rs`](../../backend/src/services/runs/read.rs)) and `GET /me/notifications` ([`services/notifications.rs`](../../backend/src/services/notifications.rs)) currently use a flat `LIMIT 100` cap — the ADR-sanctioned substitute (see Negative consequences). Future history endpoints under `/stats/personal/...` should be built keyset-native rather than retrofitted.
+
+Project-wide rollout is tracked in [#166](https://github.com/brendanbyrne/beerio-kart/issues/166).
+
 ## Links
 
 - Source: `ad-hoc`

--- a/docs/user-workflows.md
+++ b/docs/user-workflows.md
@@ -49,7 +49,7 @@ Future enhancement: prioritize sessions containing players you've competed with 
    - If time is a track record and no photo: prompt, then auto-flag if skipped.
 4. Session screen shows who has submitted, who's still pending.
 5. Next track selection happens when the chooser/host triggers it (depending on ruleset). The chooser can pick while others still have pending races — this doesn't block.
-6. If someone has pending races from earlier, they see those when they go to submit. Pending races shown in order, submit or skip each. Max 3 pending in UI (oldest expire first). Schema supports unlimited for future flexibility.
+6. If someone has pending races from earlier, they see those when they go to submit. Pending races shown in order, submit or skip each. Max 3 pending in UI (oldest shown first). Schema supports unlimited for future flexibility.
 7. Choosing and submitting are independent actions — the chooser can pick the next track even if they haven't submitted their own time yet.
 8. Repeat until the group decides to stop.
 
@@ -58,10 +58,10 @@ Earmarked: the track selection sub-workflow (how the chooser browses/searches fo
 ### 1.5 Leaving a session / session end
 
 1. Player taps "Leave Session."
-2. If they have pending races: warning that each race must be submitted within 1 hour of when it started; rejoining the session at any point within that hour preserves the pending race.
+2. Pending races stay submittable while the session is active. If you leave with pending races, you can rejoin as long as someone else is still in the session. If everyone leaves, the session ends and pending races are dropped — you'll see a notification next time you visit.
 3. If the leaving player is the host: host role transfers to the earliest-joined remaining participant.
 4. Session ends when all participants have left.
-5. Sessions whose races have all aged past their 1-hour window auto-close on the next sweeper pass — no further run submissions accepted.
+5. Sessions with no activity of any kind for an hour — no new race, run, join, leave, or skip — auto-close on the next sweeper pass. No further run submissions accepted, and any unresolved pending races are dropped.
 
 ### 1.6 Checking personal stats
 
@@ -180,3 +180,4 @@ Streamlined compared to standalone entry — the track is already known from the
 - 2026-05-06 — Initial creation. Sourced from `design.md` § "User Workflows" (workflows 1-9) and § "UI Screens" (screens 1-7 + shared components). Content copied with two minor editorial changes: the Workflow 1.4 "Phase 3 detailed design" reference updated to "Milestone Star detailed design" (cup-name convention is now canonical), and the screens preamble adds the Pixel 9 Pro reference-device sentence (factored out of `.claude/CLAUDE.md` § UI Reference Device for proximity to the screens themselves). Filename `user-workflows.md` diverges from the design record's proposed `workflows.md` due to grep collision with the operational `workflow.md` — see PR 4 discussion. PR 4 of the docs restructure.
 - 2026-05-08 — Updated the § 0 cross-reference: `workflow.md` → `project-workflow.md` (operational doc renamed for clarity — see that file's history). Dropped the "note the singular 'workflow'" caveat, no longer needed once the filename is unambiguous.
 - 2026-05-08 — Demoted the broken `[workflow.md](./workflow.md)` markdown link in the 2026-05-06 initial-creation history bullet to plain backticked text. The file no longer exists at that path (renamed to `project-workflow.md` on 2026-05-08); the rename history is documented in the bullet immediately above. PR 5 of the docs restructure (plan deviation — Cowork's PR 5 handoff did not anticipate this link, surfaced when lychee `fail: true` flip would otherwise turn it into a CI failure).
+- 2026-05-16 — Rewrote § 1.5 step 2 for ADR-0037: pending races stay submittable while the session is active and rejoining works as long as someone keeps the session alive; if everyone leaves, the session ends and pending races are dropped (with a notification). The per-race 1-hour window is gone. Step 5 (auto-close) updated for the five-signal sweeper predicate and the drop-on-close behavior. § 1.2 step 6 "(oldest expire first)" → "(oldest shown first)" — no per-race expiry remains. Issue [#51](https://github.com/brendanbyrne/beerio-kart/issues/51).

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -160,3 +160,32 @@ export interface SessionDetail {
   current_race: SessionRaceInfo | null
   races: RaceInfo[]
 }
+
+// ── Notifications (ADR-0038) ──────────────────────────────────────────
+//
+// Hand-written counterpart of the Rust `NotificationPayload` enum
+// (backend/src/services/notifications.rs). Kept in sync via PR review —
+// no codegen for MVP. Add a new payload interface + union member here
+// whenever a variant is added on the Rust side.
+
+export interface PendingRacesDroppedPayload {
+  kind: 'pending_races_dropped'
+  session_id: string
+  dropped_count: number
+}
+
+// Discriminated union of notification payload kinds. MVP carries one
+// variant; future kinds (h2h_lead_changed, track_record_lost,
+// leaderboard_rank_changed) join this union as they land.
+export type NotificationPayload = PendingRacesDroppedPayload
+
+export interface Notification {
+  id: string
+  created_at: string
+  read_at: string | null
+  payload: NotificationPayload
+}
+
+export interface UnreadCountResponse {
+  count: number
+}


### PR DESCRIPTION
## Reviewer notes

Single combined PR — the schema (`dropped_at`), the drop-on-close step, the `get_pending_races` simplification, the sweeper-predicate extension, the `notifications` table, and the `record_pending_drops` consumer are co-dependent; splitting them would force intermediate states that don't compile or don't pass tests.

**One deviation from ADR-0038:** `GET /me/notifications` uses a flat `LIMIT 100` cap instead of ADR-0032 cursor pagination. No keyset-pagination infrastructure exists anywhere in the codebase — `GET /runs`, ADR-0032's own named exemplar, also still uses a flat cap. Building keyset pagination for one endpoint in isolation would make notifications *inconsistent* with the sibling list endpoint. ADR-0032 explicitly sanctions a flat substitute "with a note about the tradeoff." Surfaced in `NOTIFICATIONS_PAGE_LIMIT`'s doc comment and api-contract.md § 1.8. Cowork reviewed the deviation and chose to keep ADR-0032 `accepted` and track project-wide keyset rollout as a follow-up — now filed as **#166**, with an `## Implementation status` section added to ADR-0032 itself.

`#47` is already closed (it tracked the ADR-0035 work that merged); the `Closes` keyword below is a harmless no-op for it. Frontend (#163) is a separate downstream PR — untouched here.

The sweeper now treats a recent join/leave/run/skip as a liveness signal, so three pre-existing sweeper tests had fixtures updated (participants that "joined now" in a backdated session would otherwise keep it alive — correct behavior, unrealistic fixture).

## Summary

Implements [ADR-0037](../blob/main/docs/decisions/0037-pending-races-dropped-on-session-close.md) (pending races dropped on session close) and the [ADR-0038](../blob/main/docs/decisions/0038-notifications-system.md) notifications-system MVP backend. When a session closes — clean last-leave or stale-session sweeper — every unresolved pending race is stamped `dropped_at` and each affected user gets a `pending_races_dropped` notification, all atomic with the close. `get_pending_races` drops its per-race timer and session-status filter (the session is the deadline); the sweeper predicate gains four activity signals.

## Linked work

- Closes #47 #51 #58 #164
- Implements docs/decisions/0037-pending-races-dropped-on-session-close.md
- Implements docs/decisions/0038-notifications-system.md
- Follow-up: #166 — project-wide ADR-0032 keyset pagination (the deliberate `LIMIT 100` deviation; see Reviewer notes)

## How to verify

Backend unit + integration tests (297 lib + integration suites):

```bash
cd backend && cargo test
```
- [x] All tests pass, including the new `services::notifications`, `lifecycle` drop/sweeper/notification-trigger, and `session_integration` notification-flow tests.

Lint + format:

```bash
cd backend && cargo clippy --all-targets && cargo +nightly fmt --check
```
- [x] Clean.

ADR-0037 spec-conformance greps (each should match the stated expectation):

```bash
grep -rn "created_at.*INTERVAL.*HOUR\|created_at.*now()" backend/src/services/sessions/races.rs   # expect: empty
grep -rn "s.status = 'active'" backend/src/services/sessions/races.rs                              # expect: empty
grep -rln "dropped_at" backend/migration backend/src/entities backend/src/services                # expect: migration, entity, helpers, lifecycle, races
```
- [ ] Per-race expiry and session-status clauses gone from `get_pending_races`; `dropped_at` present at the migration/entity/service sites.

End-to-end manual check (drop-on-close → notification inbox). Reset the dev DB first since the schema changed:

```bash
rm -f data/db/beerio-kart.db && cd backend && cargo run
```

Then, against `http://localhost:3000` — each step captures what the next needs (`TOKEN`, `SESSION_ID`) into shell variables via `jq`, so the block runs top-to-bottom as-is (requires `jq`):

```bash
# 1. Register a user — capture the access token
TOKEN=$(curl -s -X POST localhost:3000/api/v1/auth/register \
  -H 'content-type: application/json' \
  -d '{"username":"dropper","password":"testpass123"}' | jq -r .access_token)

# 2. Create a session — capture its id — then pick a track (host has 1 pending race now)
SESSION_ID=$(curl -s -X POST localhost:3000/api/v1/sessions \
  -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
  -d '{"ruleset":"random"}' | jq -r .id)
echo "TOKEN=${TOKEN:0:12}…  SESSION_ID=$SESSION_ID"   # sanity-check the captures
curl -s -X POST "localhost:3000/api/v1/sessions/$SESSION_ID/next-track" \
  -H "authorization: Bearer $TOKEN" | jq

# 3. Inbox is empty before any close
curl -s localhost:3000/api/v1/me/notifications -H "authorization: Bearer $TOKEN" | jq

# 4. Leave as the solo participant — session closes, pending race drops
curl -s -X POST "localhost:3000/api/v1/sessions/$SESSION_ID/leave" \
  -H "authorization: Bearer $TOKEN"

# 5. Unread count is now 1
curl -s localhost:3000/api/v1/me/notifications/unread-count \
  -H "authorization: Bearer $TOKEN" | jq

# 6. List shows the pending_races_dropped notification, dropped_count 1
curl -s localhost:3000/api/v1/me/notifications -H "authorization: Bearer $TOKEN" | jq

# 7. Mark all read → 204; unread count back to 0; default list empty;
#    ?include_read=true still returns it with read_at set
curl -s -i -X POST localhost:3000/api/v1/me/notifications/read-all \
  -H "authorization: Bearer $TOKEN"
curl -s localhost:3000/api/v1/me/notifications/unread-count \
  -H "authorization: Bearer $TOKEN" | jq
curl -s "localhost:3000/api/v1/me/notifications?include_read=true" \
  -H "authorization: Bearer $TOKEN" | jq
```
- [ ] Step 3: `[]`. Step 5: `{"count":1}`. Step 6: one item, `payload.kind = "pending_races_dropped"`, `payload.session_id` matches `SESSION_ID`, `payload.dropped_count = 1`, `read_at` null. Step 7: `204`, then `{"count":0}`, then `[]` for the default list and one item with a non-null `read_at` for `?include_read=true`.

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated for new logic (per `CLAUDE.md`).
- [x] Docs updated (`data-model.md`, `user-workflows.md`, `api-contract.md` — all with `Document history` entries).
- [x] Schema changes: consolidated migration edited; schema-drift test extended; local DB reset to verify.
- [x] Tested locally end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
