### PR TITLE
187: Configure ESLint plugins, Prettier integration, and add core frontend packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,9 +13,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.100.10",
+        "@tanstack/react-query-devtools": "^5.100.10",
+        "clsx": "^2.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-error-boundary": "^6.1.1",
         "react-router-dom": "^7.13.2",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -25,6 +30,9 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
@@ -147,6 +155,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.2", "@tailwindcss/oxide-darwin-arm64": "4.2.2", "@tailwindcss/oxide-darwin-x64": "4.2.2", "@tailwindcss/oxide-freebsd-x64": "4.2.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2", "@tailwindcss/oxide-linux-arm64-musl": "4.2.2", "@tailwindcss/oxide-linux-x64-gnu": "4.2.2", "@tailwindcss/oxide-linux-x64-musl": "4.2.2", "@tailwindcss/oxide-wasm32-wasi": "4.2.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2", "@tailwindcss/oxide-win32-x64-msvc": "4.2.2" } }, "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg=="],
@@ -177,11 +187,21 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.10", "", {}, "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="],
+
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.100.10", "", {}, "sha512-3DmJf25hDPus5IpVvp6ujXv6bKV2zPzI9vpbAmpJigsL/H6DPvPjmf7/Q9yVKEke//8fgeQ45abjgnLuyYxAiw=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.10", "", { "dependencies": { "@tanstack/query-core": "5.100.10" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q=="],
+
+    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.100.10", "", { "dependencies": { "@tanstack/query-devtools": "5.100.10" }, "peerDependencies": { "@tanstack/react-query": "^5.100.10", "react": "^18 || ^19" } }, "sha512-zes0+o9ef5rAZXJ9f/SeaLs2nufJaeVkZkl/Or9NGrWVF41kL9Od9ED9nCwtQlgiF2VGtrzhEw5AU/igAO+aAg=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
@@ -223,6 +243,30 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
+
+    "array.prototype.findlastindex": ["array.prototype.findlastindex@1.2.6", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-shim-unscopables": "^1.1.0" } }, "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ=="],
+
+    "array.prototype.flat": ["array.prototype.flat@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg=="],
+
+    "array.prototype.flatmap": ["array.prototype.flatmap@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg=="],
+
+    "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="],
@@ -231,6 +275,12 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
@@ -238,6 +288,8 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -255,23 +307,63 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
+
+    "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
+
+    "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
+
+    "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.328", "", {}, "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
+
+    "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
+
+    "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.10", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.16.1", "resolve": "^2.0.0-next.6" } }, "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ=="],
+
+    "eslint-module-utils": ["eslint-module-utils@2.12.1", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw=="],
+
+    "eslint-plugin-import": ["eslint-plugin-import@2.32.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.9", "array.prototype.findlastindex": "^1.2.6", "array.prototype.flat": "^1.3.3", "array.prototype.flatmap": "^1.3.3", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.1", "hasown": "^2.0.2", "is-core-module": "^2.16.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.1", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.9", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA=="],
+
+    "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.0.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA=="],
 
@@ -307,21 +399,53 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
     "frontend": ["frontend@workspace:frontend"],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
+
+    "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
 
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
@@ -333,11 +457,59 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
+
+    "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
+
+    "is-bigint": ["is-bigint@1.1.0", "", { "dependencies": { "has-bigints": "^1.0.2" } }, "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ=="],
+
+    "is-boolean-object": ["is-boolean-object@1.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
+
+    "is-data-view": ["is-data-view@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "is-typed-array": "^1.1.13" } }, "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw=="],
+
+    "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
+
+    "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
+
+    "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
+
+    "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
+
+    "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
+
+    "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
+
+    "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
+
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -355,9 +527,15 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
-    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+    "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
+
+    "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 
@@ -415,7 +593,11 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -423,9 +605,27 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
+
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
+
+    "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
+
+    "object.groupby": ["object.groupby@1.0.3", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2" } }, "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ=="],
+
+    "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -437,9 +637,13 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -453,11 +657,19 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-error-boundary": ["react-error-boundary@6.1.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w=="],
+
     "react-router": ["react-router@7.13.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA=="],
 
     "react-router-dom": ["react-router-dom@7.13.2", "", { "dependencies": { "react-router": "7.13.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA=="],
 
+    "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
+
+    "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "resolve": ["resolve@2.0.0-next.7", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.2", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -465,11 +677,23 @@
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
+    "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
+
+    "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
+
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
+
+    "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -477,15 +701,37 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
+
+    "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
+
+    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
+
+    "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
@@ -497,13 +743,25 @@
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
+    "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
+    "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
+
+    "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
+
+    "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.57.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.2", "@typescript-eslint/parser": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A=="],
+
+    "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -514,6 +772,14 @@
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
+
+    "which-builtin-type": ["which-builtin-type@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "function.prototype.name": "^1.1.6", "has-tostringtag": "^1.0.2", "is-async-function": "^2.0.0", "is-date-object": "^1.1.0", "is-finalizationregistry": "^1.1.0", "is-generator-function": "^1.0.10", "is-regex": "^1.2.1", "is-weakref": "^1.0.2", "isarray": "^2.0.5", "which-boxed-primitive": "^1.1.0", "which-collection": "^1.0.2", "which-typed-array": "^1.1.16" } }, "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q=="],
+
+    "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
+
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -529,9 +795,11 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -559,7 +827,17 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+
+    "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,6 +1,5 @@
 {
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "printWidth": 100
+    "singleQuote": true,
+    "semi": true,
+    "trailingComma": "all"
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -73,6 +73,14 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-non-null-assertion': 'warn',
 
+      // consistent-type-specifier-style — named in typescript.md § 9 but
+      // omitted from the PR-A1 AC; added per PR review. `prefer-top-level`
+      // matches § 5's `import type { … }` example and consistent-type-
+      // imports' `separate-type-imports` fix style. Fires on 3 inline-type
+      // imports (useAuth.tsx, Login.tsx, Register.tsx); warn until later
+      // PRs touching those files convert them, then flips to error.
+      'import/consistent-type-specifier-style': ['warn', 'prefer-top-level'],
+
       // --- Warn-down: strictTypeChecked / stylisticTypeChecked rules that
       // fire on existing code. PR-B2 lands the Zod parses and AbortSignal
       // plumbing that clear the no-unsafe-*/floating-promise families; the

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,9 +1,22 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import importPlugin from 'eslint-plugin-import';
+import prettier from 'eslint-config-prettier';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+// ESLint flat config — see docs/coding-standards/typescript.md § 9.
+//
+// PR-A1 (Issue #187) is purely additive infrastructure: it installs the
+// standards' lint presets but must produce ZERO new errors in CI or the
+// lefthook pre-commit hook. Any rule that fires on the existing (pre-
+// compliance) code is therefore started at `warn`, not `error`. Later PRs
+// in the frontend compliance plan fix the underlying code and flip each
+// rule back to `error`. The `warn`-level blocks below cite the PR that
+// owns the fix. See docs/designs/2026-05-16-frontend-compliance-plan.md.
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -11,13 +24,93 @@ export default defineConfig([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      // strictTypeChecked + stylisticTypeChecked replace the bare
+      // `recommended` preset (typescript.md § 9).
+      tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      jsxA11y.flatConfigs.recommended,
+      importPlugin.flatConfigs.recommended,
+      // eslint-config-prettier comes last so it can switch off the
+      // formatting rules the other presets enable — Prettier owns format.
+      prettier,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
+      // Matches the ES2023 `target` in tsconfig.app.json.
+      ecmaVersion: 2023,
       globals: globals.browser,
+      parserOptions: {
+        // Picks up tsconfig.app.json / tsconfig.node.json automatically so
+        // the type-aware rules in strictTypeChecked have type information.
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // --- Standards rules, enforced now (no existing violations) ---
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        { 'ts-expect-error': 'allow-with-description' },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'TSEnumDeclaration',
+          message:
+            'Use `as const` objects or string-literal unions instead of enum.',
+        },
+      ],
+
+      // --- Standards rules, started at `warn` (AC-named) ---
+      // consistent-type-definitions: ~25 `interface` declarations remain;
+      //   api/types.ts is converted in PR-B1, prop types in later PRs.
+      '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
+      // import/no-default-export: 11 default-export sites; flipped in PR-D1.
+      'import/no-default-export': 'warn',
+      // no-explicit-any / no-non-null-assertion: flipped to error in PR-F1.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+
+      // --- Warn-down: strictTypeChecked / stylisticTypeChecked rules that
+      // fire on existing code. PR-B2 lands the Zod parses and AbortSignal
+      // plumbing that clear the no-unsafe-*/floating-promise families; the
+      // remaining stylistic rules are cleared by the PR that touches each
+      // file. All flip back to `error` as their offenders are removed. ---
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-misused-promises': 'warn',
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/no-confusing-void-expression': 'warn',
+      '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+      '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+      '@typescript-eslint/restrict-template-expressions': 'warn',
+      '@typescript-eslint/no-deprecated': 'warn',
+      '@typescript-eslint/prefer-regexp-exec': 'warn',
+
+      // --- Warn-down: jsx-a11y rules that fire on existing code.
+      // PR-G2 (the accessibility sweep) fixes these and restores error. ---
+      'jsx-a11y/no-static-element-interactions': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/label-has-associated-control': 'warn',
+      'jsx-a11y/no-autofocus': 'warn',
+
+      // --- Off: eslint-plugin-import's module-resolution rules. These
+      // duplicate what `tsc --noEmit` already verifies, and without a
+      // TypeScript resolver they false-fire on every `.ts`/`.tsx` import.
+      // The standard scopes eslint-plugin-import to its syntactic rules
+      // (import/no-default-export); resolution stays TypeScript's job. ---
+      'import/no-unresolved': 'off',
+      'import/named': 'off',
+      'import/namespace': 'off',
+      'import/default': 'off',
+      'import/no-named-as-default-member': 'off',
     },
   },
-])
+]);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Beerio Kart</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Beerio Kart</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,19 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.10",
+    "@tanstack/react-query-devtools": "^5.100.10",
+    "clsx": "^2.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.2"
+    "react-error-boundary": "^6.1.1",
+    "react-router-dom": "^7.13.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -23,6 +29,9 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,39 +1,39 @@
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
-import { AuthProvider, useAuth } from './hooks/useAuth'
-import Login from './pages/Login'
-import Register from './pages/Register'
-import Onboarding from './pages/Onboarding'
-import Home from './pages/Home'
-import Profile from './pages/Profile'
-import Session from './pages/Session'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { AuthProvider, useAuth } from './hooks/useAuth';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Onboarding from './pages/Onboarding';
+import Home from './pages/Home';
+import Profile from './pages/Profile';
+import Session from './pages/Session';
 
 /** Shows a loading spinner while the initial silent refresh is in progress. */
 function AuthGate({ children }: { children: React.ReactNode }) {
-  const { isLoading } = useAuth()
+  const { isLoading } = useAuth();
 
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <p className="text-gray-400">Loading...</p>
       </div>
-    )
+    );
   }
 
-  return children
+  return children;
 }
 
 /** Redirects to /login if not authenticated. */
 function RequireAuth({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth()
-  if (!isAuthenticated) return <Navigate to="/login" replace />
-  return children
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) return <Navigate to="/login" replace />;
+  return children;
 }
 
 /** Redirects to / if already authenticated. */
 function GuestOnly({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth()
-  if (isAuthenticated) return <Navigate to="/" replace />
-  return children
+  const { isAuthenticated } = useAuth();
+  if (isAuthenticated) return <Navigate to="/" replace />;
+  return children;
 }
 
 function App() {
@@ -87,7 +87,7 @@ function App() {
         </AuthGate>
       </AuthProvider>
     </BrowserRouter>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,22 +11,22 @@
  * is truly expired and the user needs to log in again.
  */
 
-let accessToken: string | null = null
+let accessToken: string | null = null;
 
 export function setAccessToken(token: string | null) {
-  accessToken = token
+  accessToken = token;
 }
 
 export function getAccessToken(): string | null {
-  return accessToken
+  return accessToken;
 }
 
 /** Callback set by AuthProvider so the API client can trigger a logout
  *  (redirect to login) when a refresh fails. */
-let onAuthFailure: (() => void) | null = null
+let onAuthFailure: (() => void) | null = null;
 
 export function setOnAuthFailure(callback: () => void) {
-  onAuthFailure = callback
+  onAuthFailure = callback;
 }
 
 /**
@@ -39,40 +39,43 @@ async function tryRefresh(): Promise<boolean> {
       method: 'POST',
       // credentials: 'same-origin' is the default for same-origin requests,
       // which means the browser automatically sends the HttpOnly cookie.
-    })
-    if (!res.ok) return false
-    const data = await res.json()
-    accessToken = data.access_token
-    return true
+    });
+    if (!res.ok) return false;
+    const data = await res.json();
+    accessToken = data.access_token;
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
 /**
  * Wrapper around fetch() that adds the access token and handles 401 refresh.
  */
-export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
-  const headers = new Headers(options.headers)
+export async function apiFetch(
+  url: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(options.headers);
   if (accessToken) {
-    headers.set('Authorization', `Bearer ${accessToken}`)
+    headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  let res = await fetch(url, { ...options, headers })
+  let res = await fetch(url, { ...options, headers });
 
   // If we get a 401 and we had a token, try refreshing
   if (res.status === 401 && accessToken) {
-    const refreshed = await tryRefresh()
+    const refreshed = await tryRefresh();
     if (refreshed) {
       // Retry the original request with the new token
-      headers.set('Authorization', `Bearer ${accessToken}`)
-      res = await fetch(url, { ...options, headers })
+      headers.set('Authorization', `Bearer ${accessToken}`);
+      res = await fetch(url, { ...options, headers });
     } else {
       // Refresh failed — session is truly expired
-      accessToken = null
-      onAuthFailure?.()
+      accessToken = null;
+      onAuthFailure?.();
     }
   }
 
-  return res
+  return res;
 }

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -1,53 +1,54 @@
-import { apiFetch } from './client'
-import type { CreateRunRequest, RunDetail, RunDefaults } from './types'
+import { apiFetch } from './client';
+import type { CreateRunRequest, RunDetail, RunDefaults } from './types';
 
 export async function createRun(body: CreateRunRequest): Promise<RunDetail> {
   const res = await apiFetch('/api/v1/runs', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
-  })
+  });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to submit run')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to submit run');
   }
-  return res.json()
+  return res.json();
 }
 
 export async function listRuns(params?: {
-  session_race_id?: string
-  user_id?: string
-  track_id?: number
+  session_race_id?: string;
+  user_id?: string;
+  track_id?: number;
 }): Promise<RunDetail[]> {
-  const query = new URLSearchParams()
-  if (params?.session_race_id) query.set('session_race_id', params.session_race_id)
-  if (params?.user_id) query.set('user_id', params.user_id)
-  if (params?.track_id) query.set('track_id', String(params.track_id))
-  const qs = query.toString()
-  const res = await apiFetch(`/api/v1/runs${qs ? `?${qs}` : ''}`)
-  if (!res.ok) return []
-  return res.json()
+  const query = new URLSearchParams();
+  if (params?.session_race_id)
+    query.set('session_race_id', params.session_race_id);
+  if (params?.user_id) query.set('user_id', params.user_id);
+  if (params?.track_id) query.set('track_id', String(params.track_id));
+  const qs = query.toString();
+  const res = await apiFetch(`/api/v1/runs${qs ? `?${qs}` : ''}`);
+  if (!res.ok) return [];
+  return res.json();
 }
 
 export async function getRun(id: string): Promise<RunDetail> {
-  const res = await apiFetch(`/api/v1/runs/${id}`)
+  const res = await apiFetch(`/api/v1/runs/${id}`);
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Run not found')
+    const err = await res.json();
+    throw new Error(err.error || 'Run not found');
   }
-  return res.json()
+  return res.json();
 }
 
 export async function deleteRun(id: string): Promise<void> {
-  const res = await apiFetch(`/api/v1/runs/${id}`, { method: 'DELETE' })
+  const res = await apiFetch(`/api/v1/runs/${id}`, { method: 'DELETE' });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to delete run')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to delete run');
   }
 }
 
 export async function getRunDefaults(): Promise<RunDefaults> {
-  const res = await apiFetch('/api/v1/runs/defaults')
+  const res = await apiFetch('/api/v1/runs/defaults');
   if (!res.ok) {
     return {
       drink_type_id: null,
@@ -56,7 +57,7 @@ export async function getRunDefaults(): Promise<RunDefaults> {
       wheel_id: null,
       glider_id: null,
       source: 'none',
-    }
+    };
   }
-  return res.json()
+  return res.json();
 }

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,11 +1,16 @@
-import { apiFetch } from './client'
-import type { SessionSummary, SessionDetail, SessionRaceInfo, RaceInfo } from './types'
+import { apiFetch } from './client';
+import type {
+  SessionSummary,
+  SessionDetail,
+  SessionRaceInfo,
+  RaceInfo,
+} from './types';
 
 export async function getMySession(): Promise<string | null> {
-  const res = await apiFetch('/api/v1/sessions/mine')
-  if (!res.ok) return null
-  const data = await res.json()
-  return data.session_id ?? null
+  const res = await apiFetch('/api/v1/sessions/mine');
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.session_id ?? null;
 }
 
 export async function createSession(ruleset: string): Promise<SessionDetail> {
@@ -13,63 +18,69 @@ export async function createSession(ruleset: string): Promise<SessionDetail> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ruleset }),
-  })
+  });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to create session')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to create session');
   }
-  return res.json()
+  return res.json();
 }
 
 export async function listSessions(): Promise<SessionSummary[]> {
-  const res = await apiFetch('/api/v1/sessions')
-  if (!res.ok) return []
-  return res.json()
+  const res = await apiFetch('/api/v1/sessions');
+  if (!res.ok) return [];
+  return res.json();
 }
 
 export async function getSession(id: string): Promise<SessionDetail | null> {
-  const res = await apiFetch(`/api/v1/sessions/${id}`)
-  if (res.status === 404) return null
-  if (!res.ok) return null
-  return res.json()
+  const res = await apiFetch(`/api/v1/sessions/${id}`);
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+  return res.json();
 }
 
 export async function joinSession(id: string): Promise<void> {
-  const res = await apiFetch(`/api/v1/sessions/${id}/join`, { method: 'POST' })
+  const res = await apiFetch(`/api/v1/sessions/${id}/join`, { method: 'POST' });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to join session')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to join session');
   }
 }
 
 export async function leaveSession(id: string): Promise<void> {
-  const res = await apiFetch(`/api/v1/sessions/${id}/leave`, { method: 'POST' })
+  const res = await apiFetch(`/api/v1/sessions/${id}/leave`, {
+    method: 'POST',
+  });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to leave session')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to leave session');
   }
 }
 
 export async function nextTrack(sessionId: string): Promise<SessionRaceInfo> {
-  const res = await apiFetch(`/api/v1/sessions/${sessionId}/next-track`, { method: 'POST' })
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/next-track`, {
+    method: 'POST',
+  });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to pick track')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to pick track');
   }
-  return res.json()
+  return res.json();
 }
 
 export async function skipTurn(sessionId: string): Promise<SessionRaceInfo> {
-  const res = await apiFetch(`/api/v1/sessions/${sessionId}/skip-turn`, { method: 'POST' })
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/skip-turn`, {
+    method: 'POST',
+  });
   if (!res.ok) {
-    const err = await res.json()
-    throw new Error(err.error || 'Failed to skip track')
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to skip track');
   }
-  return res.json()
+  return res.json();
 }
 
 export async function listRaces(sessionId: string): Promise<RaceInfo[]> {
-  const res = await apiFetch(`/api/v1/sessions/${sessionId}/races`)
-  if (!res.ok) return []
-  return res.json()
+  const res = await apiFetch(`/api/v1/sessions/${sessionId}/races`);
+  if (!res.ok) return [];
+  return res.json();
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,164 +1,164 @@
 export interface SimpleItem {
-  id: number
-  name: string
-  image_path: string
+  id: number;
+  name: string;
+  image_path: string;
 }
 
 export interface TrackItem {
-  id: number
-  name: string
-  cup_id: number
-  position: number
-  image_path: string
+  id: number;
+  name: string;
+  cup_id: number;
+  position: number;
+  image_path: string;
 }
 
 export interface CupWithTracks {
-  id: number
-  name: string
-  image_path: string
-  tracks: TrackItem[]
+  id: number;
+  name: string;
+  image_path: string;
+  tracks: TrackItem[];
 }
 
 export interface DrinkType {
-  id: string
-  name: string
-  alcoholic: boolean
-  created_by: string | null
-  created_at: string
+  id: string;
+  name: string;
+  alcoholic: boolean;
+  created_by: string | null;
+  created_at: string;
 }
 
 export interface DrinkTypeInfo {
-  id: string
-  name: string
-  alcoholic: boolean
+  id: string;
+  name: string;
+  alcoholic: boolean;
 }
 
 export interface UserPublicProfile {
-  id: string
-  username: string
-  preferred_character_id: number | null
-  preferred_body_id: number | null
-  preferred_wheel_id: number | null
-  preferred_glider_id: number | null
-  preferred_drink_type_id: string | null
-  created_at: string
+  id: string;
+  username: string;
+  preferred_character_id: number | null;
+  preferred_body_id: number | null;
+  preferred_wheel_id: number | null;
+  preferred_glider_id: number | null;
+  preferred_drink_type_id: string | null;
+  created_at: string;
 }
 
 export interface UserDetailProfile {
-  id: string
-  username: string
-  preferred_character_id: number | null
-  preferred_body_id: number | null
-  preferred_wheel_id: number | null
-  preferred_glider_id: number | null
-  preferred_drink_type: DrinkTypeInfo | null
-  created_at: string
+  id: string;
+  username: string;
+  preferred_character_id: number | null;
+  preferred_body_id: number | null;
+  preferred_wheel_id: number | null;
+  preferred_glider_id: number | null;
+  preferred_drink_type: DrinkTypeInfo | null;
+  created_at: string;
 }
 
 export interface RaceSetup {
-  preferred_character_id: number
-  preferred_body_id: number
-  preferred_wheel_id: number
-  preferred_glider_id: number
+  preferred_character_id: number;
+  preferred_body_id: number;
+  preferred_wheel_id: number;
+  preferred_glider_id: number;
 }
 
 export interface SessionSummary {
-  id: string
-  host_username: string
-  participant_count: number
-  race_number: number
-  ruleset: string
+  id: string;
+  host_username: string;
+  participant_count: number;
+  race_number: number;
+  ruleset: string;
 }
 
 export interface ParticipantInfo {
-  user_id: string
-  username: string
-  joined_at: string
-  left_at: string | null
+  user_id: string;
+  username: string;
+  joined_at: string;
+  left_at: string | null;
 }
 
 export interface RaceSubmission {
-  user_id: string
-  username: string
-  track_time: number
-  disqualified: boolean
+  user_id: string;
+  username: string;
+  track_time: number;
+  disqualified: boolean;
 }
 
 export interface SessionRaceInfo {
-  id: string
-  race_number: number
-  track_id: number
-  track_name: string
-  cup_name: string
-  image_path: string
-  created_at: string
-  submissions: RaceSubmission[]
+  id: string;
+  race_number: number;
+  track_id: number;
+  track_name: string;
+  cup_name: string;
+  image_path: string;
+  created_at: string;
+  submissions: RaceSubmission[];
 }
 
 export interface CreateRunRequest {
-  session_race_id: string
-  track_time: number
-  lap1_time: number
-  lap2_time: number
-  lap3_time: number
-  character_id: number
-  body_id: number
-  wheel_id: number
-  glider_id: number
-  drink_type_id: string
-  disqualified: boolean
+  session_race_id: string;
+  track_time: number;
+  lap1_time: number;
+  lap2_time: number;
+  lap3_time: number;
+  character_id: number;
+  body_id: number;
+  wheel_id: number;
+  glider_id: number;
+  drink_type_id: string;
+  disqualified: boolean;
 }
 
 export interface RunDetail {
-  id: string
-  user_id: string
-  username: string
-  session_race_id: string
-  track_id: number
-  track_time: number
-  lap1_time: number
-  lap2_time: number
-  lap3_time: number
-  character_id: number
-  body_id: number
-  wheel_id: number
-  glider_id: number
-  drink_type_id: string
-  drink_type_name: string
-  disqualified: boolean
-  created_at: string
+  id: string;
+  user_id: string;
+  username: string;
+  session_race_id: string;
+  track_id: number;
+  track_time: number;
+  lap1_time: number;
+  lap2_time: number;
+  lap3_time: number;
+  character_id: number;
+  body_id: number;
+  wheel_id: number;
+  glider_id: number;
+  drink_type_id: string;
+  drink_type_name: string;
+  disqualified: boolean;
+  created_at: string;
 }
 
 export interface RunDefaults {
-  drink_type_id: string | null
-  character_id: number | null
-  body_id: number | null
-  wheel_id: number | null
-  glider_id: number | null
-  source: 'previous_run' | 'preferences' | 'none'
+  drink_type_id: string | null;
+  character_id: number | null;
+  body_id: number | null;
+  wheel_id: number | null;
+  glider_id: number | null;
+  source: 'previous_run' | 'preferences' | 'none';
 }
 
 export interface RaceInfo {
-  id: string
-  race_number: number
-  track_id: number
-  track_name: string
-  cup_name: string
-  run_count: number
-  created_at: string
+  id: string;
+  race_number: number;
+  track_id: number;
+  track_name: string;
+  cup_name: string;
+  run_count: number;
+  created_at: string;
 }
 
 export interface SessionDetail {
-  id: string
-  host_id: string
-  host_username: string
-  ruleset: string
-  status: string
-  created_at: string
-  participants: ParticipantInfo[]
-  race_number: number
-  current_race: SessionRaceInfo | null
-  races: RaceInfo[]
+  id: string;
+  host_id: string;
+  host_username: string;
+  ruleset: string;
+  status: string;
+  created_at: string;
+  participants: ParticipantInfo[];
+  race_number: number;
+  current_race: SessionRaceInfo | null;
+  races: RaceInfo[];
 }
 
 // ── Notifications (ADR-0038) ──────────────────────────────────────────
@@ -169,23 +169,23 @@ export interface SessionDetail {
 // whenever a variant is added on the Rust side.
 
 export interface PendingRacesDroppedPayload {
-  kind: 'pending_races_dropped'
-  session_id: string
-  dropped_count: number
+  kind: 'pending_races_dropped';
+  session_id: string;
+  dropped_count: number;
 }
 
 // Discriminated union of notification payload kinds. MVP carries one
 // variant; future kinds (h2h_lead_changed, track_record_lost,
 // leaderboard_rank_changed) join this union as they land.
-export type NotificationPayload = PendingRacesDroppedPayload
+export type NotificationPayload = PendingRacesDroppedPayload;
 
 export interface Notification {
-  id: string
-  created_at: string
-  read_at: string | null
-  payload: NotificationPayload
+  id: string;
+  created_at: string;
+  read_at: string | null;
+  payload: NotificationPayload;
 }
 
 export interface UnreadCountResponse {
-  count: number
+  count: number;
 }

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,23 +1,23 @@
-import { useEffect, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { getMySession } from '../api/sessions'
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { getMySession } from '../api/sessions';
 
 export default function BottomNav() {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const [mySessionId, setMySessionId] = useState<string | null>(null)
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [mySessionId, setMySessionId] = useState<string | null>(null);
 
   // Re-check active session on navigation so the tab stays in sync
   useEffect(() => {
-    getMySession().then(setMySessionId)
-  }, [location.pathname])
+    getMySession().then(setMySessionId);
+  }, [location.pathname]);
 
-  const sessionMatch = location.pathname.match(/^\/session\/(.+)$/)
+  const sessionMatch = location.pathname.match(/^\/session\/(.+)$/);
   const sessionPath = sessionMatch
     ? location.pathname
     : mySessionId
       ? `/session/${mySessionId}`
-      : null
+      : null;
 
   const tabs = [
     { path: '/', label: 'Home', icon: '\uD83C\uDFE0', disabled: false },
@@ -27,14 +27,22 @@ export default function BottomNav() {
       icon: '\uD83C\uDFAE',
       disabled: !sessionPath,
     },
-    { path: '/profile', label: 'Profile', icon: '\uD83D\uDC64', disabled: false },
-  ]
+    {
+      path: '/profile',
+      label: 'Profile',
+      icon: '\uD83D\uDC64',
+      disabled: false,
+    },
+  ];
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-pb">
       <div className="flex max-w-lg mx-auto">
         {tabs.map((tab) => {
-          const isActive = tab.label === 'Session' ? !!sessionMatch : location.pathname === tab.path
+          const isActive =
+            tab.label === 'Session'
+              ? !!sessionMatch
+              : location.pathname === tab.path;
 
           return (
             <button
@@ -50,11 +58,13 @@ export default function BottomNav() {
               }`}
             >
               <span className="text-xl leading-none">{tab.icon}</span>
-              <span className="text-[10px] font-medium mt-0.5">{tab.label}</span>
+              <span className="text-[10px] font-medium mt-0.5">
+                {tab.label}
+              </span>
             </button>
-          )
+          );
         })}
       </div>
     </nav>
-  )
+  );
 }

--- a/frontend/src/components/DrinkTypeSelector.tsx
+++ b/frontend/src/components/DrinkTypeSelector.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react'
-import { useDrinkTypes } from '../hooks/useGameData'
-import { apiFetch } from '../api/client'
-import type { DrinkType } from '../api/types'
+import { useState } from 'react';
+import { useDrinkTypes } from '../hooks/useGameData';
+import { apiFetch } from '../api/client';
+import type { DrinkType } from '../api/types';
 
 interface DrinkTypeSelectorProps {
-  selectedId?: string | null
-  onSelect: (drinkType: DrinkType) => void
-  onSkip?: () => void
+  selectedId?: string | null;
+  onSelect: (drinkType: DrinkType) => void;
+  onSkip?: () => void;
 }
 
 export default function DrinkTypeSelector({
@@ -14,47 +14,53 @@ export default function DrinkTypeSelector({
   onSelect,
   onSkip,
 }: DrinkTypeSelectorProps) {
-  const { items, loading, refresh } = useDrinkTypes()
-  const [showAddForm, setShowAddForm] = useState(false)
-  const [newName, setNewName] = useState('')
-  const [newAlcoholic, setNewAlcoholic] = useState(true)
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { items, loading, refresh } = useDrinkTypes();
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newAlcoholic, setNewAlcoholic] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (loading) {
-    return <div className="text-center text-gray-400 py-8">Loading drink types...</div>
+    return (
+      <div className="text-center text-gray-400 py-8">
+        Loading drink types...
+      </div>
+    );
   }
 
   async function handleAdd() {
-    if (!newName.trim()) return
-    setSubmitting(true)
-    setError(null)
+    if (!newName.trim()) return;
+    setSubmitting(true);
+    setError(null);
     try {
       const res = await apiFetch('/api/v1/drink-types', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: newName.trim(), alcoholic: newAlcoholic }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setError(data.error || 'Failed to add drink type')
-        return
+        const data = await res.json();
+        setError(data.error || 'Failed to add drink type');
+        return;
       }
-      const created: DrinkType = await res.json()
-      refresh()
-      onSelect(created)
-      setShowAddForm(false)
-      setNewName('')
+      const created: DrinkType = await res.json();
+      refresh();
+      onSelect(created);
+      setShowAddForm(false);
+      setNewName('');
     } catch {
-      setError('Network error')
+      setError('Network error');
     } finally {
-      setSubmitting(false)
+      setSubmitting(false);
     }
   }
 
   return (
     <div className="flex flex-col">
-      <h3 className="text-sm font-semibold text-gray-700 mb-2 px-1">What are you drinking?</h3>
+      <h3 className="text-sm font-semibold text-gray-700 mb-2 px-1">
+        What are you drinking?
+      </h3>
 
       <div className="space-y-1.5 max-h-64 overflow-y-auto mb-3">
         {items.map((dt) => (
@@ -67,15 +73,21 @@ export default function DrinkTypeSelector({
                 : 'border-transparent bg-white hover:border-gray-200'
             }`}
           >
-            <span className="text-lg">{dt.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}</span>
+            <span className="text-lg">
+              {dt.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
+            </span>
             <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium text-gray-900 truncate">{dt.name}</div>
+              <div className="text-sm font-medium text-gray-900 truncate">
+                {dt.name}
+              </div>
               <div className="text-xs text-gray-400">
                 {dt.alcoholic ? 'Alcoholic' : 'Non-alcoholic'}
               </div>
             </div>
             {selectedId === dt.id && (
-              <span className="text-blue-500 text-sm font-bold">{'\u2713'}</span>
+              <span className="text-blue-500 text-sm font-bold">
+                {'\u2713'}
+              </span>
             )}
           </button>
         ))}
@@ -120,8 +132,8 @@ export default function DrinkTypeSelector({
           <div className="flex gap-2">
             <button
               onClick={() => {
-                setShowAddForm(false)
-                setError(null)
+                setShowAddForm(false);
+                setError(null);
               }}
               className="flex-1 py-2 text-xs font-medium text-gray-500 bg-gray-200 rounded-lg"
             >
@@ -147,5 +159,5 @@ export default function DrinkTypeSelector({
         </button>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/components/RaceSetupPicker.tsx
+++ b/frontend/src/components/RaceSetupPicker.tsx
@@ -1,30 +1,35 @@
-import { useState } from 'react'
-import { useCharacters, useBodies, useWheels, useGliders } from '../hooks/useGameData'
-import type { SimpleItem } from '../api/types'
+import { useState } from 'react';
+import {
+  useCharacters,
+  useBodies,
+  useWheels,
+  useGliders,
+} from '../hooks/useGameData';
+import type { SimpleItem } from '../api/types';
 
 interface RaceSetupPickerProps {
-  initialCharacterId?: number | null
-  initialBodyId?: number | null
-  initialWheelId?: number | null
-  initialGliderId?: number | null
+  initialCharacterId?: number | null;
+  initialBodyId?: number | null;
+  initialWheelId?: number | null;
+  initialGliderId?: number | null;
   onComplete: (setup: {
-    characterId: number
-    bodyId: number
-    wheelId: number
-    gliderId: number
-  }) => void
-  onSkip?: () => void
-  submitLabel?: string
+    characterId: number;
+    bodyId: number;
+    wheelId: number;
+    gliderId: number;
+  }) => void;
+  onSkip?: () => void;
+  submitLabel?: string;
 }
 
-type Step = 'character' | 'body' | 'wheel' | 'glider'
-const STEPS: Step[] = ['character', 'body', 'wheel', 'glider']
+type Step = 'character' | 'body' | 'wheel' | 'glider';
+const STEPS: Step[] = ['character', 'body', 'wheel', 'glider'];
 const STEP_LABELS: Record<Step, string> = {
   character: 'Character',
   body: 'Body',
   wheel: 'Wheels',
   glider: 'Glider',
-}
+};
 
 export default function RaceSetupPicker({
   initialCharacterId,
@@ -35,65 +40,75 @@ export default function RaceSetupPicker({
   onSkip,
   submitLabel = 'Confirm Setup',
 }: RaceSetupPickerProps) {
-  const { items: characters, loading: loadingChars } = useCharacters()
-  const { items: bodies, loading: loadingBodies } = useBodies()
-  const { items: wheels, loading: loadingWheels } = useWheels()
-  const { items: gliders, loading: loadingGliders } = useGliders()
+  const { items: characters, loading: loadingChars } = useCharacters();
+  const { items: bodies, loading: loadingBodies } = useBodies();
+  const { items: wheels, loading: loadingWheels } = useWheels();
+  const { items: gliders, loading: loadingGliders } = useGliders();
 
-  const [step, setStep] = useState<Step>('character')
-  const [characterId, setCharacterId] = useState<number | null>(initialCharacterId ?? null)
-  const [bodyId, setBodyId] = useState<number | null>(initialBodyId ?? null)
-  const [wheelId, setWheelId] = useState<number | null>(initialWheelId ?? null)
-  const [gliderId, setGliderId] = useState<number | null>(initialGliderId ?? null)
+  const [step, setStep] = useState<Step>('character');
+  const [characterId, setCharacterId] = useState<number | null>(
+    initialCharacterId ?? null,
+  );
+  const [bodyId, setBodyId] = useState<number | null>(initialBodyId ?? null);
+  const [wheelId, setWheelId] = useState<number | null>(initialWheelId ?? null);
+  const [gliderId, setGliderId] = useState<number | null>(
+    initialGliderId ?? null,
+  );
 
-  const loading = loadingChars || loadingBodies || loadingWheels || loadingGliders
+  const loading =
+    loadingChars || loadingBodies || loadingWheels || loadingGliders;
 
   if (loading) {
-    return <div className="text-center text-gray-400 py-8">Loading game data...</div>
+    return (
+      <div className="text-center text-gray-400 py-8">Loading game data...</div>
+    );
   }
 
-  const currentStepIndex = STEPS.indexOf(step)
+  const currentStepIndex = STEPS.indexOf(step);
 
   const itemsForStep: Record<Step, SimpleItem[]> = {
     character: characters,
     body: bodies,
     wheel: wheels,
     glider: gliders,
-  }
+  };
 
   const selectedForStep: Record<Step, number | null> = {
     character: characterId,
     body: bodyId,
     wheel: wheelId,
     glider: gliderId,
-  }
+  };
 
   const setterForStep: Record<Step, (id: number) => void> = {
     character: setCharacterId,
     body: setBodyId,
     wheel: setWheelId,
     glider: setGliderId,
-  }
+  };
 
-  const items = itemsForStep[step]
-  const selected = selectedForStep[step]
+  const items = itemsForStep[step];
+  const selected = selectedForStep[step];
 
   function handleSelect(id: number) {
-    setterForStep[step](id)
+    setterForStep[step](id);
     // Auto-advance to next step after selection
     if (currentStepIndex < STEPS.length - 1) {
-      setTimeout(() => setStep(STEPS[currentStepIndex + 1]), 150)
+      setTimeout(() => setStep(STEPS[currentStepIndex + 1]), 150);
     }
   }
 
   function handleBack() {
     if (currentStepIndex > 0) {
-      setStep(STEPS[currentStepIndex - 1])
+      setStep(STEPS[currentStepIndex - 1]);
     }
   }
 
   const allSelected =
-    characterId !== null && bodyId !== null && wheelId !== null && gliderId !== null
+    characterId !== null &&
+    bodyId !== null &&
+    wheelId !== null &&
+    gliderId !== null;
 
   return (
     <div className="flex flex-col h-full">
@@ -123,7 +138,10 @@ export default function RaceSetupPicker({
           Pick your {STEP_LABELS[step].toLowerCase()}
         </h3>
         {currentStepIndex > 0 && (
-          <button onClick={handleBack} className="text-xs text-blue-500 font-medium">
+          <button
+            onClick={handleBack}
+            className="text-xs text-blue-500 font-medium"
+          >
             &larr; Back
           </button>
         )}
@@ -174,7 +192,7 @@ export default function RaceSetupPicker({
                 bodyId: bodyId!,
                 wheelId: wheelId!,
                 gliderId: gliderId!,
-              })
+              });
             }
           }}
           disabled={!allSelected}
@@ -188,5 +206,5 @@ export default function RaceSetupPicker({
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -1,118 +1,158 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
-import type { SessionRaceInfo, CreateRunRequest, RunDefaults, DrinkType } from '../api/types'
-import { createRun, getRunDefaults } from '../api/runs'
-import { parseTimeFields } from '../utils/time'
-import { useDrinkTypes } from '../hooks/useGameData'
-import { useCharacters, useBodies, useWheels, useGliders } from '../hooks/useGameData'
-import DrinkTypeSelector from './DrinkTypeSelector'
-import RaceSetupPicker from './RaceSetupPicker'
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import type {
+  SessionRaceInfo,
+  CreateRunRequest,
+  RunDefaults,
+  DrinkType,
+} from '../api/types';
+import { createRun, getRunDefaults } from '../api/runs';
+import { parseTimeFields } from '../utils/time';
+import { useDrinkTypes } from '../hooks/useGameData';
+import {
+  useCharacters,
+  useBodies,
+  useWheels,
+  useGliders,
+} from '../hooks/useGameData';
+import DrinkTypeSelector from './DrinkTypeSelector';
+import RaceSetupPicker from './RaceSetupPicker';
 
 interface TimeFields {
-  m: string
-  ss: string
-  mmm: string
+  m: string;
+  ss: string;
+  mmm: string;
 }
 
-const emptyTime: TimeFields = { m: '', ss: '', mmm: '' }
+const emptyTime: TimeFields = { m: '', ss: '', mmm: '' };
 
 interface RunEntrySheetProps {
-  race: SessionRaceInfo
-  onClose: () => void
-  onSubmitted: () => void
+  race: SessionRaceInfo;
+  onClose: () => void;
+  onSubmitted: () => void;
 }
 
-export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySheetProps) {
-  const [totalTime, setTotalTime] = useState<TimeFields>(emptyTime)
-  const [lap1, setLap1] = useState<TimeFields>(emptyTime)
-  const [lap2, setLap2] = useState<TimeFields>(emptyTime)
-  const [lap3, setLap3] = useState<TimeFields>(emptyTime)
+export default function RunEntrySheet({
+  race,
+  onClose,
+  onSubmitted,
+}: RunEntrySheetProps) {
+  const [totalTime, setTotalTime] = useState<TimeFields>(emptyTime);
+  const [lap1, setLap1] = useState<TimeFields>(emptyTime);
+  const [lap2, setLap2] = useState<TimeFields>(emptyTime);
+  const [lap3, setLap3] = useState<TimeFields>(emptyTime);
 
-  const [drinkTypeId, setDrinkTypeId] = useState<string | null>(null)
-  const [drinkType, setDrinkType] = useState<DrinkType | null>(null)
-  const [characterId, setCharacterId] = useState<number | null>(null)
-  const [bodyId, setBodyId] = useState<number | null>(null)
-  const [wheelId, setWheelId] = useState<number | null>(null)
-  const [gliderId, setGliderId] = useState<number | null>(null)
-  const [defaultsSource, setDefaultsSource] = useState<string>('')
+  const [drinkTypeId, setDrinkTypeId] = useState<string | null>(null);
+  const [drinkType, setDrinkType] = useState<DrinkType | null>(null);
+  const [characterId, setCharacterId] = useState<number | null>(null);
+  const [bodyId, setBodyId] = useState<number | null>(null);
+  const [wheelId, setWheelId] = useState<number | null>(null);
+  const [gliderId, setGliderId] = useState<number | null>(null);
+  const [defaultsSource, setDefaultsSource] = useState<string>('');
 
-  const [dq, setDq] = useState(false)
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [dq, setDq] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const totalMmmRef = useRef<HTMLInputElement>(null)
-  const lap1MRef = useRef<HTMLInputElement>(null)
-  const lap1MmmRef = useRef<HTMLInputElement>(null)
-  const lap2MRef = useRef<HTMLInputElement>(null)
-  const lap2MmmRef = useRef<HTMLInputElement>(null)
-  const lap3MRef = useRef<HTMLInputElement>(null)
+  const totalMmmRef = useRef<HTMLInputElement>(null);
+  const lap1MRef = useRef<HTMLInputElement>(null);
+  const lap1MmmRef = useRef<HTMLInputElement>(null);
+  const lap2MRef = useRef<HTMLInputElement>(null);
+  const lap2MmmRef = useRef<HTMLInputElement>(null);
+  const lap3MRef = useRef<HTMLInputElement>(null);
 
-  const [showDrinkPicker, setShowDrinkPicker] = useState(false)
-  const [showSetupPicker, setShowSetupPicker] = useState(false)
+  const [showDrinkPicker, setShowDrinkPicker] = useState(false);
+  const [showSetupPicker, setShowSetupPicker] = useState(false);
 
   // Load game data for resolving default names
-  const { items: drinkTypes } = useDrinkTypes()
-  const { items: characters } = useCharacters()
-  const { items: bodies } = useBodies()
-  const { items: wheels } = useWheels()
-  const { items: gliders } = useGliders()
+  const { items: drinkTypes } = useDrinkTypes();
+  const { items: characters } = useCharacters();
+  const { items: bodies } = useBodies();
+  const { items: wheels } = useWheels();
+  const { items: gliders } = useGliders();
 
   // Load defaults on mount
   useEffect(() => {
     getRunDefaults().then((d: RunDefaults) => {
-      setDrinkTypeId(d.drink_type_id)
-      setCharacterId(d.character_id)
-      setBodyId(d.body_id)
-      setWheelId(d.wheel_id)
-      setGliderId(d.glider_id)
+      setDrinkTypeId(d.drink_type_id);
+      setCharacterId(d.character_id);
+      setBodyId(d.body_id);
+      setWheelId(d.wheel_id);
+      setGliderId(d.glider_id);
       setDefaultsSource(
         d.source === 'previous_run'
           ? 'From your last run'
           : d.source === 'preferences'
             ? 'From your preferences'
             : '',
-      )
-    })
-  }, [])
+      );
+    });
+  }, []);
 
   // Derive drink type object from ID + loaded data (or explicit user pick)
   const resolvedDrinkType = useMemo(() => {
-    if (drinkType) return drinkType
+    if (drinkType) return drinkType;
     if (drinkTypeId && drinkTypes.length > 0) {
-      return drinkTypes.find((dt) => dt.id === drinkTypeId) ?? null
+      return drinkTypes.find((dt) => dt.id === drinkTypeId) ?? null;
     }
-    return null
-  }, [drinkType, drinkTypeId, drinkTypes])
+    return null;
+  }, [drinkType, drinkTypeId, drinkTypes]);
 
   // Derive setup summary from IDs + loaded game data
   const setupSummary = useMemo(() => {
-    if (!characterId || !characters.length || !bodies.length || !wheels.length || !gliders.length)
-      return ''
+    if (
+      !characterId ||
+      !characters.length ||
+      !bodies.length ||
+      !wheels.length ||
+      !gliders.length
+    )
+      return '';
     const parts = [
       characters.find((c) => c.id === characterId)?.name,
       bodies.find((b) => b.id === bodyId)?.name,
       wheels.find((w) => w.id === wheelId)?.name,
       gliders.find((g) => g.id === gliderId)?.name,
-    ].filter(Boolean)
-    return parts.length === 4 ? parts.join(' \u00B7 ') : ''
-  }, [characterId, bodyId, wheelId, gliderId, characters, bodies, wheels, gliders])
+    ].filter(Boolean);
+    return parts.length === 4 ? parts.join(' \u00B7 ') : '';
+  }, [
+    characterId,
+    bodyId,
+    wheelId,
+    gliderId,
+    characters,
+    bodies,
+    wheels,
+    gliders,
+  ]);
 
-  const parsedTotal = parseTimeFields(totalTime.m, totalTime.ss, totalTime.mmm)
-  const parsedLap1 = parseTimeFields(lap1.m, lap1.ss, lap1.mmm)
-  const parsedLap2 = parseTimeFields(lap2.m, lap2.ss, lap2.mmm)
-  const parsedLap3 = parseTimeFields(lap3.m, lap3.ss, lap3.mmm)
+  const parsedTotal = parseTimeFields(totalTime.m, totalTime.ss, totalTime.mmm);
+  const parsedLap1 = parseTimeFields(lap1.m, lap1.ss, lap1.mmm);
+  const parsedLap2 = parseTimeFields(lap2.m, lap2.ss, lap2.mmm);
+  const parsedLap3 = parseTimeFields(lap3.m, lap3.ss, lap3.mmm);
 
   const allTimesFilled =
-    parsedTotal !== null && parsedLap1 !== null && parsedLap2 !== null && parsedLap3 !== null
-  const hasSetup = characterId !== null && bodyId !== null && wheelId !== null && gliderId !== null
-  const canSubmit = allTimesFilled && drinkTypeId !== null && hasSetup && !submitting
+    parsedTotal !== null &&
+    parsedLap1 !== null &&
+    parsedLap2 !== null &&
+    parsedLap3 !== null;
+  const hasSetup =
+    characterId !== null &&
+    bodyId !== null &&
+    wheelId !== null &&
+    gliderId !== null;
+  const canSubmit =
+    allTimesFilled && drinkTypeId !== null && hasSetup && !submitting;
 
   // Lap sum warning
   const lapSum =
     parsedLap1 !== null && parsedLap2 !== null && parsedLap3 !== null
       ? parsedLap1 + parsedLap2 + parsedLap3
-      : null
-  const sumDiff = lapSum !== null && parsedTotal !== null ? Math.abs(lapSum - parsedTotal) : null
-  const showSumWarning = sumDiff !== null && sumDiff > 0
+      : null;
+  const sumDiff =
+    lapSum !== null && parsedTotal !== null
+      ? Math.abs(lapSum - parsedTotal)
+      : null;
+  const showSumWarning = sumDiff !== null && sumDiff > 0;
 
   const handleSubmit = async () => {
     if (
@@ -127,9 +167,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
       wheelId === null ||
       gliderId === null
     )
-      return
-    setSubmitting(true)
-    setError(null)
+      return;
+    setSubmitting(true);
+    setError(null);
     try {
       const body: CreateRunRequest = {
         session_race_id: race.id,
@@ -143,14 +183,14 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
         glider_id: gliderId,
         drink_type_id: drinkTypeId,
         disqualified: dq,
-      }
-      await createRun(body)
-      onSubmitted()
+      };
+      await createRun(body);
+      onSubmitted();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to submit run')
-      setSubmitting(false)
+      setError(e instanceof Error ? e.message : 'Failed to submit run');
+      setSubmitting(false);
     }
-  }
+  };
 
   return (
     <div className="fixed inset-0 z-30 flex flex-col justify-end">
@@ -173,11 +213,13 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               alt={race.track_name}
               className="w-10 h-10 rounded-lg object-contain bg-gray-100 flex-shrink-0"
               onError={(e) => {
-                ;(e.target as HTMLImageElement).style.display = 'none'
+                (e.target as HTMLImageElement).style.display = 'none';
               }}
             />
             <div>
-              <div className="font-semibold text-gray-900 text-[14px]">{race.track_name}</div>
+              <div className="font-semibold text-gray-900 text-[14px]">
+                {race.track_name}
+              </div>
               <div className="text-[12px] text-gray-500">
                 {race.cup_name} &middot; Race {race.race_number}
               </div>
@@ -205,7 +247,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
             </label>
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L1</span>
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">
+                  L1
+                </span>
                 <div className="flex-1">
                   <TimeInputGroup
                     fields={lap1}
@@ -218,7 +262,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L2</span>
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">
+                  L2
+                </span>
                 <div className="flex-1">
                   <TimeInputGroup
                     fields={lap2}
@@ -231,7 +277,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">L3</span>
+                <span className="text-[11px] font-semibold text-gray-400 w-6 text-right">
+                  L3
+                </span>
                 <div className="flex-1">
                   <TimeInputGroup
                     fields={lap3}
@@ -244,7 +292,8 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
             </div>
             {showSumWarning && sumDiff !== null && (
               <p className="text-[10px] text-amber-600 mt-1.5 text-center">
-                Lap times don&apos;t add up to total (off by {(sumDiff / 1000).toFixed(3)}s)
+                Lap times don&apos;t add up to total (off by{' '}
+                {(sumDiff / 1000).toFixed(3)}s)
               </p>
             )}
             {!showSumWarning && allTimesFilled && (
@@ -266,7 +315,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               {resolvedDrinkType ? (
                 <div className="flex items-center gap-2.5">
                   <span className="text-base">
-                    {resolvedDrinkType.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
+                    {resolvedDrinkType.alcoholic
+                      ? '\uD83C\uDF7A'
+                      : '\uD83E\uDDCA'}
                   </span>
                   <span className="text-[14px] font-medium text-gray-800">
                     {resolvedDrinkType.name}
@@ -280,7 +331,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               <span className="text-gray-400 text-[12px]">Change</span>
             </button>
             {defaultsSource && (
-              <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
+              <p className="text-[10px] text-gray-400 mt-1 px-1">
+                {defaultsSource}
+              </p>
             )}
           </div>
 
@@ -298,12 +351,16 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
                   {setupSummary || 'Setup selected'}
                 </span>
               ) : (
-                <span className="text-[14px] text-gray-400">Select race setup</span>
+                <span className="text-[14px] text-gray-400">
+                  Select race setup
+                </span>
               )}
               <span className="text-gray-400 text-[12px]">Edit</span>
             </button>
             {defaultsSource && (
-              <p className="text-[10px] text-gray-400 mt-1 px-1">{defaultsSource}</p>
+              <p className="text-[10px] text-gray-400 mt-1 px-1">
+                {defaultsSource}
+              </p>
             )}
           </div>
 
@@ -320,7 +377,9 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
             />
           </div>
 
-          {error && <p className="text-xs text-red-500 text-center mb-3">{error}</p>}
+          {error && (
+            <p className="text-xs text-red-500 text-center mb-3">{error}</p>
+          )}
 
           <button
             onClick={handleSubmit}
@@ -335,19 +394,24 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
       {showDrinkPicker && (
         <div className="fixed inset-0 z-50 bg-white flex flex-col">
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-            <button onClick={() => setShowDrinkPicker(false)} className="text-sm text-blue-500">
+            <button
+              onClick={() => setShowDrinkPicker(false)}
+              className="text-sm text-blue-500"
+            >
               Back
             </button>
-            <h2 className="text-sm font-semibold text-gray-900">Select Drink</h2>
+            <h2 className="text-sm font-semibold text-gray-900">
+              Select Drink
+            </h2>
             <div className="w-10" />
           </div>
           <div className="flex-1 overflow-y-auto p-4">
             <DrinkTypeSelector
               selectedId={drinkTypeId}
               onSelect={(dt: DrinkType) => {
-                setDrinkTypeId(dt.id)
-                setDrinkType(dt)
-                setShowDrinkPicker(false)
+                setDrinkTypeId(dt.id);
+                setDrinkType(dt);
+                setShowDrinkPicker(false);
               }}
             />
           </div>
@@ -357,7 +421,10 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
       {showSetupPicker && (
         <div className="fixed inset-0 z-50 bg-white flex flex-col">
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-            <button onClick={() => setShowSetupPicker(false)} className="text-sm text-blue-500">
+            <button
+              onClick={() => setShowSetupPicker(false)}
+              className="text-sm text-blue-500"
+            >
               Back
             </button>
             <h2 className="text-sm font-semibold text-gray-900">Race Setup</h2>
@@ -370,30 +437,30 @@ export default function RunEntrySheet({ race, onClose, onSubmitted }: RunEntrySh
               initialWheelId={wheelId}
               initialGliderId={gliderId}
               onComplete={(setup) => {
-                setCharacterId(setup.characterId)
-                setBodyId(setup.bodyId)
-                setWheelId(setup.wheelId)
-                setGliderId(setup.gliderId)
-                setShowSetupPicker(false)
+                setCharacterId(setup.characterId);
+                setBodyId(setup.bodyId);
+                setWheelId(setup.wheelId);
+                setGliderId(setup.gliderId);
+                setShowSetupPicker(false);
               }}
             />
           </div>
         </div>
       )}
     </div>
-  )
+  );
 }
 
 // ── Time Input Group (self-contained with auto-advance) ─────────────
 
 interface TimeInputGroupProps {
-  fields: TimeFields
-  setFields: React.Dispatch<React.SetStateAction<TimeFields>>
-  large?: boolean
-  mRef?: React.RefObject<HTMLInputElement | null>
-  mmmRef?: React.RefObject<HTMLInputElement | null>
-  onComplete?: () => void
-  onBackspace?: () => void
+  fields: TimeFields;
+  setFields: React.Dispatch<React.SetStateAction<TimeFields>>;
+  large?: boolean;
+  mRef?: React.RefObject<HTMLInputElement | null>;
+  mmmRef?: React.RefObject<HTMLInputElement | null>;
+  onComplete?: () => void;
+  onBackspace?: () => void;
 }
 
 function TimeInputGroup({
@@ -405,51 +472,54 @@ function TimeInputGroup({
   onComplete,
   onBackspace,
 }: TimeInputGroupProps) {
-  const fallbackMRef = useRef<HTMLInputElement>(null)
-  const ssRef = useRef<HTMLInputElement>(null)
-  const fallbackMmmRef = useRef<HTMLInputElement>(null)
-  const resolvedMRef = mRef ?? fallbackMRef
-  const resolvedMmmRef = extMmmRef ?? fallbackMmmRef
+  const fallbackMRef = useRef<HTMLInputElement>(null);
+  const ssRef = useRef<HTMLInputElement>(null);
+  const fallbackMmmRef = useRef<HTMLInputElement>(null);
+  const resolvedMRef = mRef ?? fallbackMRef;
+  const resolvedMmmRef = extMmmRef ?? fallbackMmmRef;
 
   const inputClass = large
     ? 'h-12 text-center text-xl font-mono bg-gray-100 rounded-xl border border-gray-300 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200'
-    : 'h-10 text-center text-[15px] font-mono bg-gray-50 rounded-lg border border-gray-200 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200'
+    : 'h-10 text-center text-[15px] font-mono bg-gray-50 rounded-lg border border-gray-200 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200';
   const sepClass = large
     ? 'text-xl font-mono text-gray-400 font-bold'
-    : 'text-[15px] font-mono text-gray-300 font-bold'
+    : 'text-[15px] font-mono text-gray-300 font-bold';
 
   const handleChange = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
-      const val = e.target.value.replace(/\D/g, '')
-      if (val.length > maxLen) return
-      setFields((prev) => ({ ...prev, [field]: val }))
+      const val = e.target.value.replace(/\D/g, '');
+      if (val.length > maxLen) return;
+      setFields((prev) => ({ ...prev, [field]: val }));
       if (val.length === maxLen) {
-        if (field === 'm') ssRef.current?.focus()
-        else if (field === 'ss') resolvedMmmRef.current?.focus()
-        else if (field === 'mmm') onComplete?.()
+        if (field === 'm') ssRef.current?.focus();
+        else if (field === 'ss') resolvedMmmRef.current?.focus();
+        else if (field === 'mmm') onComplete?.();
       }
-    }
-  }
+    };
+  };
 
   const advanceFrom = (field: 'm' | 'ss' | 'mmm') => {
-    if (field === 'm') ssRef.current?.focus()
-    else if (field === 'ss') resolvedMmmRef.current?.focus()
-    else if (field === 'mmm') onComplete?.()
-  }
+    if (field === 'm') ssRef.current?.focus();
+    else if (field === 'ss') resolvedMmmRef.current?.focus();
+    else if (field === 'mmm') onComplete?.();
+  };
 
   const handleKeyDown = (field: 'm' | 'ss' | 'mmm', maxLen: number) => {
     return (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Backspace' && e.currentTarget.value === '') {
-        e.preventDefault()
-        if (field === 'mmm') ssRef.current?.focus()
-        else if (field === 'ss') resolvedMRef.current?.focus()
-        else if (field === 'm') onBackspace?.()
-      } else if (/^[0-9]$/.test(e.key) && e.currentTarget.value.length >= maxLen) {
+        e.preventDefault();
+        if (field === 'mmm') ssRef.current?.focus();
+        else if (field === 'ss') resolvedMRef.current?.focus();
+        else if (field === 'm') onBackspace?.();
+      } else if (
+        /^[0-9]$/.test(e.key) &&
+        e.currentTarget.value.length >= maxLen
+      ) {
         // Field is full and user typed a digit — advance focus
-        advanceFrom(field)
+        advanceFrom(field);
       }
-    }
-  }
+    };
+  };
 
   return (
     <div className="flex items-center gap-1.5 justify-center">
@@ -489,55 +559,62 @@ function TimeInputGroup({
         maxLength={3}
       />
     </div>
-  )
+  );
 }
 
 // ── Slide to Confirm DQ ─────────────────────────────────────────────
 
 interface SlideToConfirmProps {
-  confirmed: boolean
-  onConfirm: () => void
-  onReset: () => void
+  confirmed: boolean;
+  onConfirm: () => void;
+  onReset: () => void;
 }
 
-function SlideToConfirm({ confirmed, onConfirm, onReset }: SlideToConfirmProps) {
-  const trackRef = useRef<HTMLDivElement>(null)
-  const [dragging, setDragging] = useState(false)
-  const [offsetX, setOffsetX] = useState(0)
-  const [trackWidth, setTrackWidth] = useState(280)
-  const thumbW = 44
+function SlideToConfirm({
+  confirmed,
+  onConfirm,
+  onReset,
+}: SlideToConfirmProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [offsetX, setOffsetX] = useState(0);
+  const [trackWidth, setTrackWidth] = useState(280);
+  const thumbW = 44;
 
   // Measure track width after mount and on resize
   useEffect(() => {
     const measure = () => {
-      if (trackRef.current) setTrackWidth(trackRef.current.offsetWidth)
-    }
-    measure()
-    window.addEventListener('resize', measure)
-    return () => window.removeEventListener('resize', measure)
-  }, [])
+      if (trackRef.current) setTrackWidth(trackRef.current.offsetWidth);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
 
   const handleMove = useCallback(
     (clientX: number) => {
-      if (!dragging || confirmed || !trackRef.current) return
-      const rect = trackRef.current.getBoundingClientRect()
-      const x = Math.min(Math.max(0, clientX - rect.left - thumbW / 2), trackWidth - thumbW)
-      setOffsetX(x)
+      if (!dragging || confirmed || !trackRef.current) return;
+      const rect = trackRef.current.getBoundingClientRect();
+      const x = Math.min(
+        Math.max(0, clientX - rect.left - thumbW / 2),
+        trackWidth - thumbW,
+      );
+      setOffsetX(x);
     },
     [dragging, confirmed, trackWidth],
-  )
+  );
 
   const handleEnd = useCallback(() => {
-    if (!dragging) return
-    setDragging(false)
-    const threshold = trackWidth - thumbW - 4
+    if (!dragging) return;
+    setDragging(false);
+    const threshold = trackWidth - thumbW - 4;
     if (offsetX >= threshold) {
-      setOffsetX(trackWidth - thumbW)
-      onConfirm()
+      setOffsetX(trackWidth - thumbW);
+      onConfirm();
     } else {
-      setOffsetX(0)
+      setOffsetX(0);
     }
-  }, [dragging, offsetX, onConfirm, trackWidth])
+  }, [dragging, offsetX, onConfirm, trackWidth]);
 
   if (confirmed) {
     return (
@@ -546,17 +623,19 @@ function SlideToConfirm({ confirmed, onConfirm, onReset }: SlideToConfirmProps) 
         className="w-full flex items-center justify-between px-3.5 min-h-[48px] bg-red-50 border border-red-200 rounded-xl text-left"
       >
         <div>
-          <div className="text-[14px] font-semibold text-red-700">Disqualified</div>
+          <div className="text-[14px] font-semibold text-red-700">
+            Disqualified
+          </div>
           <div className="text-[11px] text-red-400 mt-0.5">
             Excluded from leaderboards &middot; Tap to undo
           </div>
         </div>
         <span className="text-red-400 text-[18px]">{'\u2715'}</span>
       </button>
-    )
+    );
   }
 
-  const progress = Math.min(offsetX / (trackWidth - thumbW || 1), 1)
+  const progress = Math.min(offsetX / (trackWidth - thumbW || 1), 1);
 
   return (
     <div
@@ -584,15 +663,15 @@ function SlideToConfirm({ confirmed, onConfirm, onReset }: SlideToConfirmProps) 
           transition: dragging ? 'none' : 'left 0.25s ease',
         }}
         onMouseDown={(e) => {
-          e.preventDefault()
-          if (!confirmed) setDragging(true)
+          e.preventDefault();
+          if (!confirmed) setDragging(true);
         }}
         onTouchStart={() => {
-          if (!confirmed) setDragging(true)
+          if (!confirmed) setDragging(true);
         }}
       >
         <span className="text-white text-[16px] font-bold">&raquo;</span>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,58 +1,72 @@
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
-import { getAccessToken, setAccessToken, setOnAuthFailure } from '../api/client'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  getAccessToken,
+  setAccessToken,
+  setOnAuthFailure,
+} from '../api/client';
 
 interface User {
-  id: string
-  username: string
+  id: string;
+  username: string;
 }
 
 interface AuthContextValue {
-  user: User | null
-  isAuthenticated: boolean
-  isLoading: boolean
-  login: (username: string, password: string) => Promise<string | null>
-  register: (username: string, password: string) => Promise<string | null>
-  logout: () => Promise<void>
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (username: string, password: string) => Promise<string | null>;
+  register: (username: string, password: string) => Promise<string | null>;
+  logout: () => Promise<void>;
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null)
+const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const clearAuth = useCallback(() => {
-    setAccessToken(null)
-    setUser(null)
-  }, [])
+    setAccessToken(null);
+    setUser(null);
+  }, []);
 
   // On mount: attempt silent refresh to restore session from the HttpOnly cookie.
   useEffect(() => {
-    setOnAuthFailure(clearAuth)
+    setOnAuthFailure(clearAuth);
 
     async function silentRefresh() {
       try {
-        const res = await fetch('/api/v1/auth/refresh', { method: 'POST' })
+        const res = await fetch('/api/v1/auth/refresh', { method: 'POST' });
         if (res.ok) {
-          const data = await res.json()
-          setAccessToken(data.access_token)
+          const data = await res.json();
+          setAccessToken(data.access_token);
           // Decode the access token to get user info (the payload is the
           // middle segment, base64url-encoded). This avoids an extra API call.
           // JWT payloads use base64url encoding (- and _ instead of + and /),
           // but atob() only handles standard base64 — convert before decoding.
-          const base64 = data.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
-          const payload = JSON.parse(atob(base64))
-          setUser({ id: payload.sub, username: payload.username })
+          const base64 = data.access_token
+            .split('.')[1]
+            .replace(/-/g, '+')
+            .replace(/_/g, '/');
+          const payload = JSON.parse(atob(base64));
+          setUser({ id: payload.sub, username: payload.username });
         }
       } catch {
         // No valid refresh cookie — user needs to log in
       } finally {
-        setIsLoading(false)
+        setIsLoading(false);
       }
     }
 
-    silentRefresh()
-  }, [clearAuth])
+    silentRefresh();
+  }, [clearAuth]);
 
   /** Returns an error message on failure, or null on success. */
   const login = useCallback(async (username: string, password: string) => {
@@ -60,15 +74,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
-    })
+    });
 
-    const data = await res.json()
-    if (!res.ok) return data.error || 'Login failed'
+    const data = await res.json();
+    if (!res.ok) return data.error || 'Login failed';
 
-    setAccessToken(data.access_token)
-    setUser(data.user)
-    return null
-  }, [])
+    setAccessToken(data.access_token);
+    setUser(data.user);
+    return null;
+  }, []);
 
   /** Returns an error message on failure, or null on success. */
   const register = useCallback(async (username: string, password: string) => {
@@ -76,29 +90,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
-    })
+    });
 
-    const data = await res.json()
-    if (!res.ok) return data.error || 'Registration failed'
+    const data = await res.json();
+    if (!res.ok) return data.error || 'Registration failed';
 
-    setAccessToken(data.access_token)
-    setUser(data.user)
-    return null
-  }, [])
+    setAccessToken(data.access_token);
+    setUser(data.user);
+    return null;
+  }, []);
 
   const logout = useCallback(async () => {
     try {
       // Send the access token so the server can bump refresh_token_version
-      const token = getAccessToken()
+      const token = getAccessToken();
       await fetch('/api/v1/auth/logout', {
         method: 'POST',
         headers: token ? { Authorization: `Bearer ${token}` } : {},
-      })
+      });
     } catch {
       // Even if the server call fails, clear local state
     }
-    clearAuth()
-  }, [clearAuth])
+    clearAuth();
+  }, [clearAuth]);
 
   return (
     <AuthContext.Provider
@@ -113,12 +127,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     >
       {children}
     </AuthContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- co-located with AuthProvider by convention
 export function useAuth() {
-  const ctx = useContext(AuthContext)
-  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
-  return ctx
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
 }

--- a/frontend/src/hooks/useGameData.ts
+++ b/frontend/src/hooks/useGameData.ts
@@ -1,69 +1,69 @@
-import { useCallback, useEffect, useState } from 'react'
-import { apiFetch } from '../api/client'
-import type { DrinkType, SimpleItem } from '../api/types'
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api/client';
+import type { DrinkType, SimpleItem } from '../api/types';
 
 /** Fetches and caches a list of simple game data items. */
 function useSimpleList(endpoint: string) {
-  const [items, setItems] = useState<SimpleItem[]>([])
-  const [loading, setLoading] = useState(true)
+  const [items, setItems] = useState<SimpleItem[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await apiFetch(endpoint)
-        const data = await res.json()
-        setItems(data)
+        const res = await apiFetch(endpoint);
+        const data = await res.json();
+        setItems(data);
       } catch {
         // Silently fail — items stay empty
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
-    load()
-  }, [endpoint])
+    load();
+  }, [endpoint]);
 
-  return { items, loading }
+  return { items, loading };
 }
 
 export function useCharacters() {
-  return useSimpleList('/api/v1/characters')
+  return useSimpleList('/api/v1/characters');
 }
 
 export function useBodies() {
-  return useSimpleList('/api/v1/bodies')
+  return useSimpleList('/api/v1/bodies');
 }
 
 export function useWheels() {
-  return useSimpleList('/api/v1/wheels')
+  return useSimpleList('/api/v1/wheels');
 }
 
 export function useGliders() {
-  return useSimpleList('/api/v1/gliders')
+  return useSimpleList('/api/v1/gliders');
 }
 
 export function useDrinkTypes() {
-  const [items, setItems] = useState<DrinkType[]>([])
-  const [loading, setLoading] = useState(true)
-  const [version, setVersion] = useState(0)
+  const [items, setItems] = useState<DrinkType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [version, setVersion] = useState(0);
 
   const refresh = useCallback(() => {
-    setVersion((v) => v + 1)
-  }, [])
+    setVersion((v) => v + 1);
+  }, []);
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await apiFetch('/api/v1/drink-types')
-        const data = await res.json()
-        setItems(data)
+        const res = await apiFetch('/api/v1/drink-types');
+        const data = await res.json();
+        setItems(data);
       } catch {
         // Silently fail
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
-    load()
-  }, [version])
+    load();
+  }, [version]);
 
-  return { items, loading, refresh }
+  return { items, loading, refresh };
 }

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
-import { getSession } from '../api/sessions'
-import type { SessionDetail } from '../api/types'
+import { useEffect, useRef, useState } from 'react';
+import { getSession } from '../api/sessions';
+import type { SessionDetail } from '../api/types';
 
-const POLL_INTERVAL_MS = 2500
+const POLL_INTERVAL_MS = 2500;
 
 /**
  * Polls GET /sessions/:id every 2.5 seconds.
@@ -10,60 +10,60 @@ const POLL_INTERVAL_MS = 2500
  * Stops polling once the session ends (closed or not found).
  */
 export function useSession(id: string) {
-  const [session, setSession] = useState<SessionDetail | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [ended, setEnded] = useState(false)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const endedRef = useRef(false)
+  const [session, setSession] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [ended, setEnded] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const endedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false
-    endedRef.current = false
+    let cancelled = false;
+    endedRef.current = false;
 
     const stopPolling = () => {
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-    }
+    };
 
     const doFetch = async () => {
-      if (endedRef.current) return
-      const data = await getSession(id)
-      if (cancelled) return
+      if (endedRef.current) return;
+      const data = await getSession(id);
+      if (cancelled) return;
       if (data === null || data.status === 'closed') {
-        endedRef.current = true
-        setEnded(true)
-        stopPolling()
+        endedRef.current = true;
+        setEnded(true);
+        stopPolling();
       }
-      setSession(data)
-      setLoading(false)
-    }
+      setSession(data);
+      setLoading(false);
+    };
 
     const startPolling = () => {
-      if (intervalRef.current || endedRef.current) return
-      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
-    }
+      if (intervalRef.current || endedRef.current) return;
+      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS);
+    };
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        doFetch()
-        startPolling()
+        doFetch();
+        startPolling();
       } else {
-        stopPolling()
+        stopPolling();
       }
-    }
+    };
 
-    doFetch()
-    startPolling()
-    document.addEventListener('visibilitychange', handleVisibility)
+    doFetch();
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
-      cancelled = true
-      stopPolling()
-      document.removeEventListener('visibilitychange', handleVisibility)
-    }
-  }, [id])
+      cancelled = true;
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [id]);
 
-  return { session, loading, ended }
+  return { session, loading, ended };
 }

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,58 +1,60 @@
-import { useEffect, useRef, useState } from 'react'
-import { getMySession, listSessions } from '../api/sessions'
-import type { SessionSummary } from '../api/types'
+import { useEffect, useRef, useState } from 'react';
+import { getMySession, listSessions } from '../api/sessions';
+import type { SessionSummary } from '../api/types';
 
-const POLL_INTERVAL_MS = 5000
+const POLL_INTERVAL_MS = 5000;
 
 /**
  * Fetches the active session list and the user's current session ID.
  * Polls every 5 seconds. Pauses when the tab is backgrounded.
  */
 export function useSessions() {
-  const [sessions, setSessions] = useState<SessionSummary[]>([])
-  const [mySessionId, setMySessionId] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [mySessionId, setMySessionId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     const doFetch = () => {
-      Promise.all([listSessions(), getMySession()]).then(([sessionList, activeId]) => {
-        setSessions(sessionList)
-        setMySessionId(activeId)
-        setLoading(false)
-      })
-    }
+      Promise.all([listSessions(), getMySession()]).then(
+        ([sessionList, activeId]) => {
+          setSessions(sessionList);
+          setMySessionId(activeId);
+          setLoading(false);
+        },
+      );
+    };
 
     const startPolling = () => {
-      if (intervalRef.current) return
-      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS)
-    }
+      if (intervalRef.current) return;
+      intervalRef.current = setInterval(doFetch, POLL_INTERVAL_MS);
+    };
 
     const stopPolling = () => {
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-    }
+    };
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        doFetch()
-        startPolling()
+        doFetch();
+        startPolling();
       } else {
-        stopPolling()
+        stopPolling();
       }
-    }
+    };
 
-    doFetch()
-    startPolling()
-    document.addEventListener('visibilitychange', handleVisibility)
+    doFetch();
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
-      stopPolling()
-      document.removeEventListener('visibilitychange', handleVisibility)
-    }
-  }, [])
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
 
-  return { sessions, mySessionId, loading }
+  return { sessions, mySessionId, loading };
 }

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,32 +1,32 @@
-import { useCallback, useEffect, useState } from 'react'
-import { apiFetch } from '../api/client'
-import type { UserDetailProfile } from '../api/types'
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api/client';
+import type { UserDetailProfile } from '../api/types';
 
 export function useUserProfile(userId: string | undefined) {
-  const [profile, setProfile] = useState<UserDetailProfile | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [version, setVersion] = useState(0)
+  const [profile, setProfile] = useState<UserDetailProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [version, setVersion] = useState(0);
 
   const refresh = useCallback(() => {
-    setVersion((v) => v + 1)
-  }, [])
+    setVersion((v) => v + 1);
+  }, []);
 
   useEffect(() => {
-    if (!userId) return
+    if (!userId) return;
 
     async function load() {
       try {
-        const res = await apiFetch(`/api/v1/users/${userId}`)
-        const data = await res.json()
-        setProfile(data)
+        const res = await apiFetch(`/api/v1/users/${userId}`);
+        const data = await res.json();
+        setProfile(data);
       } catch {
         // Silently fail
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
-    load()
-  }, [userId, version])
+    load();
+  }, [userId, version]);
 
-  return { profile, loading, refresh }
+  return { profile, loading, refresh };
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,44 +1,46 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
-import { useUserProfile } from '../hooks/useUserProfile'
-import { useCharacters } from '../hooks/useGameData'
-import { useSessions } from '../hooks/useSessions'
-import { createSession } from '../api/sessions'
-import BottomNav from '../components/BottomNav'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { useUserProfile } from '../hooks/useUserProfile';
+import { useCharacters } from '../hooks/useGameData';
+import { useSessions } from '../hooks/useSessions';
+import { createSession } from '../api/sessions';
+import BottomNav from '../components/BottomNav';
 
 export default function Home() {
-  const { user } = useAuth()
-  const { profile } = useUserProfile(user?.id)
-  const { items: characters } = useCharacters()
-  const { sessions, mySessionId, loading: sessionsLoading } = useSessions()
-  const navigate = useNavigate()
+  const { user } = useAuth();
+  const { profile } = useUserProfile(user?.id);
+  const { items: characters } = useCharacters();
+  const { sessions, mySessionId, loading: sessionsLoading } = useSessions();
+  const navigate = useNavigate();
 
-  const [showCreate, setShowCreate] = useState(false)
-  const [creating, setCreating] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const preferredChar = characters.find((c) => c.id === profile?.preferred_character_id)
+  const preferredChar = characters.find(
+    (c) => c.id === profile?.preferred_character_id,
+  );
 
   const handleStartButton = () => {
     if (mySessionId) {
-      navigate(`/session/${mySessionId}`)
+      navigate(`/session/${mySessionId}`);
     } else {
-      setShowCreate(true)
+      setShowCreate(true);
     }
-  }
+  };
 
   const handleCreate = async () => {
-    setCreating(true)
-    setError(null)
+    setCreating(true);
+    setError(null);
     try {
-      const session = await createSession('random')
-      navigate(`/session/${session.id}`)
+      const session = await createSession('random');
+      navigate(`/session/${session.id}`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to create session')
-      setCreating(false)
+      setError(e instanceof Error ? e.message : 'Failed to create session');
+      setCreating(false);
     }
-  }
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -79,15 +81,17 @@ export default function Home() {
           <div
             className="fixed inset-0 bg-black/40 z-50 flex items-end justify-center"
             onClick={() => {
-              setShowCreate(false)
-              setError(null)
+              setShowCreate(false);
+              setError(null);
             }}
           >
             <div
               className="bg-white w-full max-w-lg rounded-t-2xl p-5 space-y-4"
               onClick={(e) => e.stopPropagation()}
             >
-              <h2 className="text-base font-bold text-gray-900">Pick a Ruleset</h2>
+              <h2 className="text-base font-bold text-gray-900">
+                Pick a Ruleset
+              </h2>
               <button
                 onClick={handleCreate}
                 disabled={creating}
@@ -98,11 +102,13 @@ export default function Home() {
               <p className="text-xs text-gray-400 text-center">
                 Tracks are chosen randomly each round
               </p>
-              {error && <p className="text-xs text-red-500 text-center">{error}</p>}
+              {error && (
+                <p className="text-xs text-red-500 text-center">{error}</p>
+              )}
               <button
                 onClick={() => {
-                  setShowCreate(false)
-                  setError(null)
+                  setShowCreate(false);
+                  setError(null);
                 }}
                 className="w-full py-2 text-sm text-gray-500"
               >
@@ -123,13 +129,15 @@ export default function Home() {
               Active Sessions
             </h2>
             {sessions.map((s) => {
-              const isMySession = s.id === mySessionId
+              const isMySession = s.id === mySessionId;
               return (
                 <button
                   key={s.id}
                   onClick={() => navigate(`/session/${s.id}`)}
                   className={`w-full rounded-xl border p-4 text-left active:bg-gray-50 transition-colors ${
-                    isMySession ? 'bg-blue-50 border-blue-200' : 'bg-white border-gray-200'
+                    isMySession
+                      ? 'bg-blue-50 border-blue-200'
+                      : 'bg-white border-gray-200'
                   }`}
                 >
                   <div className="flex items-center justify-between">
@@ -146,7 +154,8 @@ export default function Home() {
                       </div>
                       <div className="flex items-center gap-2 mt-1">
                         <span className="text-xs text-gray-400">
-                          {s.participant_count} player{s.participant_count !== 1 ? 's' : ''}
+                          {s.participant_count} player
+                          {s.participant_count !== 1 ? 's' : ''}
                         </span>
                         <span className="text-xs text-gray-400">
                           {'\u00B7'} Race {s.race_number}
@@ -158,21 +167,25 @@ export default function Home() {
                     </span>
                   </div>
                 </button>
-              )
+              );
             })}
           </div>
         ) : (
           <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
             <p className="text-3xl mb-2">{'\uD83C\uDFCE\uFE0F'}</p>
             <p className="text-sm text-gray-500">No active sessions yet</p>
-            <p className="text-xs text-gray-400 mt-1">Start one and invite your friends to join</p>
+            <p className="text-xs text-gray-400 mt-1">
+              Start one and invite your friends to join
+            </p>
           </div>
         )}
 
-        {error && !showCreate && <p className="text-xs text-red-500 text-center">{error}</p>}
+        {error && !showCreate && (
+          <p className="text-xs text-red-500 text-center">{error}</p>
+        )}
       </div>
 
       <BottomNav />
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,27 +1,27 @@
-import { useState, type FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 export default function Login() {
-  const { login } = useAuth()
-  const navigate = useNavigate()
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState(false)
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    setError(null)
-    setSubmitting(true)
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
 
-    const err = await login(username, password)
-    setSubmitting(false)
+    const err = await login(username, password);
+    setSubmitting(false);
 
     if (err) {
-      setError(err)
+      setError(err);
     } else {
-      navigate('/')
+      navigate('/');
     }
   }
 
@@ -36,7 +36,10 @@ export default function Login() {
         {error && <p className="text-red-500 text-sm text-center">{error}</p>}
 
         <div>
-          <label htmlFor="username" className="block text-sm text-gray-600 mb-1">
+          <label
+            htmlFor="username"
+            className="block text-sm text-gray-600 mb-1"
+          >
             Username
           </label>
           <input
@@ -51,7 +54,10 @@ export default function Login() {
         </div>
 
         <div>
-          <label htmlFor="password" className="block text-sm text-gray-600 mb-1">
+          <label
+            htmlFor="password"
+            className="block text-sm text-gray-600 mb-1"
+          >
             Password
           </label>
           <input
@@ -75,11 +81,14 @@ export default function Login() {
 
         <p className="text-sm text-gray-400 text-center">
           Don&apos;t have an account?{' '}
-          <Link to="/register" className="text-blue-500 hover:underline font-medium">
+          <Link
+            to="/register"
+            className="text-blue-500 hover:underline font-medium"
+          >
             Register
           </Link>
         </p>
       </form>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,29 +1,29 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { apiFetch } from '../api/client'
-import { useAuth } from '../hooks/useAuth'
-import RaceSetupPicker from '../components/RaceSetupPicker'
-import DrinkTypeSelector from '../components/DrinkTypeSelector'
-import type { DrinkType } from '../api/types'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api/client';
+import { useAuth } from '../hooks/useAuth';
+import RaceSetupPicker from '../components/RaceSetupPicker';
+import DrinkTypeSelector from '../components/DrinkTypeSelector';
+import type { DrinkType } from '../api/types';
 
-type Phase = 'race-setup' | 'drink-type'
+type Phase = 'race-setup' | 'drink-type';
 
 export default function Onboarding() {
-  const navigate = useNavigate()
-  const { user } = useAuth()
-  const [phase, setPhase] = useState<Phase>('race-setup')
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [phase, setPhase] = useState<Phase>('race-setup');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function saveRaceSetup(setup: {
-    characterId: number
-    bodyId: number
-    wheelId: number
-    gliderId: number
+    characterId: number;
+    bodyId: number;
+    wheelId: number;
+    gliderId: number;
   }) {
-    if (!user) return
-    setSaving(true)
-    setError(null)
+    if (!user) return;
+    setSaving(true);
+    setError(null);
     try {
       const res = await apiFetch(`/api/v1/users/${user.id}`, {
         method: 'PUT',
@@ -34,40 +34,40 @@ export default function Onboarding() {
           preferred_wheel_id: setup.wheelId,
           preferred_glider_id: setup.gliderId,
         }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setError(data.error || 'Failed to save race setup')
-        return
+        const data = await res.json();
+        setError(data.error || 'Failed to save race setup');
+        return;
       }
-      setPhase('drink-type')
+      setPhase('drink-type');
     } catch {
-      setError('Network error — please try again')
+      setError('Network error — please try again');
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function saveDrinkType(dt: DrinkType) {
-    if (!user) return
-    setSaving(true)
-    setError(null)
+    if (!user) return;
+    setSaving(true);
+    setError(null);
     try {
       const res = await apiFetch(`/api/v1/users/${user.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ preferred_drink_type_id: dt.id }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setError(data.error || 'Failed to save drink preference')
-        return
+        const data = await res.json();
+        setError(data.error || 'Failed to save drink preference');
+        return;
       }
-      navigate('/')
+      navigate('/');
     } catch {
-      setError('Network error — please try again')
+      setError('Network error — please try again');
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
@@ -88,7 +88,9 @@ export default function Onboarding() {
 
       {/* Content */}
       <div className="flex-1 flex flex-col min-h-0">
-        {saving && <div className="text-center text-gray-400 py-8">Saving...</div>}
+        {saving && (
+          <div className="text-center text-gray-400 py-8">Saving...</div>
+        )}
 
         {!saving && phase === 'race-setup' && (
           <RaceSetupPicker
@@ -100,10 +102,13 @@ export default function Onboarding() {
 
         {!saving && phase === 'drink-type' && (
           <div className="px-4 flex-1">
-            <DrinkTypeSelector onSelect={saveDrinkType} onSkip={() => navigate('/')} />
+            <DrinkTypeSelector
+              onSelect={saveDrinkType}
+              onSkip={() => navigate('/')}
+            />
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,49 +1,54 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { apiFetch } from '../api/client'
-import { useAuth } from '../hooks/useAuth'
-import { useUserProfile } from '../hooks/useUserProfile'
-import { useCharacters, useBodies, useWheels, useGliders } from '../hooks/useGameData'
-import RaceSetupPicker from '../components/RaceSetupPicker'
-import DrinkTypeSelector from '../components/DrinkTypeSelector'
-import BottomNav from '../components/BottomNav'
-import type { DrinkType } from '../api/types'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api/client';
+import { useAuth } from '../hooks/useAuth';
+import { useUserProfile } from '../hooks/useUserProfile';
+import {
+  useCharacters,
+  useBodies,
+  useWheels,
+  useGliders,
+} from '../hooks/useGameData';
+import RaceSetupPicker from '../components/RaceSetupPicker';
+import DrinkTypeSelector from '../components/DrinkTypeSelector';
+import BottomNav from '../components/BottomNav';
+import type { DrinkType } from '../api/types';
 
-type EditMode = null | 'race-setup' | 'drink-type' | 'password'
+type EditMode = null | 'race-setup' | 'drink-type' | 'password';
 
 export default function Profile() {
-  const navigate = useNavigate()
-  const { user, logout } = useAuth()
-  const { profile, refresh } = useUserProfile(user?.id)
-  const { items: characters } = useCharacters()
-  const { items: bodies } = useBodies()
-  const { items: wheels } = useWheels()
-  const { items: gliders } = useGliders()
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const { profile, refresh } = useUserProfile(user?.id);
+  const { items: characters } = useCharacters();
+  const { items: bodies } = useBodies();
+  const { items: wheels } = useWheels();
+  const { items: gliders } = useGliders();
 
-  const [editMode, setEditMode] = useState<EditMode>(null)
-  const [saving, setSaving] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
+  const [editMode, setEditMode] = useState<EditMode>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Password change state
-  const [currentPassword, setCurrentPassword] = useState('')
-  const [newPassword, setNewPassword] = useState('')
-  const [passwordError, setPasswordError] = useState<string | null>(null)
-  const [passwordSuccess, setPasswordSuccess] = useState(false)
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState(false);
 
-  const char = characters.find((c) => c.id === profile?.preferred_character_id)
-  const body = bodies.find((b) => b.id === profile?.preferred_body_id)
-  const wheel = wheels.find((w) => w.id === profile?.preferred_wheel_id)
-  const glider = gliders.find((g) => g.id === profile?.preferred_glider_id)
+  const char = characters.find((c) => c.id === profile?.preferred_character_id);
+  const body = bodies.find((b) => b.id === profile?.preferred_body_id);
+  const wheel = wheels.find((w) => w.id === profile?.preferred_wheel_id);
+  const glider = gliders.find((g) => g.id === profile?.preferred_glider_id);
 
   async function handleSaveRaceSetup(setup: {
-    characterId: number
-    bodyId: number
-    wheelId: number
-    gliderId: number
+    characterId: number;
+    bodyId: number;
+    wheelId: number;
+    gliderId: number;
   }) {
-    if (!user) return
-    setSaving(true)
-    setSaveError(null)
+    if (!user) return;
+    setSaving(true);
+    setSaveError(null);
     try {
       const res = await apiFetch(`/api/v1/users/${user.id}`, {
         method: 'PUT',
@@ -54,53 +59,53 @@ export default function Profile() {
           preferred_wheel_id: setup.wheelId,
           preferred_glider_id: setup.gliderId,
         }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setSaveError(data.error || 'Failed to save race setup')
-        return
+        const data = await res.json();
+        setSaveError(data.error || 'Failed to save race setup');
+        return;
       }
-      refresh()
-      setEditMode(null)
+      refresh();
+      setEditMode(null);
     } catch {
-      setSaveError('Network error — please try again')
+      setSaveError('Network error — please try again');
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function handleSaveDrinkType(dt: DrinkType) {
-    if (!user) return
-    setSaving(true)
-    setSaveError(null)
+    if (!user) return;
+    setSaving(true);
+    setSaveError(null);
     try {
       const res = await apiFetch(`/api/v1/users/${user.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ preferred_drink_type_id: dt.id }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setSaveError(data.error || 'Failed to save drink preference')
-        return
+        const data = await res.json();
+        setSaveError(data.error || 'Failed to save drink preference');
+        return;
       }
-      refresh()
-      setEditMode(null)
+      refresh();
+      setEditMode(null);
     } catch {
-      setSaveError('Network error — please try again')
+      setSaveError('Network error — please try again');
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function handleChangePassword() {
-    setPasswordError(null)
-    setPasswordSuccess(false)
+    setPasswordError(null);
+    setPasswordSuccess(false);
     if (newPassword.length < 8) {
-      setPasswordError('New password must be at least 8 characters')
-      return
+      setPasswordError('New password must be at least 8 characters');
+      return;
     }
-    setSaving(true)
+    setSaving(true);
     try {
       const res = await apiFetch('/api/v1/auth/password', {
         method: 'PUT',
@@ -109,29 +114,29 @@ export default function Profile() {
           current_password: currentPassword,
           new_password: newPassword,
         }),
-      })
+      });
       if (!res.ok) {
-        const data = await res.json()
-        setPasswordError(data.error || 'Failed to change password')
-        return
+        const data = await res.json();
+        setPasswordError(data.error || 'Failed to change password');
+        return;
       }
-      setPasswordSuccess(true)
-      setCurrentPassword('')
-      setNewPassword('')
+      setPasswordSuccess(true);
+      setCurrentPassword('');
+      setNewPassword('');
       setTimeout(() => {
-        setEditMode(null)
-        setPasswordSuccess(false)
-      }, 1500)
+        setEditMode(null);
+        setPasswordSuccess(false);
+      }, 1500);
     } catch {
-      setPasswordError('Network error')
+      setPasswordError('Network error');
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function handleLogout() {
-    await logout()
-    navigate('/login')
+    await logout();
+    navigate('/login');
   }
 
   if (!profile) {
@@ -139,7 +144,7 @@ export default function Profile() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <p className="text-gray-400">Loading profile...</p>
       </div>
-    )
+    );
   }
 
   // Full-screen edit modes
@@ -147,13 +152,20 @@ export default function Profile() {
     return (
       <div className="min-h-screen bg-gray-50 flex flex-col">
         <div className="px-4 pt-4 pb-2 flex items-center">
-          <button onClick={() => setEditMode(null)} className="text-blue-500 text-sm font-medium">
+          <button
+            onClick={() => setEditMode(null)}
+            className="text-blue-500 text-sm font-medium"
+          >
             &larr; Back
           </button>
-          <h2 className="flex-1 text-center text-base font-semibold text-gray-900">Race Setup</h2>
+          <h2 className="flex-1 text-center text-base font-semibold text-gray-900">
+            Race Setup
+          </h2>
           <div className="w-12" />
         </div>
-        {saveError && <p className="text-red-500 text-sm text-center px-4">{saveError}</p>}
+        {saveError && (
+          <p className="text-red-500 text-sm text-center px-4">{saveError}</p>
+        )}
         <div className="flex-1 flex flex-col min-h-0">
           {saving ? (
             <div className="text-center text-gray-400 py-8">Saving...</div>
@@ -169,14 +181,17 @@ export default function Profile() {
           )}
         </div>
       </div>
-    )
+    );
   }
 
   if (editMode === 'drink-type') {
     return (
       <div className="min-h-screen bg-gray-50 flex flex-col">
         <div className="px-4 pt-4 pb-2 flex items-center">
-          <button onClick={() => setEditMode(null)} className="text-blue-500 text-sm font-medium">
+          <button
+            onClick={() => setEditMode(null)}
+            className="text-blue-500 text-sm font-medium"
+          >
             &larr; Back
           </button>
           <h2 className="flex-1 text-center text-base font-semibold text-gray-900">
@@ -184,7 +199,9 @@ export default function Profile() {
           </h2>
           <div className="w-12" />
         </div>
-        {saveError && <p className="text-red-500 text-sm text-center px-4">{saveError}</p>}
+        {saveError && (
+          <p className="text-red-500 text-sm text-center px-4">{saveError}</p>
+        )}
         <div className="flex-1 px-4 pt-2">
           {saving ? (
             <div className="text-center text-gray-400 py-8">Saving...</div>
@@ -196,7 +213,7 @@ export default function Profile() {
           )}
         </div>
       </div>
-    )
+    );
   }
 
   // Default: profile view
@@ -253,17 +270,27 @@ export default function Profile() {
           className="w-full bg-white rounded-xl border border-gray-200 p-4 text-left"
         >
           <div className="flex items-center justify-between mb-1">
-            <h3 className="text-sm font-semibold text-gray-700">Preferred Drink</h3>
+            <h3 className="text-sm font-semibold text-gray-700">
+              Preferred Drink
+            </h3>
             <span className="text-xs text-blue-500 font-medium">Edit</span>
           </div>
           {profile.preferred_drink_type ? (
             <div className="flex items-center gap-2">
               <span>
-                {profile.preferred_drink_type.alcoholic ? '\uD83C\uDF7A' : '\uD83E\uDDCA'}
+                {profile.preferred_drink_type.alcoholic
+                  ? '\uD83C\uDF7A'
+                  : '\uD83E\uDDCA'}
               </span>
-              <span className="text-sm text-gray-700">{profile.preferred_drink_type.name}</span>
+              <span className="text-sm text-gray-700">
+                {profile.preferred_drink_type.name}
+              </span>
               <span className="text-xs text-gray-400">
-                ({profile.preferred_drink_type.alcoholic ? 'Alcoholic' : 'Non-alcoholic'})
+                (
+                {profile.preferred_drink_type.alcoholic
+                  ? 'Alcoholic'
+                  : 'Non-alcoholic'}
+                )
               </span>
             </div>
           ) : (
@@ -275,7 +302,9 @@ export default function Profile() {
         <div className="bg-white rounded-xl border border-gray-200 p-4">
           {editMode === 'password' ? (
             <div className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-700">Change Password</h3>
+              <h3 className="text-sm font-semibold text-gray-700">
+                Change Password
+              </h3>
               <input
                 type="password"
                 value={currentPassword}
@@ -290,15 +319,19 @@ export default function Profile() {
                 placeholder="New password (min 8 characters)"
                 className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-blue-400"
               />
-              {passwordError && <p className="text-red-500 text-xs">{passwordError}</p>}
-              {passwordSuccess && <p className="text-green-600 text-xs">Password changed!</p>}
+              {passwordError && (
+                <p className="text-red-500 text-xs">{passwordError}</p>
+              )}
+              {passwordSuccess && (
+                <p className="text-green-600 text-xs">Password changed!</p>
+              )}
               <div className="flex gap-2">
                 <button
                   onClick={() => {
-                    setEditMode(null)
-                    setPasswordError(null)
-                    setCurrentPassword('')
-                    setNewPassword('')
+                    setEditMode(null);
+                    setPasswordError(null);
+                    setCurrentPassword('');
+                    setNewPassword('');
                   }}
                   className="flex-1 py-2 text-xs font-medium text-gray-500 bg-gray-100 rounded-lg"
                 >
@@ -335,5 +368,5 @@ export default function Profile() {
 
       <BottomNav />
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,27 +1,27 @@
-import { useState, type FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 export default function Register() {
-  const { register } = useAuth()
-  const navigate = useNavigate()
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState(false)
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    setError(null)
-    setSubmitting(true)
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
 
-    const err = await register(username, password)
-    setSubmitting(false)
+    const err = await register(username, password);
+    setSubmitting(false);
 
     if (err) {
-      setError(err)
+      setError(err);
     } else {
-      navigate('/onboarding')
+      navigate('/onboarding');
     }
   }
 
@@ -31,12 +31,17 @@ export default function Register() {
         onSubmit={handleSubmit}
         className="w-full max-w-sm space-y-4 bg-white p-6 rounded-xl border border-gray-200 shadow-sm"
       >
-        <h1 className="text-2xl font-bold text-gray-900 text-center">Register</h1>
+        <h1 className="text-2xl font-bold text-gray-900 text-center">
+          Register
+        </h1>
 
         {error && <p className="text-red-500 text-sm text-center">{error}</p>}
 
         <div>
-          <label htmlFor="username" className="block text-sm text-gray-600 mb-1">
+          <label
+            htmlFor="username"
+            className="block text-sm text-gray-600 mb-1"
+          >
             Username
           </label>
           <input
@@ -51,7 +56,10 @@ export default function Register() {
         </div>
 
         <div>
-          <label htmlFor="password" className="block text-sm text-gray-600 mb-1">
+          <label
+            htmlFor="password"
+            className="block text-sm text-gray-600 mb-1"
+          >
             Password
           </label>
           <input
@@ -64,7 +72,9 @@ export default function Register() {
             minLength={8}
             required
           />
-          <p className="text-xs text-gray-400 mt-1">Must be at least 8 characters</p>
+          <p className="text-xs text-gray-400 mt-1">
+            Must be at least 8 characters
+          </p>
         </div>
 
         <button
@@ -77,11 +87,14 @@ export default function Register() {
 
         <p className="text-sm text-gray-400 text-center">
           Already have an account?{' '}
-          <Link to="/login" className="text-blue-500 hover:underline font-medium">
+          <Link
+            to="/login"
+            className="text-blue-500 hover:underline font-medium"
+          >
             Log In
           </Link>
         </p>
       </form>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1,95 +1,100 @@
-import { useState, useEffect } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
-import { useSession } from '../hooks/useSession'
-import { joinSession, leaveSession, nextTrack, skipTurn } from '../api/sessions'
-import { formatTime } from '../utils/time'
-import RunEntrySheet from '../components/RunEntrySheet'
-import BottomNav from '../components/BottomNav'
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { useSession } from '../hooks/useSession';
+import {
+  joinSession,
+  leaveSession,
+  nextTrack,
+  skipTurn,
+} from '../api/sessions';
+import { formatTime } from '../utils/time';
+import RunEntrySheet from '../components/RunEntrySheet';
+import BottomNav from '../components/BottomNav';
 
 export default function Session() {
-  const { id } = useParams<{ id: string }>()
-  const { user } = useAuth()
-  const { session, loading, ended } = useSession(id!)
-  const navigate = useNavigate()
-  const [leaving, setLeaving] = useState(false)
-  const [joiningSession, setJoiningSession] = useState(false)
-  const [joinError, setJoinError] = useState<string | null>(null)
-  const [headerExpanded, setHeaderExpanded] = useState(false)
-  const [pickingTrack, setPickingTrack] = useState(false)
-  const [skippingTrack, setSkippingTrack] = useState(false)
-  const [trackError, setTrackError] = useState<string | null>(null)
-  const [historyExpanded, setHistoryExpanded] = useState(true)
-  const [trackImageError, setTrackImageError] = useState(false)
-  const [showRunEntry, setShowRunEntry] = useState(false)
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+  const { session, loading, ended } = useSession(id!);
+  const navigate = useNavigate();
+  const [leaving, setLeaving] = useState(false);
+  const [joiningSession, setJoiningSession] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [headerExpanded, setHeaderExpanded] = useState(false);
+  const [pickingTrack, setPickingTrack] = useState(false);
+  const [skippingTrack, setSkippingTrack] = useState(false);
+  const [trackError, setTrackError] = useState<string | null>(null);
+  const [historyExpanded, setHistoryExpanded] = useState(true);
+  const [trackImageError, setTrackImageError] = useState(false);
+  const [showRunEntry, setShowRunEntry] = useState(false);
 
   const handleLeave = async () => {
-    setLeaving(true)
+    setLeaving(true);
     try {
-      await leaveSession(id!)
-      navigate('/')
+      await leaveSession(id!);
+      navigate('/');
     } catch {
-      setLeaving(false)
+      setLeaving(false);
     }
-  }
+  };
 
   const handleJoin = async () => {
-    setJoiningSession(true)
-    setJoinError(null)
+    setJoiningSession(true);
+    setJoinError(null);
     try {
-      await joinSession(id!)
+      await joinSession(id!);
     } catch (e) {
-      setJoinError(e instanceof Error ? e.message : 'Failed to join session')
-      setJoiningSession(false)
+      setJoinError(e instanceof Error ? e.message : 'Failed to join session');
+      setJoiningSession(false);
     }
-  }
+  };
 
   const handleNextTrack = async () => {
-    setPickingTrack(true)
-    setTrackError(null)
+    setPickingTrack(true);
+    setTrackError(null);
     try {
-      await nextTrack(id!)
+      await nextTrack(id!);
     } catch (e) {
-      setTrackError(e instanceof Error ? e.message : 'Failed to pick track')
+      setTrackError(e instanceof Error ? e.message : 'Failed to pick track');
     } finally {
-      setPickingTrack(false)
+      setPickingTrack(false);
     }
-  }
+  };
 
   const handleSkipTrack = async () => {
-    setSkippingTrack(true)
-    setTrackError(null)
+    setSkippingTrack(true);
+    setTrackError(null);
     try {
-      await skipTurn(id!)
+      await skipTurn(id!);
     } catch (e) {
-      setTrackError(e instanceof Error ? e.message : 'Failed to skip track')
+      setTrackError(e instanceof Error ? e.message : 'Failed to skip track');
     } finally {
-      setSkippingTrack(false)
+      setSkippingTrack(false);
     }
-  }
+  };
 
   // Reset image error state when the track changes
   useEffect(() => {
-    setTrackImageError(false)
-  }, [session?.current_race?.id])
+    setTrackImageError(false);
+  }, [session?.current_race?.id]);
 
   // Clear track error when a successful poll shows the state changed
   useEffect(() => {
-    if (trackError) setTrackError(null)
-  }, [session?.current_race?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+    if (trackError) setTrackError(null);
+  }, [session?.current_race?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-collapse history when > 3 races
-  const hasMany = (session?.races.length ?? 0) > 3
+  const hasMany = (session?.races.length ?? 0) > 3;
   useEffect(() => {
-    if (hasMany) setHistoryExpanded(false)
-  }, [hasMany])
+    if (hasMany) setHistoryExpanded(false);
+  }, [hasMany]);
 
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <p className="text-gray-400">Loading session...</p>
       </div>
-    )
+    );
   }
 
   if (ended || !session) {
@@ -104,19 +109,21 @@ export default function Session() {
           Back to Home
         </button>
       </div>
-    )
+    );
   }
 
-  const activeParticipants = session.participants.filter((p) => !p.left_at)
-  const isParticipant = activeParticipants.some((p) => p.user_id === user?.id)
-  const isHost = user?.id === session.host_id
-  const currentRace = session.current_race
-  const pastRaces = [...session.races].reverse().filter((r) => r.id !== currentRace?.id)
+  const activeParticipants = session.participants.filter((p) => !p.left_at);
+  const isParticipant = activeParticipants.some((p) => p.user_id === user?.id);
+  const isHost = user?.id === session.host_id;
+  const currentRace = session.current_race;
+  const pastRaces = [...session.races]
+    .reverse()
+    .filter((r) => r.id !== currentRace?.id);
 
   // Submission status
-  const submissions = currentRace?.submissions ?? []
-  const mySubmission = submissions.find((s) => s.user_id === user?.id)
-  const hasSubmitted = !!mySubmission
+  const submissions = currentRace?.submissions ?? [];
+  const mySubmission = submissions.find((s) => s.user_id === user?.id);
+  const hasSubmitted = !!mySubmission;
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -130,20 +137,28 @@ export default function Session() {
             <span className="text-[10px] font-medium text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
               {session.ruleset}
             </span>
-            <span className="text-sm font-semibold text-gray-900">Race {session.race_number}</span>
+            <span className="text-sm font-semibold text-gray-900">
+              Race {session.race_number}
+            </span>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-xs text-gray-400">
-              {activeParticipants.length} player{activeParticipants.length !== 1 ? 's' : ''}
+              {activeParticipants.length} player
+              {activeParticipants.length !== 1 ? 's' : ''}
             </span>
-            <span className="text-gray-400 text-xs">{headerExpanded ? '\u25B2' : '\u25BC'}</span>
+            <span className="text-gray-400 text-xs">
+              {headerExpanded ? '\u25B2' : '\u25BC'}
+            </span>
           </div>
         </button>
 
         {headerExpanded && (
           <div className="px-4 pb-3 border-t border-gray-100 pt-2 space-y-1.5">
             {activeParticipants.map((p) => (
-              <div key={p.user_id} className="flex items-center justify-between py-1">
+              <div
+                key={p.user_id}
+                className="flex items-center justify-between py-1"
+              >
                 <div className="flex items-center gap-2">
                   {p.user_id === session.host_id && (
                     <span className="text-xs">{'\uD83C\uDFE0'}</span>
@@ -174,18 +189,24 @@ export default function Session() {
             )}
             <div className="px-4 py-3">
               <div className="flex items-center justify-between">
-                <h2 className="text-lg font-bold text-gray-900">{currentRace.track_name}</h2>
+                <h2 className="text-lg font-bold text-gray-900">
+                  {currentRace.track_name}
+                </h2>
                 <span className="text-[10px] font-semibold text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
                   Race {currentRace.race_number}
                 </span>
               </div>
-              <p className="text-sm text-gray-500 mt-0.5">{currentRace.cup_name}</p>
+              <p className="text-sm text-gray-500 mt-0.5">
+                {currentRace.cup_name}
+              </p>
             </div>
           </div>
         ) : (
           <div className="bg-white rounded-xl border border-gray-200 p-6 text-center">
             <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-xl text-gray-300">{'\uD83C\uDFCE\uFE0F'}</span>
+              <span className="text-xl text-gray-300">
+                {'\uD83C\uDFCE\uFE0F'}
+              </span>
             </div>
             <p className="text-sm text-gray-500">
               {isHost
@@ -219,7 +240,9 @@ export default function Session() {
                 {skippingTrack ? 'Re-rolling...' : 'Skip Track'}
               </button>
             )}
-            {trackError && <p className="text-xs text-red-500 text-center">{trackError}</p>}
+            {trackError && (
+              <p className="text-xs text-red-500 text-center">{trackError}</p>
+            )}
           </div>
         )}
 
@@ -236,14 +259,18 @@ export default function Session() {
               >
                 <p
                   className={`text-xs font-semibold uppercase tracking-wider mb-1 ${
-                    mySubmission.disqualified ? 'text-red-500' : 'text-green-600'
+                    mySubmission.disqualified
+                      ? 'text-red-500'
+                      : 'text-green-600'
                   }`}
                 >
                   {mySubmission.disqualified ? 'Your Time (DQ)' : 'Your Time'}
                 </p>
                 <p
                   className={`text-2xl font-mono font-bold ${
-                    mySubmission.disqualified ? 'text-red-600 line-through' : 'text-green-700'
+                    mySubmission.disqualified
+                      ? 'text-red-600 line-through'
+                      : 'text-green-700'
                   }`}
                 >
                   {formatTime(mySubmission.track_time)}
@@ -267,14 +294,19 @@ export default function Session() {
           </h3>
           <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
             {activeParticipants.map((p) => {
-              const sub = submissions.find((s) => s.user_id === p.user_id)
+              const sub = submissions.find((s) => s.user_id === p.user_id);
               return (
-                <div key={p.user_id} className="px-4 py-3 flex items-center justify-between">
+                <div
+                  key={p.user_id}
+                  className="px-4 py-3 flex items-center justify-between"
+                >
                   <div className="flex items-center gap-2">
                     {p.user_id === session.host_id && (
                       <span className="text-xs">{'\uD83C\uDFE0'}</span>
                     )}
-                    <span className="text-sm font-medium text-gray-900">{p.username}</span>
+                    <span className="text-sm font-medium text-gray-900">
+                      {p.username}
+                    </span>
                   </div>
                   {currentRace ? (
                     sub ? (
@@ -288,13 +320,17 @@ export default function Session() {
                         </span>
                       )
                     ) : (
-                      <span className="text-xs text-gray-400">{'\u23F3'} Racing...</span>
+                      <span className="text-xs text-gray-400">
+                        {'\u23F3'} Racing...
+                      </span>
                     )
                   ) : (
-                    <span className="text-xs text-gray-400">{'\u23F3'} waiting</span>
+                    <span className="text-xs text-gray-400">
+                      {'\u23F3'} waiting
+                    </span>
                   )}
                 </div>
-              )
+              );
             })}
           </div>
         </div>
@@ -314,18 +350,25 @@ export default function Session() {
                   {pastRaces.length}
                 </span>
               </div>
-              <span className="text-gray-400 text-xs">{historyExpanded ? '\u25B2' : '\u25BC'}</span>
+              <span className="text-gray-400 text-xs">
+                {historyExpanded ? '\u25B2' : '\u25BC'}
+              </span>
             </button>
             {historyExpanded && (
               <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
                 {pastRaces.map((race) => (
-                  <div key={race.id} className="px-4 py-3 flex items-center justify-between">
+                  <div
+                    key={race.id}
+                    className="px-4 py-3 flex items-center justify-between"
+                  >
                     <div className="flex items-center gap-3">
                       <span className="text-xs font-semibold text-gray-400 w-5 text-center">
                         {race.race_number}
                       </span>
                       <div>
-                        <p className="text-sm font-medium text-gray-900">{race.track_name}</p>
+                        <p className="text-sm font-medium text-gray-900">
+                          {race.track_name}
+                        </p>
                         <p className="text-xs text-gray-400">{race.cup_name}</p>
                       </div>
                     </div>
@@ -361,7 +404,9 @@ export default function Session() {
             >
               {joiningSession ? 'Joining...' : 'Join Session'}
             </button>
-            {joinError && <p className="text-xs text-red-500 text-center">{joinError}</p>}
+            {joinError && (
+              <p className="text-xs text-red-500 text-center">{joinError}</p>
+            )}
           </div>
         )}
       </div>
@@ -377,5 +422,5 @@ export default function Session() {
         />
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,18 +1,22 @@
 /** Format milliseconds as M:SS.mmm (no leading zero on minutes). */
 export function formatTime(ms: number): string {
-  if (ms < 0) return '\u2014'
-  const minutes = Math.floor(ms / 60000)
-  const seconds = Math.floor((ms % 60000) / 1000)
-  const millis = ms % 1000
-  return `${minutes}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`
+  if (ms < 0) return '\u2014';
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  const millis = ms % 1000;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`;
 }
 
 /** Parse M, SS, mmm fields into total milliseconds. Returns null if invalid. */
-export function parseTimeFields(m: string, ss: string, mmm: string): number | null {
-  const mins = parseInt(m, 10)
-  const secs = parseInt(ss, 10)
-  const ms = parseInt(mmm, 10)
-  if (isNaN(mins) || isNaN(secs) || isNaN(ms)) return null
-  if (secs > 59 || ms > 999 || mins < 0 || secs < 0 || ms < 0) return null
-  return mins * 60000 + secs * 1000 + ms
+export function parseTimeFields(
+  m: string,
+  ss: string,
+  mmm: string,
+): number | null {
+  const mins = parseInt(m, 10);
+  const secs = parseInt(ss, 10);
+  const ms = parseInt(mmm, 10);
+  if (isNaN(mins) || isNaN(secs) || isNaN(ms)) return null;
+  if (secs > 59 || ms > 999 || mins < 0 || secs < 0 || ms < 0) return null;
+  return mins * 60000 + secs * 1000 + ms;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -13,4 +13,4 @@ export default defineConfig({
       },
     },
   },
-})
+});


### PR DESCRIPTION
## Reviewer notes

The bulk of the diff (commit 2, _"align Prettier config to standard and reformat frontend"_) is a one-time mechanical reformat — `semi: false → true` and `printWidth: 100 → default 80` to match `typescript.md § 9`. No behavioural edits in it; review it as formatting noise. The substantive work is commit 1 (package additions) and commit 3 (`eslint.config.js`).

**Two AC deviations, both confirmed with Brendan before implementing:**

1. The Issue AC lists `consistent-type-definitions` and `import/no-default-export` at `error`. Both fire on existing code (~25 `interface` declarations, 11 default exports), which would break the lefthook pre-commit hook for every later PR touching an offending file — contradicting PR-A1's "zero new errors" rule and PR-D1's "flip `import/no-default-export` from warn to error" wording. **Both start at `warn`**; PR-B1/D1 flip them.
2. `frontend/.prettierrc` already existed with `semi: false` / `printWidth: 100`. Rather than the AC's literal "add if not present" (a no-op), it was **aligned to `typescript.md § 9` and the frontend reformatted** — chosen over leaving the standard and the repo permanently in disagreement.

eslint-plugin-import's module-resolution rules (`no-unresolved`, `named`, `namespace`, `default`, `no-named-as-default-member`) are switched **off**, not warned-down: without a TypeScript resolver they false-fire on every `.ts`/`.tsx` import, and they duplicate what `tsc --noEmit` already verifies. The standard scopes eslint-plugin-import to its syntactic rules; resolution stays TypeScript's job.

**Flagged, not done here:** there is no frontend lint/typecheck job in CI (CI = backend coverage + markdown link-check), so the "stay green" bar is the lefthook pre-commit hook only. A follow-up Issue to add a frontend CI job would be worthwhile.

## Summary

First PR of the frontend compliance plan (PR-A1). Installs the lint plugins, Prettier integration, and runtime packages the rest of the plan depends on, and rewrites `eslint.config.js` onto the `strictTypeChecked` + `stylisticTypeChecked` presets plus `jsx-a11y` / `import` / `eslint-config-prettier`. Purely additive infrastructure: every rule that fires on the existing pre-compliance code starts at `warn`, so `bun run lint` reports **0 errors / 283 warnings** and the pre-commit hook stays green. Later compliance-plan PRs fix the underlying code and flip each rule back to `error`.

## Linked work

- Closes #187
- Per design record docs/designs/2026-05-16-frontend-compliance-plan.md (PR-A1)

## How to verify

All commands run from `frontend/`.

```bash
bun install
```
Installs the 5 new dependencies (`@tanstack/react-query`, `@tanstack/react-query-devtools`, `clsx`, `react-error-boundary`, `zod`) and 3 new devDependencies (`eslint-plugin-jsx-a11y`, `eslint-plugin-import`, `eslint-config-prettier`).

```bash
bun run lint
```
Exits **0**. Reports **0 errors, 283 warnings** — every known audit violation (default exports, `interface` over `type`, `any`, non-null `!`, unsafe `await res.json()`, floating promises, etc.) appears as a `warning`, never an `error`. This is the whole point of the warn-level start.

```bash
bun run typecheck
```
Exits 0 with no output (`tsc --noEmit` passes).

```bash
bun run build
```
`tsc -b && vite build` succeeds and emits `dist/`.

```bash
bunx prettier --check .
```
Prints `All matched files use Prettier code style!` — the reformat is complete and `.prettierrc` agrees with the on-disk code.

```bash
git commit --allow-empty -m "hook test" && git reset --soft HEAD~1
```
The lefthook pre-commit hook runs and **succeeds** (all commands skip — no staged files), then the empty commit is dropped. To exercise the hook against real files, edit any `.tsx` file, `git add` it, and `git commit`: `frontend-lint` (eslint) and `frontend-format` (prettier --check) both pass.

```bash
bun run dev
```
Dev server boots and the app loads unchanged in the browser — the reformat is non-behavioural and no new dependency is wired into runtime code yet.

## Author checklist

- [x] Linked to an Issue under "Linked work" above (or explicitly noted as skipped per workflow conventions for chore-PRs).
- [ ] Tests added or updated for new logic (per `CLAUDE.md`). — **N/A.** Config/tooling-only PR; no logic added. Test infrastructure (Vitest) lands in PR-H2.
- [x] Docs updated if applicable (`Document history` entry per `CLAUDE.md` carve-outs for files in scope). — No in-scope docs changed; the compliance-plan PR-A1 sign-off box is Brendan's to check on merge.
- [x] Schema changes: consolidated migration edited; local DB reset to verify. — **N/A**, no schema changes.
- [x] Tested locally end-to-end. — `lint`, `typecheck`, `build` all pass; reformat is non-behavioural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
