### PR TITLE
173: Enable strict tsconfig flags (noUncheckedIndexedAccess, exactOptionalPropertyTypes, isolatedModules)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/components/RaceSetupPicker.tsx
+++ b/frontend/src/components/RaceSetupPicker.tsx
@@ -92,15 +92,19 @@ export default function RaceSetupPicker({
 
   function handleSelect(id: number) {
     setterForStep[step](id);
-    // Auto-advance to next step after selection
-    if (currentStepIndex < STEPS.length - 1) {
-      setTimeout(() => setStep(STEPS[currentStepIndex + 1]), 150);
+    // Auto-advance to next step after selection. Indexing past the array
+    // end yields `undefined` under noUncheckedIndexedAccess; the truthy
+    // check both narrows the type and replaces the old bounds guard.
+    const nextStep = STEPS[currentStepIndex + 1];
+    if (nextStep) {
+      setTimeout(() => setStep(nextStep), 150);
     }
   }
 
   function handleBack() {
-    if (currentStepIndex > 0) {
-      setStep(STEPS[currentStepIndex - 1]);
+    const prevStep = STEPS[currentStepIndex - 1];
+    if (prevStep) {
+      setStep(prevStep);
     }
   }
 

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -644,7 +644,12 @@ function SlideToConfirm({
       onMouseMove={(e) => handleMove(e.clientX)}
       onMouseUp={handleEnd}
       onMouseLeave={handleEnd}
-      onTouchMove={(e) => handleMove(e.touches[0].clientX)}
+      onTouchMove={(e) => {
+        // touches[0] is Touch | undefined under noUncheckedIndexedAccess;
+        // a touchmove always carries at least one touch, but narrow anyway.
+        const touch = e.touches[0];
+        if (touch) handleMove(touch.clientX);
+      }}
       onTouchEnd={handleEnd}
     >
       <div

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -207,7 +207,7 @@ export default function Profile() {
             <div className="text-center text-gray-400 py-8">Saving...</div>
           ) : (
             <DrinkTypeSelector
-              selectedId={profile.preferred_drink_type?.id}
+              selectedId={profile.preferred_drink_type?.id ?? null}
               onSelect={handleSaveDrinkType}
             />
           )}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -18,6 +18,10 @@
 
     /* Linting */
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -16,6 +16,10 @@
 
     /* Linting */
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,


### PR DESCRIPTION
## Reviewer notes

Two things beyond the literal Issue #173 AC, both deliberate:

1. **`noImplicitOverride` added** (4th flag, alongside the three the AC names). typescript.md § 1 requires it, but it was absent from the AC, the audit, and every other compliance-plan PR — and PR-A2 is the only PR that touches `tsconfig`. It surfaces zero errors (the frontend has no classes), so it's a no-op flag that makes `tsconfig` fully § 1-compliant. Confirmed with Brendan before adding.

2. **The `typecheck` script was a no-op — fixed in its own commit (`674960b`).** `tsc --noEmit` runs against the solution-style root `tsconfig.json`, which has only `references` and no `files`/`include`; non-build-mode `tsc` therefore compiled nothing and exited 0 without checking a single file. It's now `tsc -b`. **This means PR-A1's "typecheck passes" was also vacuous** — not a regression here, but worth knowing. The real check has been `tsc -b` inside the `build` script all along; this PR just makes the standalone `typecheck` script honest.

The `e.touches[0]` fix is in the `SlideToConfirm` "Slide to DQ" control — that's the only touch handler in `RunEntrySheet`. The AC says "time-input touch handling"; the time inputs auto-advance on `input`, not touch, so the slide-to-DQ control is what to exercise.

## Summary

PR-A2 of the frontend compliance plan. Enables the remaining strict `tsconfig` flags from typescript.md § 1 — `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `isolatedModules`, `noImplicitOverride` — in both `tsconfig.app.json` and `tsconfig.node.json`, and fixes the four type errors they surface (array-index access in `RaceSetupPicker`, `Touch` lookup in `RunEntrySheet`, an `exactOptionalPropertyTypes` prop mismatch in `Profile`). Also fixes the `typecheck` script, which was checking nothing.

## Linked work

- Closes #173
- Per design record docs/designs/2026-05-16-frontend-compliance-plan.md (PR-A2)

## How to verify

### Automated — run from `frontend/`

```bash
bun install
bun run typecheck
```
`tsc -b` — exits 0. (Before this PR the script was `tsc --noEmit` and checked nothing; confirm the new script genuinely typechecks by temporarily reverting one fix, e.g. drop `?? null` in `Profile.tsx:209`, re-running — it should now fail — then restore it.)

```bash
bun run lint
```
Exits 0 — **0 errors, 285 warnings** (one fewer than PR-A1's 283… 286: the `onTouchMove` shorthand→block change clears a `no-confusing-void-expression` warning).

```bash
bun run build
```
`tsc -b && vite build` succeeds.

### Manual smoke test

Start the app (`bun run dev`) with the backend running, then:

**RaceSetupPicker step navigation** — open the race-setup picker (Onboarding after register, or Profile → race setup):
- [x] Select a character → it auto-advances to Body after ~150 ms. Repeat through Wheel and Glider.
- [x] On Glider (last step), selecting an item does **not** throw or advance — it stays put (the `STEPS[i+1]` lookup is now `undefined`, correctly handled).
- [x] Use Back from Body/Wheel/Glider → returns to the previous step. From Character (first step), Back is a no-op, no error.

**RunEntrySheet slide-to-DQ touch control** — open the run-entry sheet, reach the DQ control:
- [x] On a touch device (or browser devtools touch emulation), drag the "Slide to DQ →" thumb across the track — it tracks your finger smoothly and confirms at the end. No console errors.
- [x] Mouse drag still works identically (the mouse path was unchanged).

**Profile drink-type selector** — Profile → Preferred Drink:
- [x] The selector opens with your current preferred drink pre-selected (or nothing selected if none) — the `selectedId` prop now coalesces `undefined → null` cleanly.

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [ ] Tests added or updated for new logic (per `CLAUDE.md`). — **N/A.** No new logic — strict-flag config plus type-narrowing of existing branches. Test infrastructure (Vitest) lands in PR-H2; the narrowed branches are exercised by the manual smoke test above.
- [x] Docs updated if applicable. — No in-scope docs changed; the PR-A2 sign-off box in the compliance plan is Brendan's to check on merge.
- [x] Schema changes: N/A — no schema changes.
- [x] Tested locally end-to-end. — `typecheck`, `lint`, `build` pass; manual smoke test of the three touched flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
