### PR TITLE
Sweep api-contract.md cross-references after § 2 deletion + renumber (ADR 0039)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -190,7 +190,7 @@ For each standards file you loaded, walk its rules against the diff. Common high
 - **`rust.md`:** error handling shape (§ 1), type-driven design / newtypes (§ 2), `unwrap`/`expect` policy (§ 11), serde conventions on new DTOs (§ 14), doc comments on new public items (§ 6), file length (§ 13), Cargo deps (§ 15).
 - **`seaorm.md`:** N+1 queries (§ 2), transaction boundaries (§ 3), raw SQL parameterization (§ 10), `Option<Model>` not `unwrap`-ed (§ 7), `.all()` only when bounded (§ 2), set-based updates over fetch+save loops (§ 1), `before_save` for timestamps (§ 1), entity hand-edits (§ 6).
 - **`tokio.md`:** locks across `.await` (§ 3), `Send + 'static` requirements on spawned tasks (§ 9), blocking work on the runtime (§ 2), channel choice and bounding (§ 4), cancellation safety in `select!` (§ 6, § 7), timeouts on external calls (§ 12).
-- **`api-contract.md`:** wire format (snake_case JSON, ISO 8601 timestamps, error code field — § 2, § 6), idempotency keys on retry-vulnerable endpoints (§ 5), ETag on the polling endpoint (§ 3), versioning (§ 8).
+- **`api-contract.md`:** wire format (snake_case JSON, ISO 8601 timestamps, error code field — § 2, § 7), idempotency keys on retry-vulnerable endpoints (§ 5), ETag on the polling endpoint (§ 3), versioning (§ 8).
 
 **Cite the rule when you flag a finding.** Bad: "this should use a transaction." Good: "Per `seaorm.md` § 3, multi-write handlers must wrap in `db.transaction(...)` — this handler inserts into both `runs` and `run_flags` without one."
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -12,7 +12,7 @@ use tracing::{error, warn};
 /// Stable error-code identifiers emitted in the `code` field of every error
 /// response.
 ///
-/// Mirrors the `api-contract.md` § 8 registry one-to-one — adding a new code
+/// Mirrors the `api-contract.md` § 7 registry one-to-one — adding a new code
 /// means adding a row there and a variant here in the same change.
 ///
 /// Codes are public API contract: once the frontend starts pattern-matching

--- a/backend/src/services/sessions/lifecycle.rs
+++ b/backend/src/services/sessions/lifecycle.rs
@@ -708,7 +708,7 @@ pub async fn close_stale_sessions(db: &DatabaseConnection) -> Result<u64, Error>
     // skipped pending race within the window all keep the session alive. With
     // the per-race timer gone from `get_pending_races`, the sweeper is the
     // sole gatekeeper for closing dormant sessions, so it honors all of them.
-    // Kept in lockstep with the ETag formula in `api-contract.md` § 4 — the
+    // Kept in lockstep with the ETag formula in `api-contract.md` § 3 — the
     // two share a maintenance contract.
     let stale_ids: Vec<String> = db_query(
         StaleSessionRow::find_by_statement(sea_orm::Statement::from_sql_and_values(


### PR DESCRIPTION
## Reviewer notes

Comment/doc-only sweep — no behavior change. Companion to the docs commit \`953c9bc\` on main (api-contract.md § 2 deletion + renumber + [ADR 0039](https://github.com/brendanbyrne/beerio-kart/blob/main/docs/decisions/0039-api-client-generation.md)) and the frontend half handled inside PR #199. Cowork did the \`docs/\` sweep; this PR covers the \`.rs\` / \`.claude\` references Cowork can't edit.

## Summary

\`api-contract.md\` § 2 (API client generation) was deleted and §§ 3–11 renumbered to §§ 2–10. This updates the stale cross-references in code comments and the code-review skill:

- [\`backend/src/error.rs\`](backend/src/error.rs) — error-code registry § 8 → **§ 7**
- [\`backend/src/services/sessions/lifecycle.rs\`](backend/src/services/sessions/lifecycle.rs) — ETag formula § 4 → **§ 3**
- [\`.claude/skills/code-review/SKILL.md\`](.claude/skills/code-review/SKILL.md) — error-code field § 6 → **§ 7** (this bullet was on the pre-2026-05-06 numbering and doubly stale; the § 5 / § 3 / § 8 refs on the same line are already correct under the new numbering)

CORS in SKILL.md is § 9 under the new numbering (was § 10) — already correct by coincidence of the renumber, left as-is.

## Linked work

- Per [docs/decisions/0039-api-client-generation.md](docs/decisions/0039-api-client-generation.md)
- Follows the api-contract.md renumber in main \`953c9bc\`
- No issue — chore sweep (per the Cowork handoff that requested it)

## How to verify

- [x] Confirm no stale references remain:
  ```bash
  git grep -nE 'api-contract\.md § [0-9]' -- '*.rs' '*.ts' '.claude/' | grep -v node_modules
  ```
  Cross-check each hit against the new numbering in [docs/api-contract.md](docs/api-contract.md) (§ 2 Error response · § 3 Polling/ETag · § 5 Idempotency · § 7 Error code registry · § 8 Versioning · § 9 CORS).
- [x] \`cd backend && cargo check\` — clean (comment-only; clippy + fmt already passed pre-commit).

## Author checklist

- [x] Linked to the driving decision (ADR 0039) above; no issue (chore).
- [x] Tests added or updated for new logic — n/a, comments only.
- [x] Docs updated if applicable — this *is* the doc/comment sweep; the \`docs/\` half landed on main in \`953c9bc\`.
- [x] Schema changes — n/a.
- [x] Tested locally — rust-fmt + clippy passed pre-commit; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)