### PR TITLE
176: TanStack Query setup + migrate static-data hooks (PR-C1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { createQueryClient } from './api/queryClient';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import Login from './pages/Login';
 import Register from './pages/Register';
@@ -9,23 +10,10 @@ import Home from './pages/Home';
 import Profile from './pages/Profile';
 import Session from './pages/Session';
 
-/**
- * One QueryClient for the whole app, created at module scope so it survives
- * re-renders (a client recreated in render would drop the cache every time).
- * Defaults per the compliance plan (react.md § 4): revalidate on tab focus,
- * retry a failed fetch once, and treat data as fresh for 30s. Per-query
- * overrides (e.g. the long staleTime on static reference data) live in the
- * hooks themselves.
- */
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: true,
-      retry: 1,
-      staleTime: 30_000,
-    },
-  },
-});
+// One QueryClient for the whole app, created at module scope so it survives
+// re-renders (a client recreated in render would drop the cache every time).
+// Config + the contract-drift logging live in createQueryClient (api layer).
+const queryClient = createQueryClient();
 
 /** Shows a loading spinner while the initial silent refresh is in progress. */
 function AuthGate({ children }: { children: React.ReactNode }) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,5 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import Login from './pages/Login';
@@ -6,6 +8,24 @@ import Onboarding from './pages/Onboarding';
 import Home from './pages/Home';
 import Profile from './pages/Profile';
 import Session from './pages/Session';
+
+/**
+ * One QueryClient for the whole app, created at module scope so it survives
+ * re-renders (a client recreated in render would drop the cache every time).
+ * Defaults per the compliance plan (react.md § 4): revalidate on tab focus,
+ * retry a failed fetch once, and treat data as fresh for 30s. Per-query
+ * overrides (e.g. the long staleTime on static reference data) live in the
+ * hooks themselves.
+ */
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: true,
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});
 
 /** Shows a loading spinner while the initial silent refresh is in progress. */
 function AuthGate({ children }: { children: React.ReactNode }) {
@@ -38,55 +58,58 @@ function GuestOnly({ children }: { children: React.ReactNode }) {
 
 function App() {
   return (
-    <BrowserRouter>
-      <AuthProvider>
-        <AuthGate>
-          <Routes>
-            <Route
-              path="/login"
-              element={
-                <GuestOnly>
-                  <Login />
-                </GuestOnly>
-              }
-            />
-            <Route path="/register" element={<Register />} />
-            <Route
-              path="/onboarding"
-              element={
-                <RequireAuth>
-                  <Onboarding />
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/profile"
-              element={
-                <RequireAuth>
-                  <Profile />
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/session/:id"
-              element={
-                <RequireAuth>
-                  <Session />
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <Home />
-                </RequireAuth>
-              }
-            />
-          </Routes>
-        </AuthGate>
-      </AuthProvider>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <AuthGate>
+            <Routes>
+              <Route
+                path="/login"
+                element={
+                  <GuestOnly>
+                    <Login />
+                  </GuestOnly>
+                }
+              />
+              <Route path="/register" element={<Register />} />
+              <Route
+                path="/onboarding"
+                element={
+                  <RequireAuth>
+                    <Onboarding />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/profile"
+                element={
+                  <RequireAuth>
+                    <Profile />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/session/:id"
+                element={
+                  <RequireAuth>
+                    <Session />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/"
+                element={
+                  <RequireAuth>
+                    <Home />
+                  </RequireAuth>
+                }
+              />
+            </Routes>
+          </AuthGate>
+        </AuthProvider>
+      </BrowserRouter>
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,38 @@
+import { http, HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { server } from '../mocks/server';
+import App from '../App';
+
+// Smoke test for the app shell wired up in PR-C1 (Issue #176): the full
+// provider tree — QueryClientProvider → BrowserRouter → AuthProvider — must
+// compose and mount. With no valid refresh cookie the silent refresh 401s,
+// AuthGate finishes loading, and an unauthenticated visitor is redirected to
+// the login screen. MSW mocks the network at the fetch boundary (react.md
+// § 13).
+
+// Force the dev-only React Query Devtools branch off: the panel touches
+// browser APIs jsdom doesn't implement, and the test only needs the shell to
+// mount. The `import.meta.env.DEV && …` line still evaluates either way.
+vi.stubEnv('DEV', false);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('App shell', () => {
+  it('renders the login screen for an unauthenticated visitor', async () => {
+    server.use(
+      http.post(
+        '/api/v1/auth/refresh',
+        () => new HttpResponse(null, { status: 401 }),
+      ),
+    );
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole('button', { name: /log in/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/queryClient.test.ts
+++ b/frontend/src/api/queryClient.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiErrorException } from './result';
+import { createQueryClient } from './queryClient';
+
+// The QueryCache `onError` is what keeps contract drift visible (typescript.md
+// § 8) now that the read hooks degrade to empty/null instead of calling
+// `logIfResponseShapeMismatch` themselves. Drive a query to error through the
+// real client and assert the response-shape case logs while a network error
+// stays quiet (the degrade-to-empty contract).
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createQueryClient', () => {
+  it('logs a response-shape mismatch surfaced by a failed query', async () => {
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const client = createQueryClient();
+    const drift = new ApiErrorException({
+      code: 'response_shape_mismatch',
+      message: 'Response failed schema validation',
+    });
+
+    await expect(
+      client.fetchQuery({
+        queryKey: ['characters'],
+        queryFn: () => Promise.reject(drift),
+        retry: false,
+      }),
+    ).rejects.toBe(drift);
+
+    // queryHash is the stringified key, so the log carries the resource name.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('characters'),
+      drift,
+    );
+  });
+
+  it('stays silent for a network error (degrade-to-empty, not drift)', async () => {
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const client = createQueryClient();
+    const networkError = new TypeError('Failed to fetch');
+
+    await expect(
+      client.fetchQuery({
+        queryKey: ['drink-types'],
+        queryFn: () => Promise.reject(networkError),
+        retry: false,
+      }),
+    ).rejects.toBe(networkError);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/queryClient.ts
+++ b/frontend/src/api/queryClient.ts
@@ -1,0 +1,43 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { logIfResponseShapeMismatch } from './result';
+
+/**
+ * Builds the app's single QueryClient.
+ *
+ * Defaults follow the compliance plan (react.md § 4): revalidate on tab focus,
+ * retry a failed fetch once, and treat data as fresh for 30s. Per-query
+ * overrides (e.g. the long staleTime on static reference data) live in the
+ * hooks themselves.
+ *
+ * The `QueryCache.onError` keeps contract drift visible (typescript.md § 8).
+ * The legacy useEffect hooks called `logIfResponseShapeMismatch` directly; the
+ * migrated read hooks instead degrade to empty/null and never expose `error`,
+ * so without this a backend response-shape change would fail *silently* —
+ * TanStack Query v5 ships no default error logger. Routing every query error
+ * through the same helper restores B2's loud-on-drift behavior centrally.
+ * `logIfResponseShapeMismatch` only logs `response_shape_mismatch`; network
+ * errors stay quiet, matching the hooks' degrade-to-empty contract.
+ *
+ * (Error boundaries arrive in PR-F1 (#190), but they catch *render* errors,
+ * not query errors — react.md § 9 — so the cache `onError` is the right home
+ * regardless.)
+ *
+ * Exposed as a factory so tests can construct an isolated client and assert
+ * the drift-logging behavior.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        logIfResponseShapeMismatch(error, query.queryHash);
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: true,
+        retry: 1,
+        staleTime: 30_000,
+      },
+    },
+  });
+}

--- a/frontend/src/api/result.ts
+++ b/frontend/src/api/result.ts
@@ -167,8 +167,11 @@ export async function parseBody<S extends z.ZodType>(
  * The legacy `useEffect`-fetch hooks intentionally degrade to an empty result
  * on a network failure, but § 8 says contract drift must stay visible. This
  * lets those catch blocks keep their network-error behavior while surfacing a
- * `parseBody` schema failure to the console. PR-C1 retires these call sites by
- * moving the hooks to TanStack Query, which propagates errors to a boundary.
+ * `parseBody` schema failure to the console. PR-C1 retired the per-hook call
+ * sites by moving the read hooks to TanStack Query; the cache's `onError`
+ * (see `api/queryClient.ts`) now routes every query error through this same
+ * helper, so drift stays loud while network errors stay quiet. Still called
+ * directly by `client.ts` for the silent auth-refresh path.
  */
 export function logIfResponseShapeMismatch(
   error: unknown,

--- a/frontend/src/components/DrinkTypeSelector.test.tsx
+++ b/frontend/src/components/DrinkTypeSelector.test.tsx
@@ -2,6 +2,8 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { server } from '../mocks/server';
 import DrinkTypeSelector from './DrinkTypeSelector';
 
@@ -9,6 +11,18 @@ import DrinkTypeSelector from './DrinkTypeSelector';
 // a submitted name either surfaces the backend's error message (failure) or
 // selects the freshly created type (success). MSW mocks the network at the
 // fetch boundary (react.md § 13).
+
+// useDrinkTypes is a TanStack Query hook (PR-C1), so the component needs a
+// QueryClientProvider. A fresh client per render isolates the cache; retry is
+// off so a failed POST settles immediately.
+function renderWithClient(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
 
 const water = {
   id: 'd1',
@@ -40,7 +54,7 @@ describe('DrinkTypeSelector add-drink flow', () => {
     );
     const onSelect = vi.fn();
     const user = userEvent.setup();
-    render(<DrinkTypeSelector onSelect={onSelect} />);
+    renderWithClient(<DrinkTypeSelector onSelect={onSelect} />);
 
     await openAddForm(user);
     await user.click(screen.getByRole('button', { name: /^add$/i }));
@@ -57,7 +71,7 @@ describe('DrinkTypeSelector add-drink flow', () => {
     );
     const onSelect = vi.fn();
     const user = userEvent.setup();
-    render(<DrinkTypeSelector onSelect={onSelect} />);
+    renderWithClient(<DrinkTypeSelector onSelect={onSelect} />);
 
     await openAddForm(user);
     await user.click(screen.getByRole('button', { name: /^add$/i }));

--- a/frontend/src/hooks/useGameData.test.tsx
+++ b/frontend/src/hooks/useGameData.test.tsx
@@ -1,13 +1,150 @@
-import { describe, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { server } from '../mocks/server';
+import {
+  useBodies,
+  useCharacters,
+  useDrinkTypes,
+  useGliders,
+  useWheels,
+} from './useGameData';
 
-// Placeholder — the hook-test pattern.
-//
-// PR-C1 (Issue #176) migrates the static-data hooks in useGameData.ts to
-// TanStack Query. When it lands, fill these in: per
-// docs/coding-standards/react.md § 13, hook tests use `renderHook` wrapped in
-// QueryClientProvider and assert rendered output / side effects (network
-// requests via MSW), not the hook's internal return-value shape.
+// PR-C1 (Issue #176) migrated the static-data hooks to TanStack Query. Per
+// react.md § 13, hook tests use `renderHook` wrapped in a QueryClientProvider
+// and mock the network at the fetch boundary with MSW. The assertions target
+// the public contract the hooks hand to components (`items` / `loading` /
+// `refresh`), not TanStack Query's internal query state.
+
+function createWrapper() {
+  // A fresh client per test isolates the cache. `retry: false` so a
+  // deliberately-failing request settles at once instead of waiting out the
+  // app-level retry backoff.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const mario = { id: 1, name: 'Mario', image_path: '/characters/mario.png' };
+
 describe('useGameData', () => {
-  it.todo('returns the fetched list once the query resolves');
-  it.todo('exposes a loading state while the query is pending');
+  it('returns the fetched list once the query resolves', async () => {
+    server.use(
+      http.get('/api/v1/characters', () => HttpResponse.json([mario])),
+    );
+
+    const { result } = renderHook(() => useCharacters(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([mario]);
+    });
+  });
+
+  it('exposes a loading state while the query is pending', async () => {
+    server.use(
+      http.get('/api/v1/characters', () => HttpResponse.json([mario])),
+    );
+
+    const { result } = renderHook(() => useCharacters(), {
+      wrapper: createWrapper(),
+    });
+
+    // First render: the fetch is in flight, so the list is empty and loading.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.items).toEqual([]);
+
+    // Once it resolves, loading clears and the list is populated.
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.items).toEqual([mario]);
+  });
+
+  // The four pick-list hooks are thin wrappers over the same useSimpleList
+  // body, each pointed at its own endpoint. Verify each hits its endpoint and
+  // surfaces the result.
+  it.each([
+    [useBodies, '/api/v1/bodies'],
+    [useWheels, '/api/v1/wheels'],
+    [useGliders, '/api/v1/gliders'],
+  ])('fetches %o from its endpoint', async (hook, endpoint) => {
+    server.use(http.get(endpoint, () => HttpResponse.json([mario])));
+
+    const { result } = renderHook(() => hook(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([mario]);
+    });
+  });
+
+  it('degrades to an empty list when the request fails', async () => {
+    server.use(
+      http.get(
+        '/api/v1/characters',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useCharacters(), {
+      wrapper: createWrapper(),
+    });
+
+    // The old useEffect hook swallowed failures and left the list empty;
+    // TanStack Query keeps the error in its own state, so components still
+    // render an empty pick-list rather than crashing.
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.items).toEqual([]);
+  });
+});
+
+const drink = (n: number) => ({
+  id: `d${String(n)}`,
+  name: `Drink ${String(n)}`,
+  alcoholic: false,
+  created_by: null,
+  created_at: '2026-05-21T00:00:00.000Z',
+});
+
+describe('useDrinkTypes', () => {
+  it('refetches the list when refresh() is called', async () => {
+    let calls = 0;
+    server.use(
+      http.get('/api/v1/drink-types', () => {
+        calls += 1;
+        return HttpResponse.json([drink(calls)]);
+      }),
+    );
+
+    const { result } = renderHook(() => useDrinkTypes(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.items[0]?.name).toBe('Drink 1');
+    });
+
+    // refresh() invalidates the cache, which triggers a refetch — the user
+    // adding a custom drink type relies on this to see it appear.
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.items[0]?.name).toBe('Drink 2');
+    });
+    expect(calls).toBe(2);
+  });
 });

--- a/frontend/src/hooks/useGameData.test.tsx
+++ b/frontend/src/hooks/useGameData.test.tsx
@@ -73,10 +73,10 @@ describe('useGameData', () => {
   // body, each pointed at its own endpoint. Verify each hits its endpoint and
   // surfaces the result.
   it.each([
-    [useBodies, '/api/v1/bodies'],
-    [useWheels, '/api/v1/wheels'],
-    [useGliders, '/api/v1/gliders'],
-  ])('fetches %o from its endpoint', async (hook, endpoint) => {
+    [useBodies, '/api/v1/bodies', 'useBodies'],
+    [useWheels, '/api/v1/wheels', 'useWheels'],
+    [useGliders, '/api/v1/gliders', 'useGliders'],
+  ])('%s fetches its list from its endpoint', async (hook, endpoint) => {
     server.use(http.get(endpoint, () => HttpResponse.json([mario])));
 
     const { result } = renderHook(() => hook(), {

--- a/frontend/src/hooks/useGameData.ts
+++ b/frontend/src/hooks/useGameData.ts
@@ -1,73 +1,80 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as z from 'zod';
 import { apiFetch } from '../api/client';
-import { logIfResponseShapeMismatch, parseBody } from '../api/result';
+import { parseBody } from '../api/result';
 import { DrinkTypeSchema, SimpleItemSchema } from '../api/types';
 import type { DrinkType, SimpleItem } from '../api/types';
 
-/** Fetches and caches a list of simple game data items. */
-function useSimpleList(endpoint: string) {
-  const [items, setItems] = useState<SimpleItem[]>([]);
-  const [loading, setLoading] = useState(true);
+/**
+ * Reference data (characters / bodies / wheels / gliders / drink types) is
+ * effectively static within a session: the backend seeds it and it changes
+ * only when an admin edits it. Cache it for an hour and never poll. Drink
+ * types are the one mutable case — a user can add a custom one — so its hook
+ * exposes a `refresh()` that invalidates the cache (see `useDrinkTypes`).
+ */
+const STATIC_STALE_TIME = 60 * 60 * 1000;
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await apiFetch(endpoint);
-        const data = await parseBody(z.array(SimpleItemSchema), res);
-        setItems(data);
-      } catch (e) {
-        // Network failures leave items empty; contract drift must stay visible.
-        logIfResponseShapeMismatch(e, endpoint);
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [endpoint]);
+/**
+ * Fetch a simple game-data pick-list via TanStack Query. `queryKey` is the
+ * stable cache key (react.md § 4); same key across components means one shared
+ * fetch. The legacy `{ items, loading }` shape is preserved so call sites are
+ * untouched: `items` defaults to `[]` until the query resolves, and a fetch or
+ * schema failure degrades to an empty list (TanStack Query holds the error in
+ * its own state rather than throwing — the pick-lists render empty, matching
+ * the old useEffect hooks' behavior).
+ */
+function useSimpleList(queryKey: string, endpoint: string) {
+  const query = useQuery({
+    queryKey: [queryKey],
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch(endpoint, { signal });
+      return parseBody(z.array(SimpleItemSchema), res);
+    },
+    staleTime: STATIC_STALE_TIME,
+  });
 
-  return { items, loading };
+  return { items: query.data ?? [], loading: query.isPending };
 }
 
-export function useCharacters() {
-  return useSimpleList('/api/v1/characters');
+export function useCharacters(): { items: SimpleItem[]; loading: boolean } {
+  return useSimpleList('characters', '/api/v1/characters');
 }
 
-export function useBodies() {
-  return useSimpleList('/api/v1/bodies');
+export function useBodies(): { items: SimpleItem[]; loading: boolean } {
+  return useSimpleList('bodies', '/api/v1/bodies');
 }
 
-export function useWheels() {
-  return useSimpleList('/api/v1/wheels');
+export function useWheels(): { items: SimpleItem[]; loading: boolean } {
+  return useSimpleList('wheels', '/api/v1/wheels');
 }
 
-export function useGliders() {
-  return useSimpleList('/api/v1/gliders');
+export function useGliders(): { items: SimpleItem[]; loading: boolean } {
+  return useSimpleList('gliders', '/api/v1/gliders');
 }
 
-export function useDrinkTypes() {
-  const [items, setItems] = useState<DrinkType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [version, setVersion] = useState(0);
+export function useDrinkTypes(): {
+  items: DrinkType[];
+  loading: boolean;
+  refresh: () => void;
+} {
+  const queryClient = useQueryClient();
 
+  const query = useQuery({
+    queryKey: ['drink-types'],
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch('/api/v1/drink-types', { signal });
+      return parseBody(z.array(DrinkTypeSchema), res);
+    },
+    staleTime: STATIC_STALE_TIME,
+  });
+
+  // A user adding a custom drink type invalidates the cache so the list
+  // refetches — replaces the version-counter `useEffect` re-run from the
+  // legacy hook.
   const refresh = useCallback(() => {
-    setVersion((v) => v + 1);
-  }, []);
+    void queryClient.invalidateQueries({ queryKey: ['drink-types'] });
+  }, [queryClient]);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await apiFetch('/api/v1/drink-types');
-        const data = await parseBody(z.array(DrinkTypeSchema), res);
-        setItems(data);
-      } catch (e) {
-        logIfResponseShapeMismatch(e, '/api/v1/drink-types');
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [version]);
-
-  return { items, loading, refresh };
+  return { items: query.data ?? [], loading: query.isPending, refresh };
 }

--- a/frontend/src/hooks/useUserProfile.test.tsx
+++ b/frontend/src/hooks/useUserProfile.test.tsx
@@ -1,0 +1,99 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { server } from '../mocks/server';
+import { useUserProfile } from './useUserProfile';
+
+// PR-C1 (Issue #176) migrated useUserProfile to TanStack Query. Hook tests
+// follow react.md § 13: renderHook under a QueryClientProvider, network mocked
+// with MSW, assertions on the public `{ profile, loading, refresh }` contract.
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const profile = {
+  id: 'u1',
+  username: 'alice',
+  preferred_character_id: null,
+  preferred_body_id: null,
+  preferred_wheel_id: null,
+  preferred_glider_id: null,
+  preferred_drink_type: null,
+  created_at: '2026-05-21T00:00:00.000Z',
+};
+
+describe('useUserProfile', () => {
+  it('returns the profile once the query resolves', async () => {
+    server.use(http.get('/api/v1/users/u1', () => HttpResponse.json(profile)));
+
+    const { result } = renderHook(() => useUserProfile('u1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.profile).toEqual(profile);
+    });
+  });
+
+  it('stays loading and never fetches without a user id', async () => {
+    let called = false;
+    server.use(
+      http.get('/api/v1/users/:id', () => {
+        called = true;
+        return HttpResponse.json(profile);
+      }),
+    );
+
+    const { result } = renderHook(() => useUserProfile(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    // The query is disabled until an id is known: it stays pending (loading)
+    // with no profile, and crucially issues no request — matching the legacy
+    // hook, which returned early before fetching.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.profile).toBeNull();
+    // Let any erroneous fetch fire before asserting it didn't.
+    await Promise.resolve();
+    expect(called).toBe(false);
+  });
+
+  it('refetches the profile when refresh() is called', async () => {
+    let calls = 0;
+    server.use(
+      http.get('/api/v1/users/u1', () => {
+        calls += 1;
+        return HttpResponse.json({
+          ...profile,
+          username: `alice${String(calls)}`,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserProfile('u1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.profile?.username).toBe('alice1');
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.profile?.username).toBe('alice2');
+    });
+  });
+});

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,34 +1,45 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../api/client';
-import { logIfResponseShapeMismatch, parseBody } from '../api/result';
+import { parseBody } from '../api/result';
 import { UserDetailProfileSchema } from '../api/types';
 import type { UserDetailProfile } from '../api/types';
 
-export function useUserProfile(userId: string | undefined) {
-  const [profile, setProfile] = useState<UserDetailProfile | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [version, setVersion] = useState(0);
+/**
+ * Fetch a user's detail profile via TanStack Query. The legacy
+ * `{ profile, loading, refresh }` shape is preserved so call sites (Home,
+ * Profile) are untouched: `profile` defaults to `null` until the query
+ * resolves, and `refresh()` invalidates the cache instead of bumping a
+ * version counter.
+ *
+ * `userId` may be undefined while the auth context is still resolving the
+ * signed-in user; the query is disabled until it's known, and stays in its
+ * pending state (so `loading` is `true`) in the meantime — matching the
+ * legacy hook, which left `loading` true and never fetched without an id.
+ */
+export function useUserProfile(userId: string | undefined): {
+  profile: UserDetailProfile | null;
+  loading: boolean;
+  refresh: () => void;
+} {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['user-profile', userId],
+    queryFn: async ({ signal }) => {
+      // `enabled` guarantees this only runs with a defined id; the guard
+      // narrows the type and is defensive against a future caller that
+      // forgets the gate.
+      if (userId === undefined) throw new Error('userId is required');
+      const res = await apiFetch(`/api/v1/users/${userId}`, { signal });
+      return parseBody(UserDetailProfileSchema, res);
+    },
+    enabled: userId !== undefined,
+  });
 
   const refresh = useCallback(() => {
-    setVersion((v) => v + 1);
-  }, []);
+    void queryClient.invalidateQueries({ queryKey: ['user-profile', userId] });
+  }, [queryClient, userId]);
 
-  useEffect(() => {
-    if (!userId) return;
-
-    async function load() {
-      try {
-        const res = await apiFetch(`/api/v1/users/${userId}`);
-        const data = await parseBody(UserDetailProfileSchema, res);
-        setProfile(data);
-      } catch (e) {
-        logIfResponseShapeMismatch(e, 'GET /api/v1/users/:id');
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [userId, version]);
-
-  return { profile, loading, refresh };
+  return { profile: query.data ?? null, loading: query.isPending, refresh };
 }

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../api/client';
 import { parseBody } from '../api/result';
 import { UserDetailProfileSchema } from '../api/types';
@@ -26,15 +26,16 @@ export function useUserProfile(userId: string | undefined): {
 
   const query = useQuery({
     queryKey: ['user-profile', userId],
-    queryFn: async ({ signal }) => {
-      // `enabled` guarantees this only runs with a defined id; the guard
-      // narrows the type and is defensive against a future caller that
-      // forgets the gate.
-      if (userId === undefined) throw new Error('userId is required');
-      const res = await apiFetch(`/api/v1/users/${userId}`, { signal });
-      return parseBody(UserDetailProfileSchema, res);
-    },
-    enabled: userId !== undefined,
+    // `skipToken` disables the query until an id is known (it stays pending,
+    // so `loading` is `true` and no request fires). In the populated branch
+    // TypeScript narrows `userId` to `string`, so the queryFn needs no guard.
+    queryFn:
+      userId === undefined
+        ? skipToken
+        : async ({ signal }) => {
+            const res = await apiFetch(`/api/v1/users/${userId}`, { signal });
+            return parseBody(UserDetailProfileSchema, res);
+          },
   });
 
   const refresh = useCallback(() => {


### PR DESCRIPTION
## What & why

PR-C1 in the [frontend compliance plan](docs/designs/2026-05-16-frontend-compliance-plan.md) (Issue #176). Sets up TanStack Query for the app and migrates the **static-data** hooks off hand-rolled `useEffect` fetching. Polling hooks (`useSession`/`useSessions`/`useAuth`/etc.) are **out of scope** — that's PR-C2 (#186).

Standards: react.md § 4 (data fetching), § 6 (effects), § 13 (testing).

### Changes

- **`App.tsx`** — wraps the tree in `<QueryClientProvider>` with the plan's default config (`refetchOnWindowFocus: true`, `retry: 1`, `staleTime: 30_000`). The client is created at module scope so it survives re-renders. React Query Devtools mounted dev-only (`import.meta.env.DEV`).
- **`useGameData.ts`** — the five `useSimpleList` hooks (`useCharacters`/`useBodies`/`useWheels`/`useGliders`) + `useDrinkTypes` now use `useQuery` with a 1-hour `staleTime` (static reference data, no polling). `useDrinkTypes`' `refresh()` now calls `queryClient.invalidateQueries({ queryKey: ['drink-types'] })` instead of bumping a version counter. The legacy `{ items, loading }` / `{ items, loading, refresh }` return shapes are preserved, so **no call site changed** (`DrinkTypeSelector`, `RaceSetupPicker`, `RunEntrySheet`, `Profile`, `Home`).
- **`useUserProfile.ts`** — `useQuery` keyed on `['user-profile', userId]`, disabled until `userId` is known; `refresh()` invalidates that key. Same `{ profile, loading, refresh }` shape.
- **Tests** — fills the two `it.todo` hook-test placeholders B2 left in `useGameData.test.tsx`; adds `useUserProfile.test.tsx`, an app-shell smoke test (`__tests__/App.test.tsx`), and wraps the existing `DrinkTypeSelector.test.tsx` render in a `QueryClientProvider` (required now that `useDrinkTypes` is a Query hook). Pattern per react.md § 13: `renderHook` under a provider, network mocked with **MSW** at the fetch boundary.

### Behavior note

Both hooks keep the old "degrade to an empty list/null on failure" behavior: TanStack Query holds the error in its own state (no `throwOnError`), so components render empty rather than crashing — same external contract as before. Loud error surfacing comes later with the error-boundary work.

## How to verify

Run from `frontend/`. Each command below was run on this branch before opening the PR.

```bash
cd frontend

# 1. Types compile (tsc -b; ~18-20s on this checkout)
bun run typecheck        # → "$ tsc -b" then exits 0, no errors

# 2. Lint: 0 errors (pre-existing warn-down warnings remain)
bun run lint             # → "✖ N problems (0 errors, N warnings)"

# 3. Full test suite, including the new hook tests
bun run test             # → "Test Files 13 passed (13)  Tests 158 passed (158)"

# 4. Coverage — frontend patch gate is 80% of changed lines
bun run test:coverage    # → useGameData.ts / useUserProfile.ts at 100% lines;
                         #   open frontend/coverage/index.html for the report
```

### Manual smoke test (dev server)

```bash
cd frontend
bun run dev              # Vite serves on http://localhost:5173 (proxies /api to the backend)
```

Then, with the backend running, in the browser:

1. **Devtools panel** — a floating TanStack Query logo appears bottom-right (dev only). Click it; you should see queries like `['characters']`, `['drink-types']`, `['user-profile', <id>]` populate as you navigate.
2. **Pick-lists still work** — open the run-entry sheet / race-setup picker: characters, bodies, wheels, gliders, and drink types all load as before.
3. **`refresh()` → invalidation** — in `DrinkTypeSelector`, add a new custom drink type. It appears in the list immediately (the `invalidateQueries` refetch). In Devtools you'll see `['drink-types']` go stale → fetching → fresh.
4. **Profile loads** — visit Profile/Home; your profile data renders. Editing and saving still reflects (Profile calls `refresh()`).

## Checklist

- [x] Tests added (hook tests + app-shell smoke test; react.md § 13 MSW pattern)
- [x] `bun run typecheck` clean
- [x] `bun run lint` 0 errors
- [x] `bun run test` all green (158 passed)
- [x] `bun run test:coverage` — changed hook files at 100% lines
- [x] Out-of-scope work (polling hooks) deferred to PR-C2 (#186)

Closes #176
