### PR TITLE
175: Named exports everywhere

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -67,8 +67,8 @@ export default defineConfig([
       // consistent-type-definitions: ~25 `interface` declarations remain;
       //   api/types.ts is converted in PR-B1, prop types in later PRs.
       '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
-      // import/no-default-export: 11 default-export sites; flipped in PR-D1.
-      'import/no-default-export': 'warn',
+      // import/no-default-export: all default exports converted in PR-D1.
+      'import/no-default-export': 'error',
       // no-explicit-any / no-non-null-assertion: flipped to error in PR-F1.
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-non-null-assertion': 'warn',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,12 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { createQueryClient } from './api/queryClient';
 import { AuthProvider, useAuth } from './hooks/useAuth';
-import Login from './pages/Login';
-import Register from './pages/Register';
-import Onboarding from './pages/Onboarding';
-import Home from './pages/Home';
-import Profile from './pages/Profile';
-import Session from './pages/Session';
+import { Login } from './pages/Login';
+import { Register } from './pages/Register';
+import { Onboarding } from './pages/Onboarding';
+import { Home } from './pages/Home';
+import { Profile } from './pages/Profile';
+import { Session } from './pages/Session';
 
 // One QueryClient for the whole app, created at module scope so it survives
 // re-renders (a client recreated in render would drop the cache every time).
@@ -44,7 +44,7 @@ function GuestOnly({ children }: { children: React.ReactNode }) {
   return children;
 }
 
-function App() {
+export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
@@ -100,5 +100,3 @@ function App() {
     </QueryClientProvider>
   );
 }
-
-export default App;

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { server } from '../mocks/server';
-import App from '../App';
+import { App } from '../App';
 
 // Smoke test for the app shell wired up in PR-C1 (Issue #176): the full
 // provider tree — QueryClientProvider → BrowserRouter → AuthProvider — must

--- a/frontend/src/components/BottomNav.test.tsx
+++ b/frontend/src/components/BottomNav.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { server } from '../mocks/server';
-import BottomNav from './BottomNav';
+import { BottomNav } from './BottomNav';
 
 // PR-C2 (Issue #186) replaced BottomNav's re-fetch-on-navigation useEffect with
 // a useQuery on the shared ['my-session'] key. Per react.md § 13 the test mocks

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getMySession } from '../api/sessions';
 
-export default function BottomNav() {
+export function BottomNav() {
   const location = useLocation();
   const navigate = useNavigate();
 

--- a/frontend/src/components/DrinkTypeSelector.test.tsx
+++ b/frontend/src/components/DrinkTypeSelector.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import { server } from '../mocks/server';
-import DrinkTypeSelector from './DrinkTypeSelector';
+import { DrinkTypeSelector } from './DrinkTypeSelector';
 
 // Covers the "add a custom drink type" flow: the list loads from the API,
 // a submitted name either surfaces the backend's error message (failure) or

--- a/frontend/src/components/DrinkTypeSelector.tsx
+++ b/frontend/src/components/DrinkTypeSelector.tsx
@@ -11,7 +11,7 @@ interface DrinkTypeSelectorProps {
   onSkip?: () => void;
 }
 
-export default function DrinkTypeSelector({
+export function DrinkTypeSelector({
   selectedId,
   onSelect,
   onSkip,

--- a/frontend/src/components/RaceSetupPicker.tsx
+++ b/frontend/src/components/RaceSetupPicker.tsx
@@ -31,7 +31,7 @@ const STEP_LABELS: Record<Step, string> = {
   glider: 'Glider',
 };
 
-export default function RaceSetupPicker({
+export function RaceSetupPicker({
   initialCharacterId,
   initialBodyId,
   initialWheelId,

--- a/frontend/src/components/RunEntrySheet.test.tsx
+++ b/frontend/src/components/RunEntrySheet.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { server } from '../mocks/server';
-import RunEntrySheet from './RunEntrySheet';
+import { RunEntrySheet } from './RunEntrySheet';
 import { RaceId, TrackId } from '../api/brand';
 import type { SessionRaceInfo } from '../api/types';
 
@@ -20,7 +20,7 @@ import type { SessionRaceInfo } from '../api/types';
 // its own multi-step flow is tested in its own file; here we only need the
 // completion signal to verify the user's pick overrides the default setup.
 vi.mock('./RaceSetupPicker', () => ({
-  default: ({
+  RaceSetupPicker: ({
     onComplete,
   }: {
     onComplete: (s: {

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -14,8 +14,8 @@ import {
   useWheels,
   useGliders,
 } from '../hooks/useGameData';
-import DrinkTypeSelector from './DrinkTypeSelector';
-import RaceSetupPicker from './RaceSetupPicker';
+import { DrinkTypeSelector } from './DrinkTypeSelector';
+import { RaceSetupPicker } from './RaceSetupPicker';
 
 interface TimeFields {
   m: string;
@@ -31,7 +31,7 @@ interface RunEntrySheetProps {
   onSubmitted: () => void;
 }
 
-export default function RunEntrySheet({
+export function RunEntrySheet({
   race,
   onClose,
   onSubmitted,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import App from './App';
+import { App } from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { server } from '../mocks/server';
-import Home from './Home';
+import { Home } from './Home';
 
 // PR-C2 (Issue #186): creating a session must invalidate the membership and
 // session-list queries so the bottom-nav and Home list update without waiting

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,9 +6,9 @@ import { useUserProfile } from '../hooks/useUserProfile';
 import { useCharacters } from '../hooks/useGameData';
 import { useSessions } from '../hooks/useSessions';
 import { createSession } from '../api/sessions';
-import BottomNav from '../components/BottomNav';
+import { BottomNav } from '../components/BottomNav';
 
-export default function Home() {
+export function Home() {
   const { user } = useAuth();
   const { profile } = useUserProfile(user?.id);
   const { items: characters } = useCharacters();

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import Login from './Login';
+import { Login } from './Login';
 
 // Login reads `login` from the auth context. Mock the hook so the test
 // exercises the form's behavior without a real AuthProvider or network.

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-export default function Login() {
+export function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [username, setUsername] = useState('');

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { server } from '../mocks/server';
-import Onboarding from './Onboarding';
+import { Onboarding } from './Onboarding';
 
 // Onboarding saves the race setup, then the drink type, via PUT /users/:id.
 // Covered behavior: when a save fails the user sees the backend's error and
@@ -17,7 +17,7 @@ vi.mock('../hooks/useAuth', () => ({
 }));
 
 vi.mock('../components/RaceSetupPicker', () => ({
-  default: ({ onComplete }: { onComplete: (s: unknown) => void }) => (
+  RaceSetupPicker: ({ onComplete }: { onComplete: (s: unknown) => void }) => (
     <button
       onClick={() =>
         onComplete({ characterId: 1, bodyId: 2, wheelId: 3, gliderId: 4 })
@@ -29,7 +29,7 @@ vi.mock('../components/RaceSetupPicker', () => ({
 }));
 
 vi.mock('../components/DrinkTypeSelector', () => ({
-  default: ({ onSelect }: { onSelect: (d: unknown) => void }) => (
+  DrinkTypeSelector: ({ onSelect }: { onSelect: (d: unknown) => void }) => (
     <button onClick={() => onSelect({ id: 'd1' })}>select-drink</button>
   ),
 }));

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -3,13 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { apiFetch } from '../api/client';
 import { parseApiError } from '../api/result';
 import { useAuth } from '../hooks/useAuth';
-import RaceSetupPicker from '../components/RaceSetupPicker';
-import DrinkTypeSelector from '../components/DrinkTypeSelector';
+import { RaceSetupPicker } from '../components/RaceSetupPicker';
+import { DrinkTypeSelector } from '../components/DrinkTypeSelector';
 import type { DrinkType } from '../api/types';
 
 type Phase = 'race-setup' | 'drink-type';
 
-export default function Onboarding() {
+export function Onboarding() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [phase, setPhase] = useState<Phase>('race-setup');

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -10,14 +10,14 @@ import {
   useWheels,
   useGliders,
 } from '../hooks/useGameData';
-import RaceSetupPicker from '../components/RaceSetupPicker';
-import DrinkTypeSelector from '../components/DrinkTypeSelector';
-import BottomNav from '../components/BottomNav';
+import { RaceSetupPicker } from '../components/RaceSetupPicker';
+import { DrinkTypeSelector } from '../components/DrinkTypeSelector';
+import { BottomNav } from '../components/BottomNav';
 import type { DrinkType } from '../api/types';
 
 type EditMode = null | 'race-setup' | 'drink-type' | 'password';
 
-export default function Profile() {
+export function Profile() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { profile, refresh } = useUserProfile(user?.id);

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-export default function Register() {
+export function Register() {
   const { register } = useAuth();
   const navigate = useNavigate();
   const [username, setUsername] = useState('');

--- a/frontend/src/pages/Session.test.tsx
+++ b/frontend/src/pages/Session.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { server } from '../mocks/server';
-import Session from './Session';
+import { Session } from './Session';
 
 // PR-C2 (Issue #186): the membership/state mutations must invalidate the keys
 // they make stale — join/leave touch ['my-session'], ['sessions'] and the
@@ -21,7 +21,7 @@ vi.mock('../hooks/useAuth', () => ({
 // callback — the full form is exercised in RunEntrySheet's own test; here we
 // only need the success signal to verify Session invalidates the detail.
 vi.mock('../components/RunEntrySheet', () => ({
-  default: ({ onSubmitted }: { onSubmitted: () => void }) => (
+  RunEntrySheet: ({ onSubmitted }: { onSubmitted: () => void }) => (
     <button onClick={onSubmitted}>submit-run-stub</button>
   ),
 }));

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -11,10 +11,10 @@ import {
 } from '../api/sessions';
 import { formatTime } from '../utils/time';
 import type { SessionId } from '../api/brand';
-import RunEntrySheet from '../components/RunEntrySheet';
-import BottomNav from '../components/BottomNav';
+import { RunEntrySheet } from '../components/RunEntrySheet';
+import { BottomNav } from '../components/BottomNav';
 
-export default function Session() {
+export function Session() {
   // The route param is the external boundary where a raw URL string becomes
   // a SessionId — typing useParams with the branded type is the mint. The
   // `id!` assertions below are pre-existing (PR-D2 / Issue #192 removes them).


### PR DESCRIPTION
## What & why

PR-D1 of the [frontend compliance plan](../blob/main/docs/designs/2026-05-16-frontend-compliance-plan.md) (Stream D). Converts all default exports to named exports and flips `import/no-default-export` to an error so the rule is now enforced, not just advisory.

Closes #175.

## Changes

- **11 default-export declarations → named exports:** `App`, `BottomNav`, `DrinkTypeSelector`, `RaceSetupPicker`, `RunEntrySheet`, and the `Home` / `Login` / `Onboarding` / `Profile` / `Register` / `Session` pages.
- **Every importer updated**, including `main.tsx`'s `import { App } from './App'` and `App.tsx`'s page imports.
- **`eslint.config.js`:** `import/no-default-export` flipped `'warn'` → `'error'`.
- **Test files updated:**
  - Plain default imports → named imports across the 8 affected `*.test.tsx`.
  - `vi.mock` factories that returned `{ default: ... }` now key on the named export: `RaceSetupPicker` (in RunEntrySheet.test + Onboarding.test), `DrinkTypeSelector` (Onboarding.test), `RunEntrySheet` (Session.test).

## Coverage note

`RaceSetupPicker`, `Register`, and `Profile` have no direct test today, so I checked whether their renamed lines would drag the blocking 80% patch gate. They won't: the only changed lines in those files are import statements and the function-declaration line, and istanbul emits no `DA` (coverable-line) records for either — so Codecov doesn't count them in the patch denominator. No smoke tests needed; this PR adds no new coverable lines in untested files.

## Tests touched

8 test files updated (import style + 4 mock-factory keys). No test logic changed; all 177 tests across 20 files still pass.

## Manual test steps

All commands run from the **repo root** (root Cargo + Bun workspaces — don't `cd` into `backend`/`frontend` first):

```bash
# 1. Static checks (run in the frontend workspace — these scripts are frontend-only)
cd frontend
bun run typecheck   # tsc -b — clean
bun run lint        # 0 errors (warnings remain for later PRs); the no-default-export rule is now at error level
bun run test        # 177 passed
bun run build       # tsc -b && vite build — succeeds
cd ..

# 2. Boot the app from the repo root and click through the core flow
bun run dev         # starts backend (cargo run) + frontend (vite) together
```

Then in the browser:
1. **Login** — log in with an existing account; you land on Home.
2. **Home** — the home screen renders (BottomNav visible).
3. **Session** — open a session from Home; the session view and run-entry sheet render.

Expected: identical behavior to before — this is a mechanical export-style refactor with no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)