### PR TITLE
180: adopt React Compiler, Document Metadata, drop manual memoization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@babel/core": "^7.29.7",
         "@eslint/js": "^9.39.4",
         "@rolldown/plugin-babel": "^0.2.3",
         "@tailwindcss/vite": "^4.2.2",
@@ -64,39 +65,39 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
 
-    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
 
-    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
-    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
 
-    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
-    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
 
-    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
-    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
 
-    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
-    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
@@ -1068,6 +1069,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/dom/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -1080,7 +1083,11 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@vitest/coverage-istanbul/@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
     "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "babel-plugin-react-compiler/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1090,11 +1097,17 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-plugin-react-hooks/@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
     "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "magicast/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "magicast/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1108,8 +1121,94 @@
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "@testing-library/dom/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "@vitest/coverage-istanbul/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "babel-plugin-react-compiler/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "babel-plugin-react-compiler/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "eslint-plugin-react-hooks/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "magicast/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "magicast/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@vitest/coverage-istanbul/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "eslint-plugin-react-hooks/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "eslint-plugin-react-hooks/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@rolldown/plugin-babel": "^0.2.3",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -33,6 +34,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-istanbul": "^4.1.6",
+        "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -210,6 +212,8 @@
 
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "x64" }, "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw=="],
 
+    "@rolldown/plugin-babel": ["@rolldown/plugin-babel@0.2.3", "", { "dependencies": { "picomatch": "^4.0.4" }, "peerDependencies": { "@babel/core": "^7.29.0 || ^8.0.0-rc.1", "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1", "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1", "rolldown": "^1.0.0-rc.5", "vite": "^8.0.0" }, "optionalPeers": ["@babel/plugin-transform-runtime", "@babel/runtime", "vite"] }, "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
@@ -365,6 +369,8 @@
     "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@eslint/js": "^9.39.4",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -35,6 +36,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-istanbul": "^4.1.6",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/frontend/src/components/RunEntrySheet.test.tsx
+++ b/frontend/src/components/RunEntrySheet.test.tsx
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -230,6 +230,15 @@ describe('RunEntrySheet', () => {
     expect(img.style.display).toBe('none');
   });
 
+  // pinSliderGeometry pollutes HTMLElement.prototype globally, so cleanup must
+  // run even if an assertion throws mid-test — an end-of-body restore() would
+  // leak the mock into later tests. afterEach always drains it (react.md § 13).
+  let restoreGeometry: (() => void) | null = null;
+  afterEach(() => {
+    restoreGeometry?.();
+    restoreGeometry = null;
+  });
+
   // The slide-to-DQ control measures its track from `offsetWidth` (a layout
   // value jsdom reports as 0) and maps the pointer's clientX through
   // `getBoundingClientRect`. Pin both so the drag math is deterministic: a
@@ -253,7 +262,7 @@ describe('RunEntrySheet', () => {
         y: 0,
         toJSON: () => ({}),
       } as DOMRect);
-    return () => {
+    restoreGeometry = () => {
       rect.mockRestore();
       delete (HTMLElement.prototype as { offsetWidth?: number }).offsetWidth;
     };
@@ -267,7 +276,7 @@ describe('RunEntrySheet', () => {
         () => new HttpResponse(null, { status: 500 }),
       ),
     );
-    const restore = pinSliderGeometry();
+    pinSliderGeometry();
 
     render(
       <RunEntrySheet race={race} onClose={vi.fn()} onSubmitted={vi.fn()} />,
@@ -284,7 +293,6 @@ describe('RunEntrySheet', () => {
     fireEvent.mouseUp(track);
 
     expect(await screen.findByText('Disqualified')).toBeInTheDocument();
-    restore();
   });
 
   it('snaps back without disqualifying when released before the threshold', async () => {
@@ -295,7 +303,7 @@ describe('RunEntrySheet', () => {
         () => new HttpResponse(null, { status: 500 }),
       ),
     );
-    const restore = pinSliderGeometry();
+    pinSliderGeometry();
 
     render(
       <RunEntrySheet race={race} onClose={vi.fn()} onSubmitted={vi.fn()} />,
@@ -312,7 +320,6 @@ describe('RunEntrySheet', () => {
     fireEvent.mouseUp(track);
 
     expect(screen.queryByText('Disqualified')).not.toBeInTheDocument();
-    restore();
   });
 
   it('degrades to blank fields when the run-defaults request fails', async () => {

--- a/frontend/src/components/RunEntrySheet.test.tsx
+++ b/frontend/src/components/RunEntrySheet.test.tsx
@@ -230,6 +230,91 @@ describe('RunEntrySheet', () => {
     expect(img.style.display).toBe('none');
   });
 
+  // The slide-to-DQ control measures its track from `offsetWidth` (a layout
+  // value jsdom reports as 0) and maps the pointer's clientX through
+  // `getBoundingClientRect`. Pin both so the drag math is deterministic: a
+  // 300px-wide track with its left edge at x=0. The confirm threshold is
+  // `width - thumb(44) - 4 = 252`.
+  function pinSliderGeometry() {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 300,
+    });
+    const rect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        left: 0,
+        top: 0,
+        right: 300,
+        bottom: 48,
+        width: 300,
+        height: 48,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+    return () => {
+      rect.mockRestore();
+      delete (HTMLElement.prototype as { offsetWidth?: number }).offsetWidth;
+    };
+  }
+
+  it('disqualifies the run when the slider is dragged past the threshold', async () => {
+    mockGameData();
+    server.use(
+      http.get(
+        '/api/v1/runs/defaults',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+    const restore = pinSliderGeometry();
+
+    render(
+      <RunEntrySheet race={race} onClose={vi.fn()} onSubmitted={vi.fn()} />,
+      { wrapper: Wrapper },
+    );
+
+    const thumb = (await screen.findByText('»')).parentElement;
+    if (!thumb?.parentElement) throw new Error('slider track not found');
+    const track = thumb.parentElement;
+
+    // Grab the thumb, drag past the 252px threshold, and release.
+    fireEvent.mouseDown(thumb);
+    fireEvent.mouseMove(track, { clientX: 300 });
+    fireEvent.mouseUp(track);
+
+    expect(await screen.findByText('Disqualified')).toBeInTheDocument();
+    restore();
+  });
+
+  it('snaps back without disqualifying when released before the threshold', async () => {
+    mockGameData();
+    server.use(
+      http.get(
+        '/api/v1/runs/defaults',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+    const restore = pinSliderGeometry();
+
+    render(
+      <RunEntrySheet race={race} onClose={vi.fn()} onSubmitted={vi.fn()} />,
+      { wrapper: Wrapper },
+    );
+
+    const thumb = (await screen.findByText('»')).parentElement;
+    if (!thumb?.parentElement) throw new Error('slider track not found');
+    const track = thumb.parentElement;
+
+    // A short drag (well under the 252px threshold) releases without confirming.
+    fireEvent.mouseDown(thumb);
+    fireEvent.mouseMove(track, { clientX: 50 });
+    fireEvent.mouseUp(track);
+
+    expect(screen.queryByText('Disqualified')).not.toBeInTheDocument();
+    restore();
+  });
+
   it('degrades to blank fields when the run-defaults request fails', async () => {
     mockGameData({ drinkTypes: [] });
     server.use(

--- a/frontend/src/components/RunEntrySheet.tsx
+++ b/frontend/src/components/RunEntrySheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type {
   SessionRaceInfo,
@@ -107,16 +107,14 @@ export function RunEntrySheet({
         : '';
 
   // Derive drink type object from ID + loaded data (or explicit user pick)
-  const resolvedDrinkType = useMemo(() => {
-    if (drinkType) return drinkType;
-    if (drinkTypeId && drinkTypes.length > 0) {
-      return drinkTypes.find((dt) => dt.id === drinkTypeId) ?? null;
-    }
-    return null;
-  }, [drinkType, drinkTypeId, drinkTypes]);
+  const resolvedDrinkType = drinkType
+    ? drinkType
+    : drinkTypeId && drinkTypes.length > 0
+      ? (drinkTypes.find((dt) => dt.id === drinkTypeId) ?? null)
+      : null;
 
   // Derive setup summary from IDs + loaded game data
-  const setupSummary = useMemo(() => {
+  const setupSummary = ((): string => {
     if (
       !characterId ||
       !characters.length ||
@@ -132,16 +130,7 @@ export function RunEntrySheet({
       gliders.find((g) => g.id === gliderId)?.name,
     ].filter(Boolean);
     return parts.length === 4 ? parts.join(' \u00B7 ') : '';
-  }, [
-    characterId,
-    bodyId,
-    wheelId,
-    gliderId,
-    characters,
-    bodies,
-    wheels,
-    gliders,
-  ]);
+  })();
 
   const parsedTotal = parseTimeFields(totalTime.m, totalTime.ss, totalTime.mmm);
   const parsedLap1 = parseTimeFields(lap1.m, lap1.ss, lap1.mmm);
@@ -609,20 +598,17 @@ function SlideToConfirm({
     return () => window.removeEventListener('resize', measure);
   }, []);
 
-  const handleMove = useCallback(
-    (clientX: number) => {
-      if (!dragging || confirmed || !trackRef.current) return;
-      const rect = trackRef.current.getBoundingClientRect();
-      const x = Math.min(
-        Math.max(0, clientX - rect.left - thumbW / 2),
-        trackWidth - thumbW,
-      );
-      setOffsetX(x);
-    },
-    [dragging, confirmed, trackWidth],
-  );
+  const handleMove = (clientX: number) => {
+    if (!dragging || confirmed || !trackRef.current) return;
+    const rect = trackRef.current.getBoundingClientRect();
+    const x = Math.min(
+      Math.max(0, clientX - rect.left - thumbW / 2),
+      trackWidth - thumbW,
+    );
+    setOffsetX(x);
+  };
 
-  const handleEnd = useCallback(() => {
+  const handleEnd = () => {
     if (!dragging) return;
     setDragging(false);
     const threshold = trackWidth - thumbW - 4;
@@ -632,7 +618,7 @@ function SlideToConfirm({
     } else {
       setOffsetX(0);
     }
-  }, [dragging, offsetX, onConfirm, trackWidth]);
+  };
 
   if (confirmed) {
     return (

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -43,6 +43,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Kept as useCallback (a react.md § 7 carve-out): clearAuth is both a
+  // dependency of the mount effect below and registered into module scope
+  // via setOnAuthFailure, so it must be referentially stable. exhaustive-deps
+  // (a static rule that can't see the Compiler's memoization) enforces this,
+  // and react.md § 6 forbids silencing it — so the explicit hook stays.
   const clearAuth = useCallback(() => {
     setAccessToken(null);
     setUser(null);
@@ -81,7 +86,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [clearAuth]);
 
   /** Returns an error message on failure, or null on success. */
-  const login = useCallback(async (username: string, password: string) => {
+  const login = async (username: string, password: string) => {
     const res = await fetch('/api/v1/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -94,10 +99,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAccessToken(data.access_token);
     setUser(data.user);
     return null;
-  }, []);
+  };
 
   /** Returns an error message on failure, or null on success. */
-  const register = useCallback(async (username: string, password: string) => {
+  const register = async (username: string, password: string) => {
     const res = await fetch('/api/v1/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -110,26 +115,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAccessToken(data.access_token);
     setUser(data.user);
     return null;
-  }, []);
+  };
 
   /** Returns an error message on failure, or null on success. */
-  const changePassword = useCallback(
-    async (currentPassword: string, newPassword: string) => {
-      const res = await apiFetch('/api/v1/auth/password', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          current_password: currentPassword,
-          new_password: newPassword,
-        }),
-      });
-      if (!res.ok) return (await parseApiError(res)).message;
-      return null;
-    },
-    [],
-  );
+  const changePassword = async (
+    currentPassword: string,
+    newPassword: string,
+  ) => {
+    const res = await apiFetch('/api/v1/auth/password', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        current_password: currentPassword,
+        new_password: newPassword,
+      }),
+    });
+    if (!res.ok) return (await parseApiError(res)).message;
+    return null;
+  };
 
-  const logout = useCallback(async () => {
+  const logout = async () => {
     try {
       // Send the access token so the server can bump refresh_token_version
       const token = getAccessToken();
@@ -141,7 +146,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Even if the server call fails, clear local state
     }
     clearAuth();
-  }, [clearAuth]);
+  };
 
   return (
     <AuthContext.Provider

--- a/frontend/src/hooks/useGameData.ts
+++ b/frontend/src/hooks/useGameData.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as z from 'zod';
 import { apiFetch } from '../api/client';
@@ -72,9 +71,9 @@ export function useDrinkTypes(): {
   // A user adding a custom drink type invalidates the cache so the list
   // refetches — replaces the version-counter `useEffect` re-run from the
   // legacy hook.
-  const refresh = useCallback(() => {
+  const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['drink-types'] });
-  }, [queryClient]);
+  };
 
   return { items: query.data ?? [], loading: query.isPending, refresh };
 }

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../api/client';
 import { parseBody } from '../api/result';
@@ -38,9 +37,9 @@ export function useUserProfile(userId: string | undefined): {
           },
   });
 
-  const refresh = useCallback(() => {
+  const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['user-profile', userId] });
-  }, [queryClient, userId]);
+  };
 
   return { profile: query.data ?? null, loading: query.isPending, refresh };
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -51,6 +51,7 @@ export function Home() {
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
+      <title>Home · Beerio Kart</title>
       {/* Header */}
       <div className="bg-white px-5 pt-6 pb-5 border-b border-gray-100">
         <div className="flex items-center gap-3">

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -37,6 +37,7 @@ export function Login() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <title>Log In · Beerio Kart</title>
       <form
         action={submit}
         className="w-full max-w-sm space-y-4 bg-white p-6 rounded-xl border border-gray-200 shadow-sm"

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -73,6 +73,9 @@ export function Onboarding() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
+      <title>
+        {`${phase === 'race-setup' ? 'Pick Your Setup' : 'Pick Your Drink'} · Beerio Kart`}
+      </title>
       {/* Header */}
       <div className="px-5 pt-6 pb-4">
         <h1 className="text-xl font-bold text-gray-900">

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -105,9 +105,14 @@ export function Profile() {
     navigate('/login');
   }
 
+  // Rendered in every branch (loading / edit modes / default) so the tab title
+  // tracks the route from mount, not only once profile data resolves.
+  const pageTitle = <title>Profile · Beerio Kart</title>;
+
   if (!profile) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        {pageTitle}
         <p className="text-gray-400">Loading profile...</p>
       </div>
     );
@@ -117,6 +122,7 @@ export function Profile() {
   if (editMode === 'race-setup') {
     return (
       <div className="min-h-screen bg-gray-50 flex flex-col">
+        {pageTitle}
         <div className="px-4 pt-4 pb-2 flex items-center">
           <button
             onClick={() => setEditMode(null)}
@@ -153,6 +159,7 @@ export function Profile() {
   if (editMode === 'drink-type') {
     return (
       <div className="min-h-screen bg-gray-50 flex flex-col">
+        {pageTitle}
         <div className="px-4 pt-4 pb-2 flex items-center">
           <button
             onClick={() => setEditMode(null)}
@@ -185,7 +192,7 @@ export function Profile() {
   // Default: profile view
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
-      <title>Profile · Beerio Kart</title>
+      {pageTitle}
       {/* Header */}
       <div className="bg-white px-5 pt-6 pb-5 border-b border-gray-100">
         <h1 className="text-xl font-bold text-gray-900">{profile.username}</h1>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useActionState, useCallback, useEffect, useState } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as z from 'zod';
 import { apiFetch } from '../api/client';
@@ -32,12 +32,12 @@ export function Profile() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  // Stable callback for PasswordChangeForm so the form's success-timer
-  // effect doesn't re-fire (and reset the 1500 ms auto-close) every time
-  // Profile re-renders. The Compiler in PR-E2 will make this redundant.
-  const closePasswordForm = useCallback(() => {
+  // Passed to PasswordChangeForm as `onDone`. The React Compiler keeps it
+  // referentially stable, so the form's success-timer effect doesn't re-fire
+  // (and reset the 1500 ms auto-close) when Profile re-renders.
+  const closePasswordForm = () => {
     setEditMode(null);
-  }, []);
+  };
 
   const char = characters.find((c) => c.id === profile?.preferred_character_id);
   const body = bodies.find((b) => b.id === profile?.preferred_body_id);
@@ -185,6 +185,7 @@ export function Profile() {
   // Default: profile view
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
+      <title>Profile · Beerio Kart</title>
       {/* Header */}
       <div className="bg-white px-5 pt-6 pb-5 border-b border-gray-100">
         <h1 className="text-xl font-bold text-gray-900">{profile.username}</h1>
@@ -336,9 +337,9 @@ function PasswordChangeForm({ onDone }: { onDone: () => void }) {
   // On success, close the form after a short pause so the message is
   // visible. The setState (parent's setEditMode via onDone) lives inside
   // the timer callback, not synchronously in the effect body, so the
-  // "setState in effect" lint rule (project_setstate_in_effect_is_error)
-  // does not apply. `onDone` is `useCallback`-stable in the parent, so a
-  // Profile re-render during the 1500 ms window does not reset the timer.
+  // "set-state-in-effect" lint rule does not apply. `onDone` is kept
+  // referentially stable by the React Compiler, so a Profile re-render
+  // during the 1500 ms window does not reset the timer.
   useEffect(() => {
     if (state.kind !== 'success') return;
     const timer = setTimeout(onDone, 1500);

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -36,6 +36,7 @@ export function Register() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <title>Register · Beerio Kart</title>
       <form
         action={submit}
         className="w-full max-w-sm space-y-4 bg-white p-6 rounded-xl border border-gray-200 shadow-sm"

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -123,9 +123,14 @@ function SessionView({ id }: { id: SessionId }) {
     if (hasMany) setHistoryExpanded(false);
   }, [hasMany]);
 
+  // Rendered in every branch (loading / ended / default) so the tab title
+  // tracks the route from mount, not only once session data resolves.
+  const pageTitle = <title>Session · Beerio Kart</title>;
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        {pageTitle}
         <p className="text-gray-400">Loading session...</p>
       </div>
     );
@@ -134,6 +139,7 @@ function SessionView({ id }: { id: SessionId }) {
   if (ended || !session) {
     return (
       <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-4 px-4">
+        {pageTitle}
         <p className="text-3xl">{'\uD83C\uDFC1'}</p>
         <p className="text-base font-semibold text-gray-900">Session ended</p>
         <button
@@ -161,7 +167,7 @@ function SessionView({ id }: { id: SessionId }) {
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
-      <title>Session · Beerio Kart</title>
+      {pageTitle}
       {/* Zone 1 — Session Header (sticky top) */}
       <div className="sticky top-0 z-10 bg-white border-b border-gray-200">
         <button

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -161,6 +161,7 @@ function SessionView({ id }: { id: SessionId }) {
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
+      <title>Session · Beerio Kart</title>
       {/* Zone 1 — Session Header (sticky top) */}
       <div className="sticky top-0 z-10 bg-white border-b border-gray-200">
         <button

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,18 @@ import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import babel from '@rolldown/plugin-babel';
 import tailwindcss from '@tailwindcss/vite';
 
+// `apiFetch` calls the backend with same-origin relative URLs (/api/...), so
+// both the dev server and `vite preview` must forward /api to the Axum backend
+// on :3000. `vite preview` does NOT inherit `server.proxy`, so the rule is
+// shared here and applied to both — without the preview entry, a production
+// build served by `bun run preview` can't reach the API.
+const apiProxy = {
+  '/api': {
+    target: 'http://localhost:3000',
+    changeOrigin: true,
+  },
+};
+
 export default defineConfig({
   plugins: [
     react(),
@@ -17,11 +29,9 @@ export default defineConfig({
   ],
   server: {
     port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-    },
+    proxy: apiProxy,
+  },
+  preview: {
+    proxy: apiProxy,
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,20 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react, { reactCompilerPreset } from '@vitejs/plugin-react';
+import babel from '@rolldown/plugin-babel';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    // The React Compiler (react.md § 2) runs via a Babel pass — plugin-react v6
+    // transforms with oxc, not Babel, so the Compiler is wired in through
+    // @rolldown/plugin-babel + the plugin's reactCompilerPreset helper (it
+    // carries a preconfigured filter for React/hook files). The preset targets
+    // React 19 by default, so no `target` option is needed. Active in every
+    // mode, so dev gets the same memoization as prod.
+    babel({ presets: [reactCompilerPreset()] }),
+    tailwindcss(),
+  ],
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

PR-E2 of the [frontend compliance plan](docs/designs/2026-05-16-frontend-compliance-plan.md). Turns the React Compiler on, adopts React 19 Document Metadata for per-page titles, and removes hand-written memoization the Compiler now handles.

Closes #180.

## What changed

- **React Compiler enabled** ([vite.config.ts](frontend/vite.config.ts)). `@vitejs/plugin-react@6` (Vite 8 / oxc) no longer exposes a `babel` option, so the Compiler is wired in the documented v6 way: `@rolldown/plugin-babel` + the plugin's `reactCompilerPreset()` helper (it carries a preconfigured filter for React/hook files and targets React 19 by default). Active in dev and prod.
- **eslint:** no config change. `eslint-plugin-react-hooks@7`'s `flat.recommended` (added back in PR-A1) already ships the full Compiler rule suite at error level (`immutability`, `preserve-manual-memoization`, `purity`, `set-state-in-effect`, `use-memo`, …). Verified via `--print-config`.
- **Removed manual memoization** per `react.md` § 7: the two `useMemo` derivations + two `useCallback` drag handlers in `RunEntrySheet`, and the `refresh`/`closePasswordForm`/auth `useCallback`s in `useGameData`, `useUserProfile`, `Profile`, `useAuth`.
  - **One carve-out kept:** `useAuth`'s `clearAuth` stays `useCallback`. It's a dependency of the mount (silent-refresh) effect *and* is registered into module scope via `setOnAuthFailure`, so it must be referentially stable. `exhaustive-deps` (a static rule that can't see the Compiler) enforces this, and `react.md` § 6 forbids silencing it. Documented inline.
- **Document Metadata:** per-page `<title>` added to all six `pages/` components (Login, Register, Home, Profile, Session, and a phase-aware one for Onboarding). React 19 hoists these to `<head>`.
- **forwardRef:** none in the codebase — nothing to convert (AC confirmed).
- **Test:** added a slide-to-DQ interaction test covering the now-unwrapped drag handlers (previously zero coverage).

## Automated verification

- `react-compiler-healthcheck`: **29/29 components compiled**, no incompatible libraries, StrictMode detected.
- `bun run build` succeeds; dev transforms inject the Compiler runtime (`Session.tsx` → `_c(4)`, `useAuth.tsx` → `_c(1)` with the explicit `useCallback` preserved).
- Dev server starts clean — no Compiler errors/warnings in the console; key modules transform to 200.
- `bun run lint`: 0 errors. `bun run test`: **204 passing**. Diff (patch) coverage: **100%** of changed coverable lines.

## Manual test plan

Run `bun run dev` from the repo root, open the app on a phone-width viewport (Pixel 9 Pro reference), and check **both Chrome and Firefox**:

1. **Document titles** — watch the browser tab title as you navigate:
   - `/login` → "Log In · Beerio Kart"
   - `/register` → "Register · Beerio Kart"
   - Home → "Home · Beerio Kart"
   - Onboarding → "Pick Your Setup · Beerio Kart", then "Pick Your Drink · Beerio Kart" as the phase advances
   - Profile → "Profile · Beerio Kart"
   - A session → "Session · Beerio Kart"
   - Navigating back to Home resets the title (no stale title bleed).
2. **Auth still works** — log in, reload the page (silent refresh restores the session — confirm in the Network tab that `/auth/refresh` fires **once**, not in a loop), change password (success message → auto-closes after ~1.5s), log out.
3. **Run entry** — open a race's run sheet: defaults pre-fill, drink/setup overrides work, and the **slide-to-DQ** control: drag the thumb fully right → "Disqualified" appears; tap to undo; a short drag snaps back without DQ.
4. **Re-render profiling (the one step I couldn't automate)** — with React DevTools → Profiler, record an active Session page through a couple of polling ticks. Re-render count should be **equal or lower** than before this PR. This is expected by construction: the Compiler only *adds* memoization, and `useAuth`'s context value (previously a fresh object literal every render, forcing all consumers to re-render) is now memoized — so this should strictly *reduce* re-renders.

## Notes

- Bookkeeping: the plan still lists PR-E1 (#182) and PR-E2 (#180) sign-off boxes unchecked. Those are yours to tick on merge.