### PR TITLE
190: migrate router to createBrowserRouter with error boundaries and lazy routes

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -69,9 +69,12 @@ export default defineConfig([
       '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
       // import/no-default-export: all default exports converted in PR-D1.
       'import/no-default-export': 'error',
-      // no-explicit-any / no-non-null-assertion: flipped to error in PR-F1.
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-non-null-assertion': 'warn',
+      // no-explicit-any / no-non-null-assertion: flipped to error in PR-F1
+      // (#190). Offenders were removed earlier — the `any`-typed
+      // `await res.json()` calls by PR-B2's Zod parses, the `!` assertions by
+      // PR-D2 — so the flip lands with zero violations in production code.
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
 
       // consistent-type-specifier-style — named in typescript.md § 9 but
       // omitted from the PR-A1 AC; added per PR review. `prefer-top-level`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,42 @@
+import { Suspense, lazy } from 'react';
+import type { ReactNode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import {
+  Navigate,
+  RouterProvider,
+  createBrowserRouter,
+} from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import { ErrorBoundary } from 'react-error-boundary';
 import { createQueryClient } from './api/queryClient';
 import { AuthProvider, useAuth } from './hooks/useAuth';
-import { Login } from './pages/Login';
-import { Register } from './pages/Register';
-import { Onboarding } from './pages/Onboarding';
-import { Home } from './pages/Home';
-import { Profile } from './pages/Profile';
-import { Session } from './pages/Session';
+import { PageSkeleton } from './components/PageSkeleton';
+import { AppErrorFallback } from './components/AppErrorFallback';
+import { RouteErrorFallback } from './components/RouteErrorFallback';
+
+// Route pages are code-split (react.md § 11): each lazy() import becomes its
+// own chunk, so the initial bundle ships only the app shell + whatever route
+// the user landed on. The `.then(m => ({ default: m.X }))` adapter bridges our
+// named exports (typescript.md § 5) to React.lazy's default-export contract.
+const Login = lazy(() =>
+  import('./pages/Login').then((m) => ({ default: m.Login })),
+);
+const Register = lazy(() =>
+  import('./pages/Register').then((m) => ({ default: m.Register })),
+);
+const Onboarding = lazy(() =>
+  import('./pages/Onboarding').then((m) => ({ default: m.Onboarding })),
+);
+const Home = lazy(() =>
+  import('./pages/Home').then((m) => ({ default: m.Home })),
+);
+const Profile = lazy(() =>
+  import('./pages/Profile').then((m) => ({ default: m.Profile })),
+);
+const Session = lazy(() =>
+  import('./pages/Session').then((m) => ({ default: m.Session })),
+);
 
 // One QueryClient for the whole app, created at module scope so it survives
 // re-renders (a client recreated in render would drop the cache every time).
@@ -16,7 +44,7 @@ import { Session } from './pages/Session';
 const queryClient = createQueryClient();
 
 /** Shows a loading spinner while the initial silent refresh is in progress. */
-function AuthGate({ children }: { children: React.ReactNode }) {
+function AuthGate({ children }: { children: ReactNode }) {
   const { isLoading } = useAuth();
 
   if (isLoading) {
@@ -31,80 +59,79 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 }
 
 /** Redirects to /login if not authenticated. */
-function RequireAuth({ children }: { children: React.ReactNode }) {
+function RequireAuth({ children }: { children: ReactNode }) {
   const { isAuthenticated } = useAuth();
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   return children;
 }
 
 /** Redirects to / if already authenticated. */
-function GuestOnly({ children }: { children: React.ReactNode }) {
+function GuestOnly({ children }: { children: ReactNode }) {
   const { isAuthenticated } = useAuth();
   if (isAuthenticated) return <Navigate to="/" replace />;
   return children;
 }
 
+/** Wraps a lazy page in the shared Suspense fallback (react.md § 11). */
+function page(node: ReactNode): ReactNode {
+  return <Suspense fallback={<PageSkeleton />}>{node}</Suspense>;
+}
+
+/**
+ * Builds a route with the shared route-scoped errorElement attached, so a
+ * render crash in one page shows RouteErrorFallback in place of that page
+ * (caught here, before it reaches the app-level boundary in AppProviders).
+ */
+function route(path: string, element: ReactNode): RouteObject {
+  return { path, element, errorElement: <RouteErrorFallback /> };
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- `routes` is a static route table consumed by createBrowserRouter (and by tests, which build a memory router from it), not a fast-refreshable component. Mirrors the useAuth.tsx precedent for a justified react-refresh opt-out.
+export const routes: RouteObject[] = [
+  route('/login', <GuestOnly>{page(<Login />)}</GuestOnly>),
+  route('/register', page(<Register />)),
+  route('/onboarding', <RequireAuth>{page(<Onboarding />)}</RequireAuth>),
+  route('/profile', <RequireAuth>{page(<Profile />)}</RequireAuth>),
+  route('/session/:id', <RequireAuth>{page(<Session />)}</RequireAuth>),
+  route('/', <RequireAuth>{page(<Home />)}</RequireAuth>),
+  // Catch-all: unknown paths (e.g. /session with no :id) redirect home rather
+  // than dead-ending on a 404. Per design.md ("never a burden", "sensible
+  // defaults"), bouncing a mistyped URL to the home screen beats a 404 page.
+  // This is distinct from the errorElement above, which handles render crashes
+  // on a *matched* route — unmatched-path handling and crash handling are
+  // separate concerns.
+  route('*', <Navigate to="/" replace />),
+];
+
+const router = createBrowserRouter(routes);
+
+/**
+ * The provider stack that wraps the router. Exported so tests can mount it
+ * around a `createMemoryRouter(routes, …)` for a specific initial path — the
+ * module-scope `router` above uses real browser history, which is a shared
+ * singleton and awkward to drive per-test.
+ *
+ * ErrorBoundary is outermost: it's the app-level catch-all for crashes outside
+ * the routed tree (a provider, the router itself). Render crashes *inside* a
+ * route are caught earlier by that route's errorElement (RouteErrorFallback).
+ */
+export function AppProviders({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary FallbackComponent={AppErrorFallback}>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <AuthGate>{children}</AuthGate>
+        </AuthProvider>
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
+    </ErrorBoundary>
+  );
+}
+
 export function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AuthProvider>
-          <AuthGate>
-            <Routes>
-              <Route
-                path="/login"
-                element={
-                  <GuestOnly>
-                    <Login />
-                  </GuestOnly>
-                }
-              />
-              <Route path="/register" element={<Register />} />
-              <Route
-                path="/onboarding"
-                element={
-                  <RequireAuth>
-                    <Onboarding />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  <RequireAuth>
-                    <Profile />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/session/:id"
-                element={
-                  <RequireAuth>
-                    <Session />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/"
-                element={
-                  <RequireAuth>
-                    <Home />
-                  </RequireAuth>
-                }
-              />
-              {/* Catch-all: unknown paths (e.g. /session with no :id) redirect
-                  home rather than rendering an empty <Routes>. Load-bearing
-                  for the deep-link-without-id case — Session.tsx's
-                  `if (!id) <Navigate />` guard can't fire from real browser
-                  navigation because <Route path="/session/:id"> requires the
-                  param, so this catch-all is what users actually hit. PR-F1
-                  (#190) will replace this with a real 404 / errorElement. */}
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </Routes>
-          </AuthGate>
-        </AuthProvider>
-      </BrowserRouter>
-      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-    </QueryClientProvider>
+    <AppProviders>
+      <RouterProvider router={router} />
+    </AppProviders>
   );
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -68,10 +68,14 @@ describe('App shell', () => {
     ).toBeInTheDocument();
   });
 
-  it('attaches a route-scoped errorElement to every top-level route', () => {
+  it('attaches the route-scoped errorElement to every top-level route', () => {
     expect(routes.length).toBeGreaterThan(0);
     for (const r of routes) {
-      expect(r.errorElement).toBeDefined();
+      // toEqual, not toBeDefined: pin that it's specifically RouteErrorFallback
+      // (route-scoped), so a regression wiring the global AppErrorFallback — or
+      // any other element — onto a route fails here. React elements compare
+      // structurally under toEqual.
+      expect(r.errorElement).toEqual(<RouteErrorFallback />);
     }
   });
 

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,20 +1,35 @@
 import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { ErrorBoundary } from 'react-error-boundary';
 import { server } from '../mocks/server';
-import { App } from '../App';
+import { App, AppProviders, routes } from '../App';
+import { AppErrorFallback } from '../components/AppErrorFallback';
+import { RouteErrorFallback } from '../components/RouteErrorFallback';
 
-// Smoke test for the app shell wired up in PR-C1 (Issue #176): the full
-// provider tree — QueryClientProvider → BrowserRouter → AuthProvider — must
-// compose and mount. With no valid refresh cookie the silent refresh 401s,
-// AuthGate finishes loading, and an unauthenticated visitor is redirected to
-// the login screen. MSW mocks the network at the fetch boundary (react.md
-// § 13).
+// App shell wired up across PR-C1 (provider tree) and PR-F1 (Issue #190 —
+// createBrowserRouter + RouterProvider, lazy routes, app-level + per-route
+// error boundaries). The full stack — ErrorBoundary → QueryClientProvider →
+// AuthProvider → AuthGate → RouterProvider — must compose and mount, an
+// unauthenticated visitor must land on the login screen, unknown paths must
+// route through the catch-all, and a render crash in a route must be caught by
+// that route's scoped fallback rather than the global one. MSW mocks the
+// network at the fetch boundary (react.md § 13).
 
 // Force the dev-only React Query Devtools branch off: the panel touches
 // browser APIs jsdom doesn't implement, and the test only needs the shell to
 // mount. The `import.meta.env.DEV && …` line still evaluates either way.
 vi.stubEnv('DEV', false);
+
+function unauthenticated() {
+  server.use(
+    http.post(
+      '/api/v1/auth/refresh',
+      () => new HttpResponse(null, { status: 401 }),
+    ),
+  );
+}
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -22,12 +37,7 @@ afterEach(() => {
 
 describe('App shell', () => {
   it('renders the login screen for an unauthenticated visitor', async () => {
-    server.use(
-      http.post(
-        '/api/v1/auth/refresh',
-        () => new HttpResponse(null, { status: 401 }),
-      ),
-    );
+    unauthenticated();
 
     render(<App />);
 
@@ -37,22 +47,61 @@ describe('App shell', () => {
   });
 
   it('routes unknown paths through the catch-all instead of rendering blank', async () => {
-    // PR-D2 / Issue #192 added <Route path="*" /> so paths that don't match
-    // any declared route (e.g. /session with no :id segment) redirect to "/"
-    // rather than rendering an empty <Routes>. With no auth, the / route
-    // bounces to /login, so the user-visible end state is the login screen.
-    server.use(
-      http.post(
-        '/api/v1/auth/refresh',
-        () => new HttpResponse(null, { status: 401 }),
-      ),
-    );
+    // Paths that don't match any declared route (e.g. /session with no :id
+    // segment) redirect to "/" rather than dead-ending. With no auth the /
+    // route bounces to /login, so the user-visible end state is the login
+    // screen. Driven through a memory router so the initial path is explicit
+    // (the module-scope browser router shares real history across renders).
+    unauthenticated();
 
-    window.history.pushState({}, '', '/session');
-    render(<App />);
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/session'],
+    });
+    render(
+      <AppProviders>
+        <RouterProvider router={router} />
+      </AppProviders>,
+    );
 
     expect(
       await screen.findByRole('button', { name: /log in/i }),
     ).toBeInTheDocument();
+  });
+
+  it('attaches a route-scoped errorElement to every top-level route', () => {
+    expect(routes.length).toBeGreaterThan(0);
+    for (const r of routes) {
+      expect(r.errorElement).toBeDefined();
+    }
+  });
+
+  it('catches a route render crash with the route-scoped fallback, not the global one', async () => {
+    // A thrown render error inside a route element must be caught by that
+    // route's errorElement (RouteErrorFallback) — the app-level ErrorBoundary
+    // (AppErrorFallback) stays dormant. This is the layering the app relies on
+    // so one broken page can't blank the whole tree.
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    function Boom(): never {
+      throw new Error('kaboom');
+    }
+    const router = createMemoryRouter(
+      [{ path: '/', element: <Boom />, errorElement: <RouteErrorFallback /> }],
+      { initialEntries: ['/'] },
+    );
+    render(
+      <ErrorBoundary FallbackComponent={AppErrorFallback}>
+        <RouterProvider router={router} />
+      </ErrorBoundary>,
+    );
+
+    expect(
+      await screen.findByText(/this page ran into a problem/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    errorSpy.mockRestore();
   });
 });

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { AppProviders, routes } from '../App';
+
+// PR-F1 (Issue #190): the router maps each path to its lazily-loaded page.
+// This verifies the wiring for an authenticated visitor without dragging in
+// each page's data dependencies: useAuth is stubbed to a signed-in user and
+// every page is stubbed to a trivial marker, so the test asserts only that the
+// right lazy chunk resolves under the right route (and exercises the
+// named-export → React.lazy adapter for each page). The unauthenticated path
+// and the real Login render live in App.test.tsx.
+
+vi.mock('../hooks/useAuth', () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => ({
+    user: { id: 'u1', username: 'alice' },
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    changePassword: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+vi.mock('../pages/Home', () => ({ Home: () => <div>home page</div> }));
+vi.mock('../pages/Profile', () => ({ Profile: () => <div>profile page</div> }));
+vi.mock('../pages/Session', () => ({ Session: () => <div>session page</div> }));
+vi.mock('../pages/Onboarding', () => ({
+  Onboarding: () => <div>onboarding page</div>,
+}));
+vi.mock('../pages/Register', () => ({
+  Register: () => <div>register page</div>,
+}));
+
+// Devtools touch browser APIs jsdom lacks; keep the dev-only branch off.
+vi.stubEnv('DEV', false);
+
+describe('authenticated routing', () => {
+  it.each([
+    ['/', 'home page'],
+    ['/profile', 'profile page'],
+    ['/session/abc', 'session page'],
+    ['/onboarding', 'onboarding page'],
+    ['/register', 'register page'],
+  ])('renders the lazy page mounted at %s', async (path, marker) => {
+    const router = createMemoryRouter(routes, { initialEntries: [path] });
+    render(
+      <AppProviders>
+        <RouterProvider router={router} />
+      </AppProviders>,
+    );
+
+    expect(await screen.findByText(marker)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AppErrorFallback.test.tsx
+++ b/frontend/src/components/AppErrorFallback.test.tsx
@@ -10,6 +10,7 @@ import { AppErrorFallback } from './AppErrorFallback';
 const originalLocation = window.location;
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   Object.defineProperty(window, 'location', {
     configurable: true,
     value: originalLocation,
@@ -28,6 +29,20 @@ describe('AppErrorFallback', () => {
     expect(
       screen.getByRole('heading', { name: /something went wrong/i }),
     ).toBeInTheDocument();
+  });
+
+  it('renders a non-Error thrown value without crashing', () => {
+    // react-error-boundary types `error` as unknown — code can throw a string,
+    // object, anything. The fallback must stringify it, not assume `.message`.
+    vi.stubEnv('DEV', true);
+    render(
+      <AppErrorFallback
+        error="boom as a string"
+        resetErrorBoundary={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/boom as a string/)).toBeInTheDocument();
   });
 
   it('reloads the page when Reload is pressed', async () => {

--- a/frontend/src/components/AppErrorFallback.test.tsx
+++ b/frontend/src/components/AppErrorFallback.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppErrorFallback } from './AppErrorFallback';
+
+// AppErrorFallback is the app-level react-error-boundary fallback (react.md
+// § 9). Its user-visible contract: tell the user the app broke, and offer a
+// reload that actually reloads the page.
+
+const originalLocation = window.location;
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+describe('AppErrorFallback', () => {
+  it('tells the user something went wrong', () => {
+    render(
+      <AppErrorFallback
+        error={new Error('boom')}
+        resetErrorBoundary={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /something went wrong/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('reloads the page when Reload is pressed', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload },
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AppErrorFallback
+        error={new Error('boom')}
+        resetErrorBoundary={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /reload/i }));
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/AppErrorFallback.tsx
+++ b/frontend/src/components/AppErrorFallback.tsx
@@ -1,0 +1,39 @@
+import type { FallbackProps } from 'react-error-boundary';
+
+// App-level fallback for the react-error-boundary that wraps the whole tree
+// (react.md § 9). This is the last-resort catch-all: react-router's per-route
+// `errorElement` (RouteErrorFallback) handles render crashes inside a route,
+// so this only fires for failures outside the routed tree (a provider, the
+// router itself). A full page reload is the honest recovery for an app-shell
+// crash — `resetErrorBoundary` would just re-render into the same broken state.
+//
+// `FallbackProps.error` is untyped at the library boundary; narrow before use.
+export function AppErrorFallback({ error }: FallbackProps) {
+  const detail = error instanceof Error ? error.message : String(error);
+
+  return (
+    <div
+      role="alert"
+      className="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center"
+    >
+      <h1 className="text-xl font-bold text-gray-900">Something went wrong</h1>
+      <p className="text-sm text-gray-500">
+        The app hit an unexpected error. Reloading usually fixes it.
+      </p>
+      {import.meta.env.DEV && (
+        <pre className="max-w-full overflow-auto text-xs text-red-500">
+          {detail}
+        </pre>
+      )}
+      <button
+        type="button"
+        onClick={() => {
+          window.location.reload();
+        }}
+        className="min-h-[44px] px-6 py-2.5 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors"
+      >
+        Reload
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/BottomNav.test.tsx
+++ b/frontend/src/components/BottomNav.test.tsx
@@ -9,10 +9,11 @@ import { server } from '../mocks/server';
 import { BottomNav } from './BottomNav';
 
 // PR-C2 (Issue #186) replaced BottomNav's re-fetch-on-navigation useEffect with
-// a useQuery on the shared ['my-session'] key. Per react.md § 13 the test mocks
-// the endpoint with MSW and asserts the user-visible behavior: whether the
-// Session tab is reachable, and that tapping it navigates to the active
-// session.
+// a useQuery on the shared ['my-session'] key. PR-F1 (Issue #190) then swapped
+// the <button onClick={navigate}> tabs for <NavLink> (react.md § 11): an
+// enabled tab is now a real link (role "link"), while the Session tab stays a
+// disabled <button> when there's no session to reach. Per react.md § 13 the
+// test mocks the endpoint with MSW and asserts the user-visible behavior.
 
 function renderNav(node: ReactNode, initialPath = '/') {
   const queryClient = new QueryClient({
@@ -35,12 +36,12 @@ describe('BottomNav', () => {
 
     renderNav(<BottomNav />);
 
-    const sessionTab = screen.getByRole('button', { name: /session/i });
-    // Disabled on first render (query still pending), enabled once it resolves.
-    expect(sessionTab).toBeDisabled();
-    await waitFor(() => {
-      expect(sessionTab).toBeEnabled();
-    });
+    // While the query is pending there's no session to reach, so the tab is a
+    // disabled <button>; once it resolves the tab becomes a real <NavLink>.
+    expect(screen.getByRole('button', { name: /session/i })).toBeDisabled();
+    expect(
+      await screen.findByRole('link', { name: /session/i }),
+    ).toBeInTheDocument();
   });
 
   it('leaves the Session tab disabled when there is no active session', async () => {
@@ -57,7 +58,12 @@ describe('BottomNav', () => {
     await waitFor(() => {
       expect(calls).toBe(1);
     });
+    // No session ever arrives, so the tab stays a disabled button (never a
+    // link the user could follow).
     expect(screen.getByRole('button', { name: /session/i })).toBeDisabled();
+    expect(
+      screen.queryByRole('link', { name: /session/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('navigates to the active session when the Session tab is tapped', async () => {
@@ -75,12 +81,34 @@ describe('BottomNav', () => {
       </Routes>,
     );
 
-    const sessionTab = screen.getByRole('button', { name: /session/i });
-    await waitFor(() => {
-      expect(sessionTab).toBeEnabled();
-    });
+    const sessionTab = await screen.findByRole('link', { name: /session/i });
     await user.click(sessionTab);
 
     expect(await screen.findByText('Session s1 page')).toBeInTheDocument();
+  });
+
+  it('marks the current route tab with aria-current="page"', async () => {
+    let calls = 0;
+    server.use(
+      http.get('/api/v1/sessions/mine', () => {
+        calls += 1;
+        return HttpResponse.json({ session_id: null });
+      }),
+    );
+
+    renderNav(<BottomNav />, '/profile');
+
+    // Let the my-session query settle so no state update lands after the test.
+    await waitFor(() => {
+      expect(calls).toBe(1);
+    });
+    expect(screen.getByRole('link', { name: /profile/i })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    // The Home tab uses `end`, so "/" must NOT match the "/profile" prefix.
+    expect(screen.getByRole('link', { name: /home/i })).not.toHaveAttribute(
+      'aria-current',
+    );
   });
 });

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,10 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { getMySession } from '../api/sessions';
+
+const TAB_BASE =
+  'flex-1 flex flex-col items-center py-2 min-h-[52px] transition-colors';
+
+// NavLink drives the active styling and sets aria-current="page" itself
+// (react.md § 11); this only supplies the colors per active state.
+function tabClass(isActive: boolean): string {
+  return `${TAB_BASE} ${
+    isActive ? 'text-blue-500' : 'text-gray-400 hover:text-gray-600'
+  }`;
+}
 
 export function BottomNav() {
   const location = useLocation();
-  const navigate = useNavigate();
 
   // Shares the ['my-session'] key with useSessions, so the two dedupe to one
   // fetch and the session mutations' invalidation keeps this tab in sync —
@@ -21,58 +31,49 @@ export function BottomNav() {
     queryFn: ({ signal }) => getMySession(signal),
   });
 
-  const sessionMatch = location.pathname.match(/^\/session\/(.+)$/);
+  const sessionMatch = /^\/session\/(.+)$/.exec(location.pathname);
+  // When viewing a session, link to the current one; otherwise deep-link to the
+  // active session if one exists. Null means no session to reach → disabled.
   const sessionPath = sessionMatch
     ? location.pathname
     : mySessionId
       ? `/session/${mySessionId}`
       : null;
 
-  const tabs = [
-    { path: '/', label: 'Home', icon: '\uD83C\uDFE0', disabled: false },
-    {
-      path: sessionPath ?? '/session',
-      label: 'Session',
-      icon: '\uD83C\uDFAE',
-      disabled: !sessionPath,
-    },
-    {
-      path: '/profile',
-      label: 'Profile',
-      icon: '\uD83D\uDC64',
-      disabled: false,
-    },
-  ];
-
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-pb">
       <div className="flex max-w-lg mx-auto">
-        {tabs.map((tab) => {
-          const isActive =
-            tab.label === 'Session'
-              ? !!sessionMatch
-              : location.pathname === tab.path;
+        {/* `end` so "/" is active only on the home route, not every path. */}
+        <NavLink to="/" end className={({ isActive }) => tabClass(isActive)}>
+          <span className="text-xl leading-none">{'🏠'}</span>
+          <span className="text-[10px] font-medium mt-0.5">Home</span>
+        </NavLink>
 
-          return (
-            <button
-              key={tab.label}
-              onClick={() => !tab.disabled && navigate(tab.path)}
-              disabled={tab.disabled}
-              className={`flex-1 flex flex-col items-center py-2 min-h-[52px] transition-colors ${
-                isActive
-                  ? 'text-blue-500'
-                  : tab.disabled
-                    ? 'text-gray-300 cursor-not-allowed'
-                    : 'text-gray-400 hover:text-gray-600'
-              }`}
-            >
-              <span className="text-xl leading-none">{tab.icon}</span>
-              <span className="text-[10px] font-medium mt-0.5">
-                {tab.label}
-              </span>
-            </button>
-          );
-        })}
+        {sessionPath ? (
+          <NavLink
+            to={sessionPath}
+            className={({ isActive }) => tabClass(isActive)}
+          >
+            <span className="text-xl leading-none">{'🎮'}</span>
+            <span className="text-[10px] font-medium mt-0.5">Session</span>
+          </NavLink>
+        ) : (
+          // No reachable session yet: a NavLink has no disabled state, so the
+          // inert tab is a disabled <button> (skipped by keyboard, greyed out).
+          <button
+            type="button"
+            disabled
+            className={`${TAB_BASE} text-gray-300 cursor-not-allowed`}
+          >
+            <span className="text-xl leading-none">{'🎮'}</span>
+            <span className="text-[10px] font-medium mt-0.5">Session</span>
+          </button>
+        )}
+
+        <NavLink to="/profile" className={({ isActive }) => tabClass(isActive)}>
+          <span className="text-xl leading-none">{'👤'}</span>
+          <span className="text-[10px] font-medium mt-0.5">Profile</span>
+        </NavLink>
       </div>
     </nav>
   );

--- a/frontend/src/components/PageSkeleton.test.tsx
+++ b/frontend/src/components/PageSkeleton.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PageSkeleton } from './PageSkeleton';
+
+// PageSkeleton is the Suspense fallback for lazily-loaded routes (react.md
+// § 11). It's presentational, but the one behavior worth pinning is the
+// screen-reader-facing loading announcement — a blank or unlabeled loading
+// state is the silent regression this guards against.
+describe('PageSkeleton', () => {
+  it('exposes a labelled loading status to assistive tech', () => {
+    render(<PageSkeleton />);
+
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveTextContent(/loading/i);
+  });
+});

--- a/frontend/src/components/PageSkeleton.tsx
+++ b/frontend/src/components/PageSkeleton.tsx
@@ -1,0 +1,19 @@
+// Suspense fallback for lazily-loaded route pages (react.md § 11). Shown for
+// the brief moment a route's code chunk is in flight. `role="status"` +
+// the visually-hidden label make the loading state audible to screen readers;
+// the pulsing bars give a sighted user a content placeholder rather than a
+// blank screen.
+export function PageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="min-h-screen flex flex-col items-center justify-center gap-3 bg-gray-50 px-4"
+    >
+      <span className="sr-only">Loading…</span>
+      <div className="w-40 h-6 bg-gray-200 rounded animate-pulse" />
+      <div className="w-64 h-4 bg-gray-200 rounded animate-pulse" />
+      <div className="w-52 h-4 bg-gray-200 rounded animate-pulse" />
+    </div>
+  );
+}

--- a/frontend/src/components/RouteErrorFallback.test.tsx
+++ b/frontend/src/components/RouteErrorFallback.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { RouteErrorFallback } from './RouteErrorFallback';
+
+// RouteErrorFallback is the per-route errorElement (react.md § 9, § 11). It
+// reads the error via useRouteError, so it can only render inside a data
+// router's error path — these tests drive it through createMemoryRouter.
+
+// react-router logs caught route errors to console.error; silence the expected
+// noise so the suite output stays readable.
+const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+afterEach(() => {
+  errorSpy.mockClear();
+  vi.unstubAllEnvs();
+});
+
+describe('RouteErrorFallback', () => {
+  it('shows a route-scoped message with a way back home when a route crashes', async () => {
+    function Boom(): never {
+      throw new Error('render crash');
+    }
+    const router = createMemoryRouter(
+      [{ path: '/', element: <Boom />, errorElement: <RouteErrorFallback /> }],
+      { initialEntries: ['/'] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /this page ran into a problem/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go home/i })).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  it('surfaces the status when a route throws an error Response', async () => {
+    // The status detail renders only in the dev build (we don't leak error
+    // internals to users in prod); pin DEV on so the branch is observable.
+    vi.stubEnv('DEV', true);
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          loader: () => {
+            // react-router treats a thrown Response as a route error response
+            // (the loader 404 pattern); only-throw-error doesn't know that.
+            // eslint-disable-next-line @typescript-eslint/only-throw-error
+            throw new Response('Nope', {
+              status: 404,
+              statusText: 'Not Found',
+            });
+          },
+          element: <div>unreachable</div>,
+          errorElement: <RouteErrorFallback />,
+        },
+      ],
+      { initialEntries: ['/'] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    // The dev-only detail line renders the status of the route error response.
+    expect(await screen.findByText(/404 Not Found/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RouteErrorFallback.test.tsx
+++ b/frontend/src/components/RouteErrorFallback.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { RouteErrorFallback } from './RouteErrorFallback';
 
@@ -10,10 +11,15 @@ import { RouteErrorFallback } from './RouteErrorFallback';
 // react-router logs caught route errors to console.error; silence the expected
 // noise so the suite output stays readable.
 const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+const originalLocation = window.location;
 
 afterEach(() => {
   errorSpy.mockClear();
   vi.unstubAllEnvs();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: originalLocation,
+  });
 });
 
 describe('RouteErrorFallback', () => {
@@ -37,6 +43,30 @@ describe('RouteErrorFallback', () => {
       'href',
       '/',
     );
+  });
+
+  it('hard-reloads the page when Reload is pressed', async () => {
+    // Reload is the primary recovery for the chunk-load-after-redeploy case: a
+    // full reload re-fetches index.html + a fresh manifest, unlike the "Go
+    // home" client-side nav.
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload },
+    });
+    function Boom(): never {
+      throw new Error('Failed to fetch dynamically imported module');
+    }
+    const router = createMemoryRouter(
+      [{ path: '/', element: <Boom />, errorElement: <RouteErrorFallback /> }],
+      { initialEntries: ['/'] },
+    );
+    const user = userEvent.setup();
+
+    render(<RouterProvider router={router} />);
+    await user.click(await screen.findByRole('button', { name: /reload/i }));
+
+    expect(reload).toHaveBeenCalledOnce();
   });
 
   it('surfaces the status when a route throws an error Response', async () => {

--- a/frontend/src/components/RouteErrorFallback.tsx
+++ b/frontend/src/components/RouteErrorFallback.tsx
@@ -3,8 +3,16 @@ import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom';
 // Route-scoped errorElement (react.md § 9, § 11). react-router renders this in
 // place of a route's element when that element throws during render, catching
 // the crash *before* it bubbles to the app-level AppErrorFallback. That keeps
-// failures isolated to one route — a busted page can't blank the whole app —
-// and gives the user a way out via the "Go home" link rather than a dead end.
+// failures isolated to one route — a busted page can't blank the whole app.
+//
+// Two recovery paths, and the order matters. With code-split routes the most
+// common real trigger here isn't a logic crash — it's a dynamic-import failure
+// after a redeploy: a user on a stale index.html navigates to a route whose
+// chunk hash no longer exists, lazy() throws, and we land here. "Go home" is a
+// client-side <Link> that re-hits the same stale manifest and can loop, so the
+// primary action is a hard Reload (re-fetches index.html + a fresh manifest —
+// the reliable fix for the chunk-load case); "Go home" stays as the secondary
+// way out for an actual render crash on one page.
 export function RouteErrorFallback() {
   const error = useRouteError();
 
@@ -32,12 +40,23 @@ export function RouteErrorFallback() {
           {detail}
         </pre>
       )}
-      <Link
-        to="/"
-        className="min-h-[44px] flex items-center px-6 py-2.5 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors"
-      >
-        Go home
-      </Link>
+      <div className="flex flex-col items-center gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            window.location.reload();
+          }}
+          className="min-h-[44px] px-6 py-2.5 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors"
+        >
+          Reload
+        </button>
+        <Link
+          to="/"
+          className="min-h-[44px] flex items-center text-sm text-blue-500 hover:underline font-medium"
+        >
+          Go home
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/RouteErrorFallback.tsx
+++ b/frontend/src/components/RouteErrorFallback.tsx
@@ -1,0 +1,43 @@
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom';
+
+// Route-scoped errorElement (react.md § 9, § 11). react-router renders this in
+// place of a route's element when that element throws during render, catching
+// the crash *before* it bubbles to the app-level AppErrorFallback. That keeps
+// failures isolated to one route — a busted page can't blank the whole app —
+// and gives the user a way out via the "Go home" link rather than a dead end.
+export function RouteErrorFallback() {
+  const error = useRouteError();
+
+  // A route Response (e.g. a 404 thrown by a future loader) carries a status;
+  // a render-time crash is a thrown Error. Everything else stringifies.
+  const detail = isRouteErrorResponse(error)
+    ? `${String(error.status)} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : String(error);
+
+  return (
+    <div
+      role="alert"
+      className="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-50 px-4 text-center"
+    >
+      <h1 className="text-xl font-bold text-gray-900">
+        This page ran into a problem
+      </h1>
+      <p className="text-sm text-gray-500">
+        Something on this screen failed to load. The rest of the app is fine.
+      </p>
+      {import.meta.env.DEV && (
+        <pre className="max-w-full overflow-auto text-xs text-red-500">
+          {detail}
+        </pre>
+      )}
+      <Link
+        to="/"
+        className="min-h-[44px] flex items-center px-6 py-2.5 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Reviewer notes

Diff looks large but is mostly mechanical: `App.tsx` is a near-total rewrite of the routing tree (old `<Routes>` JSX → declarative `routes` table), and `BottomNav.tsx`'s tab loop was unrolled to split the `<NavLink>` (enabled) and `<button disabled>` (no-session) cases. The three new fallback/skeleton components are small and self-contained. No behavior change to any page's internals.

One judgment call worth a glance: the catch-all (`path: '*'`) still **redirects unknown paths to `/`** rather than showing a 404. An earlier `App.tsx` comment had floated "PR-F1 will replace this with a 404" — I kept the redirect (friendlier per design.md's "never a burden" / "sensible defaults"; a dedicated 404 isn't in the AC). The `errorElement` work is orthogonal — it handles render *crashes* on matched routes, not unmatched paths.

## Summary

PR-F1 of the [frontend compliance plan](docs/designs/2026-05-16-frontend-compliance-plan.md). Migrates react-router to `createBrowserRouter` + `RouterProvider`, adds an app-level error boundary plus per-route `errorElement`, code-splits every page with `lazy()` + `<Suspense>`, converts the bottom-nav buttons to real `<NavLink>`s, and flips the last two warn-level lint rules (`no-explicit-any`, `no-non-null-assertion`) to error.

Closes #190.

## What changed

- **Router migration** ([App.tsx](frontend/src/App.tsx)): `BrowserRouter` + `<Routes>` → `createBrowserRouter` + `RouterProvider` (react.md § 11, declarative mode). The provider stack `ErrorBoundary > QueryClientProvider > AuthProvider > AuthGate` wraps `RouterProvider` — none of those need router context, so this is simpler than a layout route, and React context still flows into route elements. The `RequireAuth`/`GuestOnly` guards stay element wrappers (they use `<Navigate>`, which has router context inside `RouterProvider`). All routes preserved with identical guard semantics; catch-all `*` still redirects home.
- **Lazy routes / code-splitting** (react.md § 11): all six pages are `lazy()`-loaded via the named-export adapter `(m) => ({ default: m.X })` and wrapped in `<Suspense fallback={<PageSkeleton/>}>` (inside the guard, so no skeleton flash on redirect). `vite build` now emits a separate chunk per page (Login/Register/Onboarding/Home/Profile/Session) instead of one bundle.
- **Error boundaries** (react.md § 9): the app-level [`react-error-boundary`](frontend/src/components/AppErrorFallback.tsx) is the outermost catch-all for crashes *outside* the routed tree; each route gets a route-scoped [`errorElement`](frontend/src/components/RouteErrorFallback.tsx) through a shared `route()` factory — so a render crash on one page is caught route-scoped (via `useRouteError`) and never blanks the app. New: [`PageSkeleton`](frontend/src/components/PageSkeleton.tsx) (Suspense fallback, `role="status"`).
- **BottomNav → NavLink** ([BottomNav.tsx](frontend/src/components/BottomNav.tsx), react.md § 10/§ 11): `<button onClick={navigate}>` → `<NavLink>`, which renders a real `<a>` (middle/cmd-click work, keyboard `Enter` activates, screen readers announce a link) and sets `aria-current="page"` itself. The Session tab, when there's no reachable session, stays a disabled `<button>` (NavLink has no disabled state). Home uses `end` so `/` isn't active on every path.
- **Lint flip** ([eslint.config.js](frontend/eslint.config.js)): `no-explicit-any` + `no-non-null-assertion` `warn` → `error`. Offenders were already removed (the `any`-typed `res.json()` by PR-B2, the `!` assertions by PR-D2), so the flip lands with zero violations.

## Automated verification

```bash
cd frontend
bun run typecheck   # tsc -b → 0 errors
bun run lint        # eslint → 0 errors (warnings are pre-existing warn-down rules owned by G1/G2/H1)
bun run test        # vitest → 217 passing (29 files)
bun run build       # emits separate dist/assets/{Login,Register,Onboarding,Home,Profile,Session}-*.js chunks
```

Diff (patch) coverage: **100%** of changed coverable lines.

## How to verify

Start the backend and frontend from the repo root (two terminals):

```bash
cargo run                 # terminal 1 — API on :3000
cd frontend && bun run dev # terminal 2 — app on :5173 (proxies /api → :3000)
```

Open http://localhost:5173 on a phone-width viewport (Pixel 9 Pro reference), and check **both Chrome and Firefox**:

- [x] **Every route navigates.** Log in → land on Home. Use the bottom nav to move Home ↔ Session ↔ Profile. Visit `/onboarding` and `/register` directly. No blank screens, no console errors.
- [ ] **Lazy chunks load per route.** Open DevTools → Network (filter JS) and hard-reload. Navigating to a page you haven't visited fetches a new `Profile-*.js` / `Session-*.js` / etc. chunk on demand (not all upfront). On a throttled connection ("Slow 3G") you briefly see the loading skeleton before the page paints.
- [x] **NavLink semantics.** The active tab is highlighted and (DevTools → inspect) carries `aria-current="page"`; the others don't. **Middle-click** or **Cmd/Ctrl-click** a tab opens it in a new tab (real anchor — the old `<button>` couldn't). With no active session, the Session tab is greyed out and not focusable via Tab.
- [x] **Catch-all.** Manually enter a bogus URL like http://localhost:5173/does-not-exist → redirected to Home (or `/login` if logged out), not a blank page.
- [ ] **Route-scoped error boundary.** Temporarily add `throw new Error('test');` at the top of one page component (e.g. [Profile.tsx](frontend/src/pages/Profile.tsx)). Navigate there → you see **"This page ran into a problem"** with a working **Go home** link — and the global "Something went wrong" screen does **not** appear. Other routes still work. Revert the throw.

## Author checklist

- [x] Linked to an Issue under "Linked work" above.
- [x] Tests added or updated for new logic (NavLink roles + aria-current, route-crash layering, catch-all, per-route errorElement, authenticated lazy routing, the three new components).
- [x] Docs updated if applicable — none needed (no `docs/` files in scope; the compliance-plan sign-off is Brendan's on merge).
- [x] Schema changes: none.
- [x] Tested locally end-to-end (automated suite + build; manual steps above for the reviewer).