### PR TITLE
ci: drop Codecov skip_validation workaround (v7.0.0 fixes #1876)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -64,12 +64,3 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
           flags: backend
-          # TEMPORARY workaround for codecov/codecov-action#1876: the uploader
-          # intermittently fails to import Codecov's GPG verification key
-          # ("gpg: Can't check signature: No public key"), failing the job even
-          # though coverage generated fine. This started ~2026-06-13 (the job
-          # passed on 06-12 with no change to our code or the action pin). Skip
-          # the CLI signature check to ride out the Codecov-side outage; the
-          # binary is still fetched over HTTPS from cli.codecov.io. REVERT this
-          # once the key-import failures stop.
-          skip_validation: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -60,12 +60,3 @@ jobs:
           files: frontend/coverage/lcov.info
           fail_ci_if_error: true
           flags: frontend
-          # TEMPORARY workaround for codecov/codecov-action#1876: the uploader
-          # intermittently fails to import Codecov's GPG verification key
-          # ("gpg: Can't check signature: No public key"), failing the job even
-          # though coverage generated fine. This started ~2026-06-13 (jobs
-          # passed on 06-12 with no change to our code or the action pin). Skip
-          # the CLI signature check to ride out the Codecov-side outage; the
-          # binary is still fetched over HTTPS from cli.codecov.io. REVERT this
-          # once the key-import failures stop. (Mirrors backend.yml.)
-          skip_validation: true


### PR DESCRIPTION
`codecov-action` v7.0.0 (landed on main via #229) natively fixes the intermittent GPG key-import failure ([codecov/codecov-action#1876](https://github.com/codecov/codecov-action/issues/1876)) that we worked around with `skip_validation: true` in #230/#231 during the Codecov-side outage.

This removes the now-obsolete hack from **both** `backend.yml` and `frontend.yml`, restoring the CLI signature-integrity check that `skip_validation` was bypassing. The version bump itself already happened in #229; this is just the cleanup the temp comments asked for ("REVERT once the key-import failures stop").

## Why it's safe
v7.0.0 was proven to handle the GPG step on its own: on **#229's** CI, the frontend `Coverage` job ran v7.0.0 **without** `skip_validation` and uploaded to Codecov cleanly (patch checks posted green). This PR just brings `backend.yml`/`frontend.yml` to that same state.

## How to verify
This PR's own coverage jobs are the test — they run v7.0.0 with no `skip_validation`:
1. **Backend `Coverage`** and **Frontend `Coverage`** checks both go green (the upload step no longer errors on GPG).
2. **`codecov/patch/backend`** and **`codecov/patch/frontend`** post from Codecov — confirming the report actually uploaded and was processed (not bypassed).
3. In each Coverage job log, the "Upload to Codecov" step should show the GPG verification running (no "Bypassing validation...") followed by a successful upload.

If Codecov's GPG endpoint is *still* flaking under v7.0.0 (unexpected, given #229), the checks would fail here and we'd reconsider — but the report generation itself is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)