### PR TITLE
227: flip no-conditional-expect + no-node-access lint rules to error

### DIFF
--- a/docs/coding-standards/testing.md
+++ b/docs/coding-standards/testing.md
@@ -125,10 +125,11 @@ These rules are partly enforced so they can't silently reappear:
   flat React config, scoped to test files in [`eslint.config.js`](../../frontend/eslint.config.js).
   Together they lock in `valid-expect`, `valid-expect-in-promise`,
   `expect-expect`, `no-focused-tests`, `no-disabled-tests`, and the async-query
-  hygiene rules. Two rules that fire on existing valid patterns
-  (`vitest/no-conditional-expect`, `testing-library/no-node-access`) start at
-  `warn` per that file's preamble. Rule 2 (outcome over choreography) is
-  review-enforced.
+  hygiene rules. Two rules that fired on existing valid patterns
+  (`vitest/no-conditional-expect`, `testing-library/no-node-access`) started at
+  `warn` and were ratcheted to `error` once their offenders were reworked to
+  unconditional assertions / accessible-name queries (#227). Rule 2 (outcome
+  over choreography) is review-enforced.
 
 ## Document history
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -174,13 +174,11 @@ export default defineConfig([
     files: ['**/*.test.{ts,tsx}', 'src/__tests__/**/*.{ts,tsx}'],
     rules: {
       ...vitest.configs.recommended.rules,
-      // Started at `warn`, not `error`, per this file's preamble: it fires on
-      // two legitimate shapes for asserting on a failure — result.test.ts's
-      // `try { …; expect.unreachable() } catch { expect(err) }`, and
-      // runs.test.ts's discriminated-`Result` narrowing
-      // (`expect(r.ok).toBe(false); if (!r.ok) expect(r.error.code)…`). Flip to
-      // `error` once both are reworked to unconditional assertions (#227).
-      'vitest/no-conditional-expect': 'warn',
+      // Enforced once its offender count hit zero (#227): result.test.ts's
+      // `try/expect.unreachable()/catch` and runs.test.ts's in-`if` Result
+      // narrowing were reworked to unconditional assertions. (The preset already
+      // sets this to `error`; listed explicitly to document the ratchet flip.)
+      'vitest/no-conditional-expect': 'error',
     },
   },
   {
@@ -191,11 +189,11 @@ export default defineConfig([
     files: ['**/*.test.{ts,tsx}', 'src/__tests__/**/*.{ts,tsx}'],
     rules: {
       ...testingLibrary.configs['flat/react'].rules,
-      // Started at `warn`, not `error`, per this file's preamble: it fires on
-      // the unavoidable raw-node drag simulation for the custom div-based DQ
-      // slider (RunEntrySheet.test.tsx), which has no Testing Library query.
-      // Flip to `error` if that drag is reworked or the rule disabled inline.
-      'testing-library/no-node-access': 'warn',
+      // Enforced once its offender count hit zero (#227): the RunEntrySheet
+      // DQ-slider drag now drives the track via its `role="button"` accessible
+      // name instead of walking `parentElement`. (The preset already sets this
+      // to `error`; listed explicitly to document the ratchet flip.)
+      'testing-library/no-node-access': 'error',
     },
   },
   {

--- a/frontend/src/api/result.test.ts
+++ b/frontend/src/api/result.test.ts
@@ -88,30 +88,25 @@ describe('parseBody', () => {
 
   it('throws a response_shape_mismatch ApiErrorException on a schema failure', async () => {
     const res = new Response(JSON.stringify({ name: 'ok' })); // count missing
-    try {
-      await parseBody(schema, res);
-      expect.unreachable('parseBody should have thrown');
-    } catch (e) {
-      expect(e).toBeInstanceOf(ApiErrorException);
-      expect((e as ApiErrorException).apiError.code).toBe(
-        'response_shape_mismatch',
-      );
-      // The ZodError is preserved as `cause` so the original detail survives.
-      expect((e as ApiErrorException).cause).toBeInstanceOf(ZodError);
-    }
+    // Capture the rejection once and assert on it at the top level — a Response
+    // body can only be read once, so we can't re-await the promise, and the
+    // assertions must not live inside a `catch` (vitest/no-conditional-expect).
+    const err = await parseBody(schema, res).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiErrorException);
+    expect((err as ApiErrorException).apiError.code).toBe(
+      'response_shape_mismatch',
+    );
+    // The ZodError is preserved as `cause` so the original detail survives.
+    expect((err as ApiErrorException).cause).toBeInstanceOf(ZodError);
   });
 
   it('throws response_shape_mismatch when the body is not JSON', async () => {
     const res = new Response('not json at all');
-    try {
-      await parseBody(schema, res);
-      expect.unreachable('parseBody should have thrown');
-    } catch (e) {
-      expect(e).toBeInstanceOf(ApiErrorException);
-      expect((e as ApiErrorException).apiError.code).toBe(
-        'response_shape_mismatch',
-      );
-    }
+    const err = await parseBody(schema, res).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiErrorException);
+    expect((err as ApiErrorException).apiError.code).toBe(
+      'response_shape_mismatch',
+    );
   });
 });
 

--- a/frontend/src/api/runs.test.ts
+++ b/frontend/src/api/runs.test.ts
@@ -143,10 +143,11 @@ describe('getRunDefaults', () => {
     );
     const result = await getRunDefaults();
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.source).toBe('previous_run');
-      expect(result.value.character_id).toBe(1);
-    }
+    // Narrow the discriminated Result with a throwing guard so the assertions
+    // sit at the top level, not inside an `if` (vitest/no-conditional-expect).
+    if (!result.ok) throw new Error('expected an ok Result');
+    expect(result.value.source).toBe('previous_run');
+    expect(result.value.character_id).toBe(1);
   });
 
   it('returns an error Result carrying the typed code when the request fails', async () => {
@@ -160,8 +161,7 @@ describe('getRunDefaults', () => {
     );
     const result = await getRunDefaults();
     expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe('internal');
-    }
+    if (result.ok) throw new Error('expected an error Result');
+    expect(result.error.code).toBe('internal');
   });
 });

--- a/frontend/src/api/runs.test.ts
+++ b/frontend/src/api/runs.test.ts
@@ -163,5 +163,7 @@ describe('getRunDefaults', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected an error Result');
     expect(result.error.code).toBe('internal');
+    // Also pin the backend `error` field threaded through parseApiError.
+    expect(result.error.message).toBe('Defaults unavailable');
   });
 });

--- a/frontend/src/components/RunEntrySheet.test.tsx
+++ b/frontend/src/components/RunEntrySheet.test.tsx
@@ -283,12 +283,15 @@ describe('RunEntrySheet', () => {
       { wrapper: Wrapper },
     );
 
-    const thumb = (await screen.findByText('»')).parentElement;
-    if (!thumb?.parentElement) throw new Error('slider track not found');
-    const track = thumb.parentElement;
+    // The track is the role="button" element carrying every drag handler; the
+    // thumb is aria-hidden and presentational (a press on it just bubbles here),
+    // so we drive the track directly via its accessible name — no node walking.
+    const track = await screen.findByRole('button', {
+      name: /disqualify this run/i,
+    });
 
-    // Grab the thumb, drag past the 252px threshold, and release.
-    fireEvent.mouseDown(thumb);
+    // Drag past the 252px threshold and release.
+    fireEvent.mouseDown(track);
     fireEvent.mouseMove(track, { clientX: 300 });
     fireEvent.mouseUp(track);
 
@@ -312,11 +315,14 @@ describe('RunEntrySheet', () => {
       { wrapper: Wrapper },
     );
 
-    const thumb = (await screen.findByText('»')).parentElement;
-    if (!thumb?.parentElement) throw new Error('slider track not found');
-    const track = thumb.parentElement;
+    // The track is the role="button" element carrying every drag handler; the
+    // thumb is aria-hidden and presentational (a press on it just bubbles here),
+    // so we drive the track directly via its accessible name — no node walking.
+    const track = await screen.findByRole('button', {
+      name: /disqualify this run/i,
+    });
 
-    fireEvent.touchStart(thumb);
+    fireEvent.touchStart(track);
     fireEvent.touchMove(track, { touches: [{ clientX: 300 }] });
     fireEvent.touchEnd(track);
 
@@ -338,12 +344,15 @@ describe('RunEntrySheet', () => {
       { wrapper: Wrapper },
     );
 
-    const thumb = (await screen.findByText('»')).parentElement;
-    if (!thumb?.parentElement) throw new Error('slider track not found');
-    const track = thumb.parentElement;
+    // The track is the role="button" element carrying every drag handler; the
+    // thumb is aria-hidden and presentational (a press on it just bubbles here),
+    // so we drive the track directly via its accessible name — no node walking.
+    const track = await screen.findByRole('button', {
+      name: /disqualify this run/i,
+    });
 
     // A short drag (well under the 252px threshold) releases without confirming.
-    fireEvent.mouseDown(thumb);
+    fireEvent.mouseDown(track);
     fireEvent.mouseMove(track, { clientX: 50 });
     fireEvent.mouseUp(track);
 


### PR DESCRIPTION
Closes #227. Follow-up from PR #225 review (the frontend-standards lint-preset adoption).

## What & why

PR #225 adopted the `@vitest/eslint-plugin` and `eslint-plugin-testing-library` presets but started two rules at **`warn`** because each fired on a legitimate existing pattern rather than a real defect. This PR reworks those patterns to zero offenders, then ratchets both rules to **`error`** per `eslint.config.js`'s ratchet convention.

Both rules are already `error` in their upstream presets — the config explicitly *downgraded* them to `warn`. So the flip is just restoring `error`, now that there are zero violations.

### `vitest/no-conditional-expect` (was 8 offenders)
- **`src/api/result.test.ts`** — the `try { …; expect.unreachable() } catch { expect(err) }` shape put assertions inside a `catch`. Reworked to a **capture-once** pattern: `const err = await parseBody(...).catch((e) => e)` then assert at the top level. (Capture-once, not `await expect(...).rejects` repeated, because a `Response` body can only be read once — re-awaiting would throw "body already read" instead of the schema error.)
- **`src/api/runs.test.ts`** — the discriminated-`Result` narrowing put assertions inside `if (result.ok) { … }`. Reworked to a **throwing guard** (`if (!result.ok) throw …`) that narrows the union so the assertions sit at the top level.

### `testing-library/no-node-access` (was 15 offenders)
- **`src/components/RunEntrySheet.test.tsx`** — the DQ-slider drag tests walked `.parentElement` from the `»` thumb text to reach the thumb and track DOM nodes. The **track** is the `role="button"` element that carries *every* drag handler (`onMouseDown/Move/Up`, `onTouch*`); the thumb is `aria-hidden` and presentational (a press on it just bubbles to the track). So the tests now query the track directly via its accessible name (`findByRole('button', { name: /disqualify this run/i })`) and fire all events on it — behaviorally identical (the geometry mock is on `HTMLElement.prototype`), zero node walking, no `eslint-disable` needed.

No production code changes — only test files and `eslint.config.js`.

## Testing

No user-visible behavior changes; verification is lint + the existing suite:

```bash
cd frontend
bun install --frozen-lockfile

# 1. The two target rules report ZERO offenders:
bunx eslint . | grep -E "no-conditional-expect|no-node-access"   # → no output

# 2. Lint passes with both rules now at `error` (remaining warnings are other
#    rules still intentionally at warn, owned by later compliance PRs):
bun run lint        # → "0 errors", exit 0

# 3. Full suite still green (the reworked DQ-slider + Result/parseBody tests):
bun run test        # → 30 files, 246 tests passed

# 4. Types still check (the throwing-guard narrowing relies on TS):
bun run typecheck   # → clean
```

To confirm the ratchet actually bites: temporarily re-introduce a `expect` inside a `catch` (or a `.parentElement` access) in any test file and `bun run lint` should now **fail** with an error, not a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)