### PR TITLE
209: leave the current session on logout

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -68,6 +68,7 @@ A drink type is identified by `(name, alcoholic)`, matched case-insensitively on
 POST   /sessions                   Create a new session (choose ruleset)
 GET    /sessions                   List active sessions (sorted by most recent activity)
 GET    /sessions/:id               Get session details (participants, current race, state)
+GET    /sessions/mine              Get the caller's current session (`{ session_id }`, null if not in one)
 POST   /sessions/:id/join          Join a session (dedicated endpoint — designed for future password support)
 POST   /sessions/:id/leave         Leave a session (if you were the last to leave, the session closes and unresolved pending races are dropped)
 POST   /sessions/:id/next-track    Trigger next track selection (host or chooser, depending on ruleset)

--- a/docs/user-workflows.md
+++ b/docs/user-workflows.md
@@ -62,6 +62,7 @@ Earmarked: the track selection sub-workflow (how the chooser browses/searches fo
 3. If the leaving player is the host: host role transfers to the earliest-joined remaining participant.
 4. Session ends when all participants have left.
 5. Sessions with no activity of any kind for an hour — no new race, run, join, leave, or skip — auto-close on the next sweeper pass. No further run submissions accepted, and any unresolved pending races are dropped.
+6. Logging out leaves your current session first (always — even mid-session), so a sole-participant session closes immediately on logout rather than lingering until the sweeper. Best-effort: a failed leave never blocks the sign-out, with the sweeper as the backstop.
 
 ### 1.6 Checking personal stats
 
@@ -181,3 +182,4 @@ Streamlined compared to standalone entry — the track is already known from the
 - 2026-05-08 — Updated the § 0 cross-reference: `workflow.md` → `project-workflow.md` (operational doc renamed for clarity — see that file's history). Dropped the "note the singular 'workflow'" caveat, no longer needed once the filename is unambiguous.
 - 2026-05-08 — Demoted the broken `[workflow.md](./workflow.md)` markdown link in the 2026-05-06 initial-creation history bullet to plain backticked text. The file no longer exists at that path (renamed to `project-workflow.md` on 2026-05-08); the rename history is documented in the bullet immediately above. PR 5 of the docs restructure (plan deviation — Cowork's PR 5 handoff did not anticipate this link, surfaced when lychee `fail: true` flip would otherwise turn it into a CI failure).
 - 2026-05-16 — Rewrote § 1.5 step 2 for ADR-0037: pending races stay submittable while the session is active and rejoining works as long as someone keeps the session alive; if everyone leaves, the session ends and pending races are dropped (with a notification). The per-race 1-hour window is gone. Step 5 (auto-close) updated for the five-signal sweeper predicate and the drop-on-close behavior. § 1.2 step 6 "(oldest expire first)" → "(oldest shown first)" — no per-race expiry remains. Issue [#51](https://github.com/brendanbyrne/beerio-kart/issues/51).
+- 2026-06-20 — § 1.5 step 6 added: logout now leaves your current session before signing out ([#209](https://github.com/brendanbyrne/beerio-kart/issues/209)). Chose **always-leave** (not only-when-sole) so a sole-participant session closes on logout instead of waiting for the hourly sweeper; best-effort, so a failed leave never blocks the sign-out.

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -245,4 +245,146 @@ describe('useAuth', () => {
       expect(err).toBe('Current password is incorrect');
     });
   });
+
+  describe('logout (#209 — leave session first)', () => {
+    // Log in so the API client holds an access token; `getMySession` /
+    // `leaveSession` go through `apiFetch`, which attaches it.
+    async function loggedInHook() {
+      const view = setupHook();
+      await waitFor(() => {
+        expect(view.result.current.isLoading).toBe(false);
+      });
+      server.use(
+        http.post('/api/v1/auth/login', () => HttpResponse.json(session)),
+      );
+      await act(async () => {
+        await view.result.current.login('alice', 'hunter2');
+      });
+      expect(view.result.current.isAuthenticated).toBe(true);
+      return view;
+    }
+
+    it('leaves the current session before POSTing logout, then clears auth', async () => {
+      const { result } = await loggedInHook();
+
+      const calls: string[] = [];
+      let leftSessionId: string | undefined;
+      server.use(
+        http.get('/api/v1/sessions/mine', () => {
+          calls.push('mine');
+          return HttpResponse.json({ session_id: 's1' });
+        }),
+        http.post('/api/v1/sessions/:id/leave', ({ params }) => {
+          calls.push('leave');
+          leftSessionId = params.id as string;
+          return new HttpResponse(null, { status: 204 });
+        }),
+        http.post('/api/v1/auth/logout', () => {
+          calls.push('logout');
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      // Leave is called with the live session id, strictly before the logout
+      // POST (which revokes the refresh token), then local auth is cleared.
+      expect(leftSessionId).toBe('s1');
+      expect(calls).toEqual(['mine', 'leave', 'logout']);
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.user).toBeNull();
+    });
+
+    it('still signs out after attempting the leave when leaving fails', async () => {
+      const { result } = await loggedInHook();
+
+      const calls: string[] = [];
+      server.use(
+        http.get('/api/v1/sessions/mine', () => {
+          calls.push('mine');
+          return HttpResponse.json({ session_id: 's1' });
+        }),
+        // Leave errors (500, not a 401 — no refresh path); logout must proceed.
+        http.post('/api/v1/sessions/:id/leave', () => {
+          calls.push('leave');
+          return HttpResponse.json({ error: 'leave failed' }, { status: 500 });
+        }),
+        http.post('/api/v1/auth/logout', () => {
+          calls.push('logout');
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      // Leave was attempted (and failed) strictly before the logout POST; the
+      // failure was swallowed and sign-out completed regardless.
+      expect(calls).toEqual(['mine', 'leave', 'logout']);
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.user).toBeNull();
+    });
+
+    it('does not call leaveSession when not in a session', async () => {
+      const { result } = await loggedInHook();
+
+      let leaveCalled = false;
+      let logoutPosted = false;
+      server.use(
+        http.get('/api/v1/sessions/mine', () =>
+          HttpResponse.json({ session_id: null }),
+        ),
+        http.post('/api/v1/sessions/:id/leave', () => {
+          leaveCalled = true;
+          return new HttpResponse(null, { status: 204 });
+        }),
+        http.post('/api/v1/auth/logout', () => {
+          logoutPosted = true;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(leaveCalled).toBe(false);
+      expect(logoutPosted).toBe(true);
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    it('skips leaveSession and still signs out when fetching the current session errors', async () => {
+      const { result } = await loggedInHook();
+
+      let leaveCalled = false;
+      let logoutPosted = false;
+      server.use(
+        // getMySession swallows a non-ok /mine and resolves to null, so leave
+        // is skipped — a different path to the no-session outcome than a null
+        // body, and one a slow/erroring sessions service hits in practice.
+        http.get('/api/v1/sessions/mine', () =>
+          HttpResponse.json({ error: 'boom' }, { status: 500 }),
+        ),
+        http.post('/api/v1/sessions/:id/leave', () => {
+          leaveCalled = true;
+          return new HttpResponse(null, { status: 204 });
+        }),
+        http.post('/api/v1/auth/logout', () => {
+          logoutPosted = true;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(leaveCalled).toBe(false);
+      expect(logoutPosted).toBe(true);
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+  });
 });

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -14,6 +14,7 @@ import {
 } from '../api/client';
 import type { AuthFailureReason } from '../api/client';
 import { parseApiError, parseBody } from '../api/result';
+import { getMySession, leaveSession } from '../api/sessions';
 import {
   AccessTokenPayloadSchema,
   AuthSessionSchema,
@@ -168,6 +169,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = async () => {
+    // Leave the current session before signing out (#209). A sole participant
+    // who logs out without leaving would keep the session `active` until the
+    // hourly stale-session sweeper closes it; leaving first closes it at once
+    // (the backend's `leave_session` closes a session whose last participant
+    // departs). This runs *before* the logout POST and the token clear because
+    // both `getMySession` and `leaveSession` go through `apiFetch`, which needs
+    // the still-live access token. Best-effort: not being in a session, a
+    // network error, or a rejected leave must not block the sign-out, so any
+    // failure is swallowed and we fall through to clear local state regardless.
+    // The stale-session sweeper remains the server-side backstop.
+    try {
+      const sessionId = await getMySession();
+      if (sessionId) await leaveSession(sessionId);
+    } catch {
+      // Best-effort — sign-out proceeds regardless (see above).
+    }
+
     try {
       // Send the access token so the server can bump refresh_token_version
       const token = getAccessToken();

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -182,8 +182,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const sessionId = await getMySession();
       if (sessionId) await leaveSession(sessionId);
-    } catch {
-      // Best-effort — sign-out proceeds regardless (see above).
+    } catch (e) {
+      // Best-effort — sign-out proceeds regardless (see above). getMySession
+      // returns null (no throw) when you're simply not in a session, so a
+      // throw here is abnormal — a network failure or a genuinely-rejected
+      // leave — and otherwise invisible until the sweeper catches it. Log at
+      // debug so a persistently-broken leave is diagnosable without noise.
+      console.debug('logout: best-effort leave failed', e);
     }
 
     try {


### PR DESCRIPTION
## What & why

When a user logged out mid-session, the frontend cleared tokens but never left the session. The `session_participants` row kept `left_at = NULL`, so a **sole participant's session stayed `active`** until the hourly stale-session sweeper closed it (and a multi-participant logout left the user listed as present, auto-rejoining on next login).

`useAuth.logout` now leaves the current session first:

```
getMySession()  →  if (session id) leaveSession(id)  →  POST /auth/logout  →  clearAuth()
```

The backend already does the rest — `leave_session → transfer_host_or_close` closes a session whose last participant departs, and transfers host to the earliest-joined remaining participant otherwise. So this is a purely frontend change that makes logout *call* leave.

### Ordering & error handling
- The leave runs **before** the logout POST and the token clear because `getMySession`/`leaveSession` go through `apiFetch`, which needs the still-live access token (`clearAuth()` nulls it last).
- The leave is **best-effort**: not being in a session, a network error, or a rejected leave is swallowed and sign-out proceeds regardless. The sweeper remains the server-side backstop, so a missed leave self-heals within the hour.

## ⚠️ Open decisions — please confirm

The issue flagged two decisions for confirmation. My choices and reasoning:

1. **Always-leave (chosen) vs. only-when-sole.** Logout leaves whatever session you're in, not just when you're the sole participant. This matches typical mobile-app behavior and avoids a participant-count round-trip. It's safe for the multi-participant case: the backend transfers host / keeps the session open for the others (verified in `services/sessions/lifecycle.rs`). The alternative would preserve multi-participant membership across logout/login — say the word if you'd prefer that and I'll flip both the code and the doc note in this same PR.

2. **Await sequentially, no timeout (chosen) vs. fire-and-forget / `Promise.race` timeout.** I await the leave so it's guaranteed sent before the token is cleared, and I rely on the browser's own fetch timeout rather than adding one — consistent with every other call in `apiFetch` (none are time-bounded). Trade-off: on a dead network the logout (and the redirect to /login) waits for the browser to time out the leave, with no busy-state on the button. That no-feedback-on-slow-network behavior is **pre-existing** (the logout POST already had it; `Profile.tsx` is unchanged here). If you want a snappier logout, a fire-and-forget leave or a short `Promise.race` timeout is a small follow-up.

## Changes

- **`frontend/src/hooks/useAuth.tsx`** — `logout` leaves the current session first (best-effort), imports `getMySession`/`leaveSession`.
- **`frontend/src/hooks/useAuth.test.tsx`** — 4 new tests (below).
- **`docs/user-workflows.md`** — § 1.5 step 6 records the logout-leaves behavior + a history entry.
- **`docs/api-contract.md`** — § 1.5 adds the previously-undocumented `GET /sessions/mine` that the auth flow now depends on.

## Automated tests (`useAuth.test.tsx`)

All four assert against MSW handlers validated against the real contract (`MySessionResponseSchema`, `leaveSession` throwing `ApiErrorException`, 204/500 status codes):

1. **Ordered leave-before-logout** — `calls === ['mine', 'leave', 'logout']`, leave gets the live session id, auth cleared.
2. **Leave failure still completes** — `/leave` 500s; asserts the leave was *attempted first* (`['mine','leave','logout']`) and sign-out still finished.
3. **Not in a session** — `/mine` returns `{ session_id: null }` → leave **not** called, logout POST still fired.
4. **`/mine` errors** — `/mine` 500s → `getMySession` swallows and returns null → leave skipped, sign-out still completes.

`bun run lint` ✓ · `bun run typecheck` ✓ · `bun run test:coverage` ✓ (274 tests; new logout lines fully covered).

## Manual verification

Two clients (or two browsers / one incognito), backend + frontend running (`cargo run` and `bun run dev` from the repo root):

1. Log in as user **A** on client 1; create or join a session. Confirm it appears in the Home session list on client 2 (logged in as a different user, or just polling the public list).
2. On client 1, log out (Profile → **Log Out**).
3. **Expected:** within one poll cycle (~2–3 s) the session disappears from client 2's Home list — the backend marked it `ended_at`. A was the sole participant, so the session closed.
4. **Multi-participant no-regression:** A and B both in one session; A logs out. Session stays open for B; if A was host, host transfers to B. (Verify B's view still shows the session active with B as host.)
5. **Best-effort:** with the network throttled/offline at logout, confirm the sign-out still completes and lands on /login (the leave is swallowed; the sweeper would clean up server-side).

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
